### PR TITLE
Added request to context so you find the RequestUri when logging

### DIFF
--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -119,6 +119,7 @@ namespace Microsoft.Extensions.Http
             if (context == null)
             {
                 context = new Context();
+                context.Add("request", request);
                 request.SetPolicyExecutionContext(context);
                 cleanUpContext = true;
             }


### PR DESCRIPTION
Added request to context so you find the RequestUri when logging onRetry attempts in the generic TransientHttpErrorPolicy

Summary of the changes (Less than 80 chars)
Add http request message to context as "request"
