### PR TITLE
Supporting Environment Variables from Azure App Service

### DIFF
--- a/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         private const string SqlAzureServerPrefix = "SQLAZURECONNSTR_";
         private const string SqlServerPrefix = "SQLCONNSTR_";
         private const string CustomPrefix = "CUSTOMCONNSTR_";
-
         private const string ConnStrKeyFormat = "ConnectionStrings:{0}";
         private const string ProviderKeyFormat = "ConnectionStrings:{0}_ProviderName";
+        private const string AzureOmittedDashCharacter = "-";
 
         private readonly string _prefix;
 
@@ -62,6 +62,23 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             }
 
             Data = data;
+        }
+        /// <summary>
+        /// Attempts to find a value with the given key, returns true if one is found, false otherwise.
+        /// </summary>
+        /// <param name="key">The key to lookup.</param>
+        /// <param name="value">The value found at key if one is found.</param>
+        /// <returns>True if key has a value, false otherwise.</returns>
+        public override bool TryGet(string key, out string value)
+        {
+            var result = base.TryGet(key, out value);
+            
+            if (!result)
+            {
+                result = base.TryGet(key.Replace(AzureOmittedDashCharacter, string.Empty), out value);
+            }
+
+            return result;
         }
 
         private static string NormalizeKey(string key)

--- a/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
+++ b/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                     {"MYSQLCONNSTR_db3", "MySQLConnStr"},
                     {"SQLAZURECONNSTR_db4", "SQLAzureConnStr"},
                     {"CommonEnv", "CommonEnvValue"},
+                    {"WithDash", "WithDashValue"},
                 };
             var envConfigSrc = new EnvironmentVariablesConfigurationProvider();
 
@@ -78,6 +79,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("ConnectionStrings:db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:db4_ProviderName"));
             Assert.Equal("CommonEnvValue", envConfigSrc.Get("CommonEnv"));
+            Assert.Equal("WithDashValue", envConfigSrc.Get("With-Dash"));
         }
 
         [Fact]


### PR DESCRIPTION
Supporting Environment Variables from Azure App Service whereby dashes have been removed.
Fixes issue #1659

Summary of the changes
 - Retries to get the value again with the key having the dash omitted (`-`)

Addresses #1659
