### PR TITLE
Caching ResourceManagerStringLocalizer creation

### DIFF
--- a/src/Localization/Localization/src/ResourceManagerStringLocalizerFactory.cs
+++ b/src/Localization/Localization/src/ResourceManagerStringLocalizerFactory.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Localization
                 var assembly = typeInfo.Assembly;
 
                 return CreateResourceManagerStringLocalizer(assembly, baseName);
-            }
+            });
         }
 
         /// <summary>

--- a/src/Localization/Localization/src/ResourceManagerStringLocalizerFactory.cs
+++ b/src/Localization/Localization/src/ResourceManagerStringLocalizerFactory.cs
@@ -149,13 +149,14 @@ namespace Microsoft.Extensions.Localization
                 throw new ArgumentNullException(nameof(resourceSource));
             }
 
-            var typeInfo = resourceSource.GetTypeInfo();
+            return _localizerCache.GetOrAdd(resourceSource.AssemblyQualifiedName, _ =>
+            {
+                var typeInfo = resourceSource.GetTypeInfo();
+                var baseName = GetResourcePrefix(typeInfo);
+                var assembly = typeInfo.Assembly;
 
-            var baseName = GetResourcePrefix(typeInfo);
-
-            var assembly = typeInfo.Assembly;
-
-            return _localizerCache.GetOrAdd(baseName, _ => CreateResourceManagerStringLocalizer(assembly, baseName));
+                return CreateResourceManagerStringLocalizer(assembly, baseName);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1264

As per the issue details, the current code is doing too much reflection. 
Here the `_localizerCache` is reused to add entries for the `Type` based initialization. The keys can't collide with the other usage of the dictionary.
`AssemblyQualifiedName` is used as the key to isolate all types in the dictionary.
