### PR TITLE
Add support for value types in dependency injection

### DIFF
--- a/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -100,7 +100,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ScopeParameter);
             }
 
-            return Expression.Lambda<Func<ServiceProviderEngineScope, object>>(VisitCallSite(callSite, null), ScopeParameter);
+            return Expression.Lambda<Func<ServiceProviderEngineScope, object>>(
+                Convert(VisitCallSite(callSite, null), typeof(object)),
+                ScopeParameter);
         }
 
         protected override Expression VisitRootCache(ServiceCallSite singletonCallSite, object context)
@@ -186,7 +188,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private static Expression Convert(Expression expression, Type type)
         {
             // Don't convert if the expression is already assignable
-            if (type.GetTypeInfo().IsAssignableFrom(expression.Type.GetTypeInfo()))
+            if (!expression.Type.IsValueType && type.GetTypeInfo().IsAssignableFrom(expression.Type.GetTypeInfo()))
             {
                 return expression;
             }
@@ -218,7 +220,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 keyExpression,
                 resolvedVariable);
 
-            var captureDisposible = TryCaptureDisposable(callSite, ScopeParameter, VisitCallSiteMain(callSite, null));
+            var captureDisposible = Convert(
+                TryCaptureDisposable(callSite, ScopeParameter, VisitCallSiteMain(callSite, null)),
+                typeof(object));
 
             var assignExpression = Expression.Assign(
                 resolvedVariable,

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -392,15 +392,22 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                 // load value
                 Ldloc(context.Generator, resultLocal.LocalIndex);
-                // return
-                context.Generator.Emit(OpCodes.Ret);
             }
             else
             {
                 VisitCallSite(callSite, context);
-                // return
-                context.Generator.Emit(OpCodes.Ret);
             }
+
+            if (callSite.ServiceType.IsValueType)
+            {
+                context.Generator.Emit(OpCodes.Box, callSite.ServiceType);
+            }
+            else if (callSite.ImplementationType?.IsValueType == true)
+            {
+                context.Generator.Emit(OpCodes.Box, callSite.ImplementationType);
+            }
+            // return
+            context.Generator.Emit(OpCodes.Ret);
 
             return new ILEmitResolverBuilderRuntimeContext
             {

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ILEmitServiceProviderEngine : ServiceProviderEngine
     {
-        private readonly ILEmitResolverBuilder _expressionResolverBuilder;
+        private readonly ILEmitResolverBuilder _ilEmitResolverBuilder;
         public ILEmitServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
         {
-            _expressionResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
+            _ilEmitResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
         }
 
         protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
-            var realizedService = _expressionResolverBuilder.Build(callSite);
+            var realizedService = _ilEmitResolverBuilder.Build(callSite);
             RealizedServices[callSite.ServiceType] = realizedService;
             return realizedService;
         }

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -10,11 +10,19 @@ using Microsoft.Extensions.DependencyInjection.Specification;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Microsoft.Extensions.DependencyInjection.Tests.Fakes;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     public abstract class ServiceProviderContainerTests : DependencyInjectionSpecificationTests
     {
+        private readonly ITestOutputHelper _outputHelper;
+
+        protected ServiceProviderContainerTests(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
         [Fact]
         public void RethrowOriginalExceptionFromConstructor()
         {
@@ -180,12 +188,19 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.NotNull(provider.CreateScope());
         }
 
-        [Theory(Skip = "We don't support value task services currently")]
+        [Theory]
         [InlineData(ServiceLifetime.Transient)]
         [InlineData(ServiceLifetime.Scoped)]
         [InlineData(ServiceLifetime.Singleton)]
         public void WorksWithStructServices(ServiceLifetime lifetime)
         {
+#if NETCOREAPP5_0
+            if (GetType() == typeof(ServiceProviderILEmitContainerTests) && lifetime == ServiceLifetime.Scoped)
+            {
+                _outputHelper.WriteLine("We don't support scoped value type services when using the ILEmitServiceProviderEngine in netcoreapp5.0 currently");
+                return;
+            }
+#endif
             IServiceCollection serviceCollection = new ServiceCollection();
             serviceCollection.Add(new ServiceDescriptor(typeof(IFakeService), typeof(StructFakeService), lifetime));
             serviceCollection.Add(new ServiceDescriptor(typeof(StructService), typeof(StructService), lifetime));

--- a/src/DependencyInjection/DI/test/ServiceProviderDefaultContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderDefaultContainerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
 {
@@ -9,5 +10,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Default });
+
+        public ServiceProviderDefaultContainerTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
     }
 }

--- a/src/DependencyInjection/DI/test/ServiceProviderDynamicContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderDynamicContainerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
 {
@@ -9,5 +10,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider();
+
+        public ServiceProviderDynamicContainerTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
     }
 }

--- a/src/DependencyInjection/DI/test/ServiceProviderExpressionsContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderExpressionsContainerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
 {
@@ -9,5 +10,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Expressions });
+
+        public ServiceProviderExpressionsContainerTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
     }
 }

--- a/src/DependencyInjection/DI/test/ServiceProviderILEmitContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderILEmitContainerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
 {
@@ -9,5 +10,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider(new ServiceProviderOptions() { Mode = ServiceProviderMode.ILEmit});
+
+        public ServiceProviderILEmitContainerTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
     }
 }


### PR DESCRIPTION
This pull request adds support for value types in:
- `ExpressionsServiceProviderEngine`  and
- `ILEmitServiceProviderEngine`*

*(including **CLR** bug for `ServiceLifetime.Scoped` when targeting `netcoreapp5.0`)

Summary of the changes:
- Copy-paste typo fix in `ILEmitServiceProviderEngine.cs`
- Add two extra calls to `Convert` in `ExpressionResolverBuilder.cs`
- Update `Convert` in `ExpressionResolverBuilder.cs` to also check for `expression.Type.IsValueType`
- Emit `OpCodes.Box` as appropriate in `ILEmitResolverBuilder.cs`
- Update `ServiceProviderContainerTests.cs` to no longer skip tests for value types (structs)

There's a small problem with this though: I've had to exclude one specific scenario for the tests, as it fails with an error stating that the CLR detected an invalid program. I need some help to figure out what's wrong in this specific case and devise a solution. Is this perhaps an indication of an _actual_ bug in the CLR for `netcoreapp5.0`?

Addresses #2403
