### PR TITLE
Allow ignoring static properties in ConfigurationBinder

### DIFF
--- a/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netcoreapp5.0.cs
+++ b/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netcoreapp5.0.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Extensions.Configuration
     {
         public BinderOptions() { }
         public bool BindNonPublicProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IgnoreStaticProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public static partial class ConfigurationBinder
     {

--- a/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netstandard2.0.cs
+++ b/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netstandard2.0.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Extensions.Configuration
     {
         public BinderOptions() { }
         public bool BindNonPublicProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IgnoreStaticProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public static partial class ConfigurationBinder
     {

--- a/src/Configuration/Config.Binder/src/BinderOptions.cs
+++ b/src/Configuration/Config.Binder/src/BinderOptions.cs
@@ -13,5 +13,11 @@ namespace Microsoft.Extensions.Configuration
         /// If true, the binder will attempt to set all non read-only properties.
         /// </summary>
         public bool BindNonPublicProperties { get; set; }
+
+        /// <summary>
+        /// When false (the default), the binder will set both instance and static properties.
+        /// If true, the binder will attempt to set only instance properties, ignoring static ones.
+        /// </summary>
+        public bool IgnoreStaticProperties { get; set; }
     }
 }

--- a/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
+++ b/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
@@ -189,10 +189,11 @@ namespace Microsoft.Extensions.Configuration
 
         private static void BindProperty(PropertyInfo property, object instance, IConfiguration config, BinderOptions options)
         {
-            // We don't support set only, non public, or indexer properties
+            // We don't support set only, non public, indexer properties, or ignored static properties
             if (property.GetMethod == null ||
                 (!options.BindNonPublicProperties && !property.GetMethod.IsPublic) ||
-                property.GetMethod.GetParameters().Length > 0)
+                property.GetMethod.GetParameters().Length > 0 ||
+                (options.IgnoreStaticProperties && property.GetMethod.IsStatic))
             {
                 return;
             }


### PR DESCRIPTION
- An `IgnoreStaticProperties` binder option was added
- Default behavior remains unchanged (binding to static properties enabled)

Addresses #1627
