### PR TITLE
Consistently handle prefixes in AddEnvironmentVariables

### DIFF
--- a/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -94,11 +94,9 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             }
             else
             {
-                key = NormalizeKey(key);
-
                 if (key.StartsWith(prefixFilter, StringComparison.OrdinalIgnoreCase))
                 {
-                    entry.Key = key.Substring(prefixFilter.Length);
+                    entry.Key = NormalizeKey(key.Substring(prefixFilter.Length));
                     yield return entry;
                 }
 

--- a/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
+++ b/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
@@ -85,23 +85,24 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         {
             var dict = new Hashtable()
             {
-                {"CUSTOMCONNSTR_db1", "CustomConnStr"},
-                {"SQLCONNSTR_db2", "SQLConnStr"},
-                {"MYSQLCONNSTR_db3", "MySQLConnStr"},
-                {"SQLAZURECONNSTR_db4", "SQLAzureConnStr"},
+                {"CUSTOMCONNSTR_PREFIX_db1", "CustomConnStr"},
+                {"SQLCONNSTR_PREFIX_db2", "SQLConnStr"},
+                {"MYSQLCONNSTR_PREFIX_db3", "MySQLConnStr"},
+                {"SQLAZURECONNSTR_PREFIX_db4", "SQLAzureConnStr"},
                 {"CommonEnv", "CommonEnvValue"},
             };
-            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("ConnectionStrings:");
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("PREFIX_");
 
             envConfigSrc.Load(dict);
 
-            Assert.Equal("CustomConnStr", envConfigSrc.Get("db1"));
-            Assert.Equal("SQLConnStr", envConfigSrc.Get("db2"));
-            Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("db2_ProviderName"));
-            Assert.Equal("MySQLConnStr", envConfigSrc.Get("db3"));
-            Assert.Equal("MySql.Data.MySqlClient", envConfigSrc.Get("db3_ProviderName"));
-            Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("db4"));
-            Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("db4_ProviderName"));
+            Assert.Equal("CustomConnStr", envConfigSrc.Get("ConnectionStrings:db1"));
+            Assert.Equal("SQLConnStr", envConfigSrc.Get("ConnectionStrings:db2"));
+            Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:db2_ProviderName"));
+            Assert.Equal("MySQLConnStr", envConfigSrc.Get("ConnectionStrings:db3"));
+            Assert.Equal("MySql.Data.MySqlClient", envConfigSrc.Get("ConnectionStrings:db3_ProviderName"));
+            Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("ConnectionStrings:db4"));
+            Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:db4_ProviderName"));
+            Assert.False(envConfigSrc.TryGet("CommonEnv", out var _));
         }
 
         [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Resolves an issue where Connection Strings from Azure App Services are not able to be imported when you call `AddEnvironmentVariables(string prefix)`. 

`AzureEnvToAppEnv(...)` will always yield dictionary entries with keys starting with `ConnectionString:` for Connection Strings detected from Azure. The environment variable filter will then immediately filter these out as they can never start with the user-defined `_prefix` unless it's either empty or literally `ConnectionString:`. 

Addresses: https://github.com/aspnet/Extensions/issues/1306