### PR TITLE
Issue #1220: Allow the specification of the EventSourceProvider name.

### DIFF
--- a/src/Logging/Logging.EventSource/src/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLoggerFactoryExtensions.cs
@@ -20,16 +20,28 @@ namespace Microsoft.Extensions.Logging
         /// <param name="builder">The extension method argument.</param>
         public static ILoggingBuilder AddEventSourceLogger(this ILoggingBuilder builder)
         {
+            return AddEventSourceLogger(builder, null);
+        }
+
+        /// <summary>
+        /// Adds an event logger named 'EventSource' to the factory.
+        /// </summary>
+        /// <param name="builder">The extension method argument.</param>
+        /// <param name="providerName">Events will be logged using the specified provider name</param>
+        public static ILoggingBuilder AddEventSourceLogger(this ILoggingBuilder builder, string providerName)
+        {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.TryAddSingleton(LoggingEventSource.Instance);
+            builder.Services.TryAddSingleton((_) => new LoggingEventSource(providerName));
+            builder.Services.TryAddSingleton(ServiceDescriptor.Singleton<EventSourceLogger, EventSourceLogger>());
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, EventSourceLoggerProvider>());
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<LoggerFilterOptions>, EventLogFiltersConfigureOptions>());
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<LoggerFilterOptions>, EventLogFiltersConfigureOptionsChangeSource>());
             return builder;
         }
+
     }
 }

--- a/src/Logging/Logging.EventSource/src/EventSourceLoggerProvider.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLoggerProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Logging.EventSource
     /// The provider for the <see cref="EventSourceLogger"/>.
     /// </summary>
     [ProviderAlias("EventSource")]
-    public class EventSourceLoggerProvider : ILoggerProvider
+    internal class EventSourceLoggerProvider : ILoggerProvider
     {
         private static int _globalFactoryID;
 

--- a/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Extensions.Logging.EventSource
     /// <summary>
     /// The LoggingEventSource is the bridge form all ILogger based logging to EventSource/EventListener logging.
     ///
-    /// You turn this logging on by enabling the EvenSource called
+    /// You turn this logging on by enabling the name provided in the LoggingEventSourceOptions.  The default EvenSource
+    /// is called
     ///
     ///      Microsoft-Extensions-Logging
     ///
@@ -74,9 +75,10 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///     }
     /// }
     /// </summary>
-    [EventSource(Name = "Microsoft-Extensions-Logging")]
     public sealed class LoggingEventSource : System.Diagnostics.Tracing.EventSource
     {
+        public const string DefaultProviderName = "Microsoft-Extensions-Logging";
+
         /// <summary>
         /// This is public from an EventSource consumer point of view, but since these defintions
         /// are not needed outside this class
@@ -101,20 +103,18 @@ namespace Microsoft.Extensions.Logging.EventSource
             public const EventKeywords JsonMessage = (EventKeywords)8;
         }
 
-        /// <summary>
-        ///  The one and only instance of the LoggingEventSource.
-        /// </summary>
-        internal static readonly LoggingEventSource Instance = new LoggingEventSource();
-
         // It's important to have _filterSpec initialization here rather than in ctor
         // base ctor might call OnEventCommand and set filter spec
         // having assingment in ctor would overwrite the value
         private LoggerFilterRule[] _filterSpec = new LoggerFilterRule[0];
         private CancellationTokenSource _cancellationTokenSource;
 
-        private LoggingEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
+        public LoggingEventSource() : this(DefaultProviderName) { }
+
+        public LoggingEventSource(string providerName) : base(providerName ?? DefaultProviderName, EventSourceSettings.EtwSelfDescribingEventFormat)
         {
         }
+
 
         /// <summary>
         /// FormattedMessage() is called when ILogger.Log() is called. and the FormattedMessage keyword is active


### PR DESCRIPTION
Addresses Issue #1220 

- Provides an overload to `AddEventSourceLogger` that allows for the use of a provider name when registering with dependency injection
- Gave` LoggingEventSource` a public constructor to remove the need for a static `Instance` property.  This class would almost certainly be used through dependency injection and so the `Instance` was redundant.  A possible future design improvement would be to make `LoggingEventSource` internal to the assembly since the direct access to the `LoggingEventSource` will not improve the semantics of `ILogger` in any way.
- Provides a couple of unit tests to validate that naming works properly.
