### PR TITLE
IExternalScopeProvider can now be injected (#2409)

### DIFF
--- a/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
+++ b/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.Logging
     public partial class LoggerExternalScopeProvider : Microsoft.Extensions.Logging.IExternalScopeProvider
     {
         public LoggerExternalScopeProvider() { }
-        public void ForEachScope<TState>(System.Action<object, TState> callback, TState state) { }
+        public virtual void ForEachScope<TState>(System.Action<object, TState> callback, TState state) { }
         public System.IDisposable Push(object state) { throw null; }
     }
     public static partial class LoggerFactoryExtensions

--- a/src/Logging/Logging.Abstractions/src/LoggerExternalScopeProvider.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerExternalScopeProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging
         { }
 
         /// <inheritdoc />
-        public void ForEachScope<TState>(Action<object, TState> callback, TState state)
+        public virtual void ForEachScope<TState>(Action<object, TState> callback, TState state)
         {
             void Report(Scope current)
             {

--- a/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netcoreapp3.0.cs
+++ b/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netcoreapp3.0.cs
@@ -39,9 +39,13 @@ namespace Microsoft.Extensions.Logging
     public partial class LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory, System.IDisposable
     {
         public LoggerFactory() { }
+        public LoggerFactory(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.LoggerFilterOptions filterOptions) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.LoggerFilterOptions filterOptions, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public void AddProvider(Microsoft.Extensions.Logging.ILoggerProvider provider) { }
         protected virtual bool CheckDisposed() { throw null; }
         public static Microsoft.Extensions.Logging.ILoggerFactory Create(System.Action<Microsoft.Extensions.Logging.ILoggingBuilder> configure) { throw null; }

--- a/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netstandard2.0.cs
+++ b/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netstandard2.0.cs
@@ -39,9 +39,13 @@ namespace Microsoft.Extensions.Logging
     public partial class LoggerFactory : Microsoft.Extensions.Logging.ILoggerFactory, System.IDisposable
     {
         public LoggerFactory() { }
+        public LoggerFactory(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.LoggerFilterOptions filterOptions) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Logging.LoggerFilterOptions filterOptions, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption) { }
+        public LoggerFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider> providers, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.LoggerFilterOptions> filterOption, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public void AddProvider(Microsoft.Extensions.Logging.ILoggerProvider provider) { }
         protected virtual bool CheckDisposed() { throw null; }
         public static Microsoft.Extensions.Logging.ILoggerFactory Create(System.Action<Microsoft.Extensions.Logging.ILoggingBuilder> configure) { throw null; }

--- a/src/Logging/Logging/src/LoggingServiceCollectionExtensions.cs
+++ b/src/Logging/Logging/src/LoggingServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddOptions();
 
+            services.TryAdd(ServiceDescriptor.Singleton<IExternalScopeProvider, LoggerExternalScopeProvider>());
             services.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
             services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(Logger<>)));
 


### PR DESCRIPTION
- Added IExternalScopeProvider parameter to LoggerFactory to allow injection.
- Registers default implementation if not otherwise registered.

Addresses #2409

Note: this is currently based on the release/3.0 branch since I verified that it would solve the problems I'm having with the current stable release. I can rebase to 3.1 if necessary.