### PR TITLE
AzureKeyVaultConfigurationProvider to respect ReloadInterval

### DIFF
--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
                 _reloadInterval = reloadInterval.Value;
             }
 
-            _pollingTask = null;
             _cancellationToken = new CancellationTokenSource();
         }
 

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
             // schedule a polling task only if none exists and a valid delay is specified
             if (_pollingTask == null && _reloadInterval > TimeSpan.Zero)
             {
-                _pollingTask = Task.Run(PollForSecretChangesAsync);
+                _pollingTask = PollForSecretChangesAsync();
             }
         }
 

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
 
         protected virtual async Task WaitForReload()
         {
-            await Task.Delay(_reloadInterval.Value.Milliseconds, _cancellationToken.Token);
+            await Task.Delay(_reloadInterval.Value, _cancellationToken.Token);
         }
 
         private async Task LoadAsync()
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
             // schedule a polling task only if none exists and a valid delay is specified
             if (_pollingTask == null && _reloadInterval != null)
             {
-                _pollingTask = PollForSecretChangesAsync();
+                _pollingTask = Task.Run(PollForSecretChangesAsync);
             }
         }
 

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         {
             while (!_cancellationToken.IsCancellationRequested)
             {
-                await WaitForReload();
+                await WaitForReload().ConfigureAwait(false);
                 try
                 {
-                    await LoadAsync();
+                    await LoadAsync().ConfigureAwait(false);
                 }
                 catch (Exception)
                 {
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
 
         protected virtual async Task WaitForReload()
         {
-            await Task.Delay(_reloadInterval, _cancellationToken.Token);
+            await Task.Delay(_reloadInterval, _cancellationToken.Token).ConfigureAwait(false);
         }
 
         private async Task LoadAsync()


### PR DESCRIPTION
Summary:
 - Use `Task.Delay(TimeSpan, CancellationToken)`
 - Non-nullable private `_reloadInterval` to simplify code.
 - `.ConfigureAwait(false)` everywhere

Addresses #1265 
