### PR TITLE
Delay logging scope creation

### DIFF
--- a/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
+++ b/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
@@ -42,6 +42,10 @@ namespace Microsoft.Extensions.Logging
     public partial interface ILogger<out TCategoryName> : Microsoft.Extensions.Logging.ILogger
     {
     }
+    public partial interface IScopeFuncLogger
+    {
+        System.IDisposable BeginScope<TState, TScopeState>(System.Func<TState, TScopeState> scopeCreator, in TState state);
+    }
     public partial interface ISupportExternalScope
     {
         void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider);
@@ -49,6 +53,8 @@ namespace Microsoft.Extensions.Logging
     public static partial class LoggerExtensions
     {
         public static System.IDisposable BeginScope(this Microsoft.Extensions.Logging.ILogger logger, string messageFormat, params object[] args) { throw null; }
+        public static System.IDisposable BeginScope<TState, TScopeState>(this Microsoft.Extensions.Logging.ILogger logger, System.Func<TState, TScopeState> scopeCreator, in TState state) { throw null; }
+        public static bool IsNullScope(this System.IDisposable disposable) { throw null; }
         public static void Log(this Microsoft.Extensions.Logging.ILogger logger, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, System.Exception exception, string message, params object[] args) { }
         public static void Log(this Microsoft.Extensions.Logging.ILogger logger, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string message, params object[] args) { }
         public static void Log(this Microsoft.Extensions.Logging.ILogger logger, Microsoft.Extensions.Logging.LogLevel logLevel, System.Exception exception, string message, params object[] args) { }
@@ -103,12 +109,14 @@ namespace Microsoft.Extensions.Logging
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, System.Exception> Define<T1, T2, T3, T4, T5>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, System.Exception> Define<T1, T2, T3, T4, T5, T6>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
     }
-    public partial class Logger<T> : Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.ILogger<T>
+    public partial class Logger<T> : Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.ILogger<T>, Microsoft.Extensions.Logging.IScopeFuncLogger
     {
         public Logger(Microsoft.Extensions.Logging.ILoggerFactory factory) { }
+        public System.IDisposable BeginScope<TState, TScopeState>(System.Func<TState, TScopeState> scopeCreator, in TState state) { throw null; }
         System.IDisposable Microsoft.Extensions.Logging.ILogger.BeginScope<TState>(TState state) { throw null; }
         bool Microsoft.Extensions.Logging.ILogger.IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         void Microsoft.Extensions.Logging.ILogger.Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+        System.IDisposable Microsoft.Extensions.Logging.IScopeFuncLogger.BeginScope<TState, TScopeState>(System.Func<TState, TScopeState> scopeCreator, in TState state) { throw null; }
     }
     public enum LogLevel
     {
@@ -123,13 +131,15 @@ namespace Microsoft.Extensions.Logging
 }
 namespace Microsoft.Extensions.Logging.Abstractions
 {
-    public partial class NullLogger : Microsoft.Extensions.Logging.ILogger
+    public partial class NullLogger : Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.IScopeFuncLogger
     {
         internal NullLogger() { }
         public static Microsoft.Extensions.Logging.Abstractions.NullLogger Instance { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+        public System.IDisposable BeginScope<TState, TScopeState>(System.Func<TState, TScopeState> scopeCreator, in TState state) { throw null; }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { throw null; }
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+        System.IDisposable Microsoft.Extensions.Logging.IScopeFuncLogger.BeginScope<TState, TScopeState>(System.Func<TState, TScopeState> scopeCreator, in TState state) { throw null; }
     }
     public partial class NullLoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory, System.IDisposable
     {

--- a/src/Logging/Logging.Abstractions/src/IScopeFuncLogger.cs
+++ b/src/Logging/Logging.Abstractions/src/IScopeFuncLogger.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface IScopeFuncLogger
+    {
+        IDisposable BeginScope<TState, TScopeState>(Func<TState, TScopeState> scopeCreator, in TState state);
+    }
+}

--- a/src/Logging/Logging.Abstractions/src/LoggerExtensions.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerExtensions.cs
@@ -12,6 +12,20 @@ namespace Microsoft.Extensions.Logging
     {
         private static readonly Func<FormattedLogValues, Exception, string> _messageFormatter = MessageFormatter;
 
+        public static IDisposable BeginScope<TState, TScopeState>(this ILogger logger, Func<TState, TScopeState> scopeCreator, in TState state)
+        {
+            if (logger is IScopeFuncLogger funcLogger)
+            {
+                return funcLogger.BeginScope(scopeCreator, in state);
+            }
+            else
+            {
+                return logger.BeginScope(scopeCreator(state));
+            }
+        }
+
+        public static bool IsNullScope(this IDisposable disposable) => disposable is null || ReferenceEquals(disposable, NullScope.Instance);
+
         //------------------------------------------DEBUG------------------------------------------//
 
         /// <summary>

--- a/src/Logging/Logging.Abstractions/src/LoggerT.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerT.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Logging
     /// provided <see cref="ILoggerFactory"/>.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
-    public class Logger<T> : ILogger<T>
+    public class Logger<T> : ILogger<T>, IScopeFuncLogger
     {
         private readonly ILogger _logger;
 
@@ -32,6 +32,11 @@ namespace Microsoft.Extensions.Logging
         IDisposable ILogger.BeginScope<TState>(TState state)
         {
             return _logger.BeginScope(state);
+        }
+
+        public IDisposable BeginScope<TState, TScopeState>(Func<TState, TScopeState> scopeCreator, in TState state)
+        {
+            return _logger.BeginScope(scopeCreator, in state);
         }
 
         bool ILogger.IsEnabled(LogLevel logLevel)

--- a/src/Logging/Logging.Abstractions/src/NullLogger.cs
+++ b/src/Logging/Logging.Abstractions/src/NullLogger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     /// <summary>
     /// Minimalistic logger that does nothing.
     /// </summary>
-    public class NullLogger : ILogger
+    public class NullLogger : ILogger, IScopeFuncLogger
     {
         public static NullLogger Instance { get; } = new NullLogger();
 
@@ -18,6 +18,12 @@ namespace Microsoft.Extensions.Logging.Abstractions
 
         /// <inheritdoc />
         public IDisposable BeginScope<TState>(TState state)
+        {
+            return NullScope.Instance;
+        }
+
+        /// <inheritdoc />
+        public IDisposable BeginScope<TState, TScopeState>(Func<TState, TScopeState> scopeCreator, in TState state)
         {
             return NullScope.Instance;
         }

--- a/src/Logging/Logging/src/Logger.cs
+++ b/src/Logging/Logging/src/Logger.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Logging
 {
-    internal class Logger : ILogger
+    internal class Logger : ILogger, IScopeFuncLogger
     {
         public LoggerInformation[] Loggers { get; set; }
         public MessageLogger[] MessageLoggers { get; set; }
@@ -92,6 +92,19 @@ namespace Microsoft.Extensions.Logging
             }
 
             return false;
+        }
+
+        /// <inheritdoc />
+        public IDisposable BeginScope<TState, TScopeState>(Func<TState, TScopeState> scopeCreator, in TState state)
+        {
+            var loggers = ScopeLoggers;
+
+            if (loggers == null)
+            {
+                return NullScope.Instance;
+            }
+
+            return BeginScope(scopeCreator(state));
         }
 
         public IDisposable BeginScope<TState>(TState state)


### PR DESCRIPTION
It would be good if there was something between logging totally off and logging totally allocately.

Scope creation is a pretty significant allocator, even if scopes are off and logging is at a minimum level
```
dotnet new web
```
Allocates as the following

![image](https://user-images.githubusercontent.com/1142958/56102246-c4b1ee00-5f23-11e9-9e2b-f42928068506.png)

Usage for this change

Change
```csharp
return logger.BeginScope(new HostingLogScope(httpContext, activityId));
```
to
```csharp
return logger.BeginScope(
    (state) => new HostingLogScope(state.httpContext, state.activityId), 
    (httpContext, activityId));
```
To drop the allocations when `CaptureScopes == false`

/cc @davidfowl 