### PR TITLE
DI - Cache CallSiteValidator results during walk

### DIFF
--- a/src/DependencyInjection/DI/perf/CallSiteValidatorBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/CallSiteValidatorBenchmark.cs
@@ -1,0 +1,186 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection.ServiceLookup;
+
+namespace Microsoft.Extensions.DependencyInjection.Performance
+{
+    public class CallSiteValidatorBenchmark
+    {
+        private ServiceCallSite _callSite;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddTransient<A>();
+            services.AddTransient<B>();
+            services.AddTransient<C>();
+            services.AddTransient<D>();
+            services.AddTransient<E>();
+            services.AddTransient<F>();
+            services.AddTransient<G>();
+            services.AddTransient<H>();
+            services.AddTransient<I>();
+            services.AddTransient<J>();
+            services.AddTransient<K>();
+            services.AddTransient<L>();
+            services.AddTransient<M>();
+            services.AddTransient<N>();
+            services.AddTransient<O>();
+            services.AddTransient<P>();
+
+            var callSiteFactory = new CallSiteFactory(services.ToArray());
+
+            _callSite = callSiteFactory.GetCallSite(typeof(A), new CallSiteChain());
+        }
+
+        [Benchmark()]
+        public void ValidateCallSite()
+        {
+            var callSiteValidator = new CallSiteValidator();
+
+            callSiteValidator.ValidateCallSite(_callSite);
+        }
+
+        private class A
+        {
+            public A(B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l)
+            {
+
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void Foo()
+            {
+
+            }
+        }
+
+        private class B
+        {
+            public B(C c, D d, E e, F f, G g, H h, I i, J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class C
+        {
+            public C(D d, E e, F f, G g, H h, I i, J j, K k, L l)
+            {
+
+            }
+
+        }
+
+        private class D
+        {
+            public D(E e, F f, G g, H h, I i, J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class E
+        {
+            public E(F f, G g, H h, I i, J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class F
+        {
+            public F(G g, H h, I i, J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class G
+        {
+            public G(H h, I i, J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class H
+        {
+            public H(I i, J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class I
+        {
+            public I(J j, K k, L l)
+            {
+
+            }
+        }
+
+        private class J
+        {
+            public J(K k, L l)
+            {
+
+            }
+        }
+
+        private class K
+        {
+            public K(L l)
+            {
+
+            }
+        }
+
+        private class L
+        {
+            public L(M m)
+            {
+
+            }
+        }
+
+        private class M
+        {
+            public M(N n)
+            {
+
+            }
+        }
+
+        private class N
+        {
+            public N(O o)
+            {
+
+            }
+        }
+
+        private class O
+        {
+            public O(P p)
+            {
+
+            }
+        }
+
+        private class P
+        {
+            public P()
+            {
+
+            }
+        }
+
+    }
+}

--- a/src/DependencyInjection/DI/perf/CallSiteValidatorBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/CallSiteValidatorBenchmark.cs
@@ -53,12 +53,6 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             {
 
             }
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void Foo()
-            {
-
-            }
         }
 
         private class B

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             bool ignoreServiceType = argument.IgnoreServiceType;
 
             if ((!ignoreServiceType && _scopedServices.TryGetValue(callSite.ServiceType, out scoped)) ||
-                _scopedServices.TryGetValue(callSite.ImplementationType, out scoped))
+                (callSite.ImplementationType != null && _scopedServices.TryGetValue(callSite.ImplementationType, out scoped)))
             {
                 return scoped;
             }
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 lock (_nonScopedServices)
                 {
                     if ((!ignoreServiceType && _nonScopedServices.Contains(callSite.ServiceType)) ||
-                        _nonScopedServices.Contains(callSite.ImplementationType))
+                        (callSite.ImplementationType != null && _nonScopedServices.Contains(callSite.ImplementationType)))
                     {
                         return null;
                     }
@@ -48,22 +48,28 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             if (scoped != null)
             {
-                _scopedServices[callSite.ImplementationType] = scoped;
-
                 if (!ignoreServiceType)
                 {
                     _scopedServices[callSite.ServiceType] = scoped;
+                }
+
+                if (callSite.ImplementationType != null)
+                {
+                    _scopedServices[callSite.ImplementationType] = scoped;
                 }
             }
             else
             {
                 lock (_nonScopedServices)
                 {
-                    _nonScopedServices.Add(callSite.ImplementationType);
-
                     if (!ignoreServiceType)
                     {
                         _nonScopedServices.Add(callSite.ServiceType);
+                    }
+
+                    if (callSite.ImplementationType != null)
+                    {
+                        _nonScopedServices.Add(callSite.ImplementationType);
                     }
                 }
             }

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return scoped;
         }
 
-
         public void ValidateResolution(Type serviceType, IServiceScope scope, IServiceScope rootScope)
         {
             if (ReferenceEquals(scope, rootScope)

--- a/src/DependencyInjection/DI/test/ServiceProviderValidationTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderValidationTests.cs
@@ -111,7 +111,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(result);
         }
 
-
         [Fact]
         public void GetService_DoesNotThrow_WhenGetServiceForServiceWithMultipleImplementationScopesWhereLastIsNotScoped()
         {


### PR DESCRIPTION
Caches the results of CallSiteValidator during its walk
 - Adds results to either _scopedServices or _nonScopedServices for each new service encountered instead of only adding at the top-level.
- Also caches results for implementation types as well since those would be the same as the service results.
- There's extra complexity around caching the results of services resolved under a EnumerableCallSite -- the service type should not be considered or results stored for it for any call sites that are direct children of a EnumerableCallSite.
- Tests added around the EnumerableCallSiteComplexity, name are... uhh... long, open to renaming them if you got better names in mind 🤷‍♂ 

Addresses #2353

# Performance Comparison
As measured by CallSiteValidatorBenchmark.cs:
## Before
![BeforeUpdate](https://user-images.githubusercontent.com/1155895/65369557-b7103b00-dc1c-11e9-988e-611bba7ee989.PNG)

## After
![AfterUpdate](https://user-images.githubusercontent.com/1155895/65369558-bbd4ef00-dc1c-11e9-9379-dd8af93a17c7.PNG)
