### PR TITLE
Adding link to MySQL distributed caching

### DIFF
--- a/src/Caching/README.md
+++ b/src/Caching/README.md
@@ -2,3 +2,6 @@ Caching
 =======
 
 Contains libraries for in-memory caching and distributed caching. Includes distributed cache implementations for in-memory, Microsoft SQL Server, and Redis.
+
+Third party caching implementations:
+* MySQL distributed caching project (Pomelo Foundation) <https://github.com/PomeloFoundation/Caching-MySQL>


### PR DESCRIPTION
Adding link to external 3rd party distributed cache for MySQL under supervision of Pomelo Foundation.
 - implementing abstraction similar to SqlServer and StackExchangeRedis caching
 - main dependency being of https://github.com/mysql-net/MySqlConnector

Addresses https://github.com/aspnet/AspNetCore.Docs/issues/11730
and creating PR as suggested