### PR TITLE
LoggerFactory Configurable ScopeProvider

### DIFF
--- a/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netstandard2.0.cs
+++ b/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netstandard2.0.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Extensions.Logging
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.LoggerFilterOptions filterOptions) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption) { }
+        public Microsoft.Extensions.Logging.IExternalScopeProvider ScopeProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void AddProvider(Microsoft.Extensions.Logging.ILoggerProvider provider) { }
         protected virtual bool CheckDisposed() { throw null; }
         public static Microsoft.Extensions.Logging.ILoggerFactory Create(System.Action<Microsoft.Extensions.Logging.ILoggingBuilder> configure) { throw null; }

--- a/src/Logging/Logging/src/LoggerFactory.cs
+++ b/src/Logging/Logging/src/LoggerFactory.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Extensions.Logging
         private volatile bool _disposed;
         private IDisposable _changeTokenRegistration;
         private LoggerFilterOptions _filterOptions;
-        private LoggerExternalScopeProvider _scopeProvider;
 
         /// <summary>
         /// Creates a new <see cref="LoggerFactory"/> instance.
@@ -63,6 +62,8 @@ namespace Microsoft.Extensions.Logging
             _changeTokenRegistration = filterOption.OnChange(RefreshFilters);
             RefreshFilters(filterOption.CurrentValue);
         }
+
+        public IExternalScopeProvider ScopeProvider { get; set; }
 
         /// <summary>
         /// Creates new instance of <see cref="ILoggerFactory"/> configured using provided <paramref name="configure"/> delegate.
@@ -161,12 +162,12 @@ namespace Microsoft.Extensions.Logging
 
             if (provider is ISupportExternalScope supportsExternalScope)
             {
-                if (_scopeProvider == null)
+                if (ScopeProvider == null)
                 {
-                    _scopeProvider = new LoggerExternalScopeProvider();
+                    ScopeProvider = new LoggerExternalScopeProvider();
                 }
 
-                supportsExternalScope.SetScopeProvider(_scopeProvider);
+                supportsExternalScope.SetScopeProvider(ScopeProvider);
             }
         }
 
@@ -206,9 +207,9 @@ namespace Microsoft.Extensions.Logging
                 }
             }
 
-            if (_scopeProvider != null)
+            if (ScopeProvider != null)
             {
-                scopeLoggers?.Add(new ScopeLogger(logger: null, externalScopeProvider: _scopeProvider));
+                scopeLoggers?.Add(new ScopeLogger(logger: null, externalScopeProvider: ScopeProvider));
             }
 
             return (messageLoggers.ToArray(), scopeLoggers?.ToArray());


### PR DESCRIPTION
It currently near impossible to stay on the default ExecutionContext without switching off logging in its entirety due to the scopes stored in the AsyncLocal in `LoggerExternalScopeProvider`; even if Scopes are off.

The only other-ways around it are to implement your own `ILoggerFactory` and ditch `LoggerFactory` or only use loggers that don't implement `ISupportExternalScope`. Both approaches are unsatisfactory as they don't allow you reuse logging.

Allowing it to be set allows `NullExternalScopeProvider` to be set instead and something along the lines of:
```csharp
.ConfigureServices(services => 
{
    services.AddSingleton(NullExternalScopeProvider.Instance);
    services.Replace(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>(
        (services) =>
        {
            var factory = new LoggerFactory();
            factory.ScopeProvider = NullExternalScopeProvider.Instance;
            return factory;
        }));
})
```

Ideally it would get the from DI so `services.AddSingleton(NullExternalScopeProvider.Instance);` would replace it.

/cc @anurse @davidfowl @sebastienros 