### PR TITLE
Support configuring the Azure Key Vault IConfigurationSource as optional.

### DIFF
--- a/src/Configuration/Config.AzureKeyVault/ref/Microsoft.Extensions.Configuration.AzureKeyVault.netstandard2.0.cs
+++ b/src/Configuration/Config.AzureKeyVault/ref/Microsoft.Extensions.Configuration.AzureKeyVault.netstandard2.0.cs
@@ -8,11 +8,18 @@ namespace Microsoft.Extensions.Configuration
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Microsoft.Extensions.Configuration.AzureKeyVault.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, Microsoft.Azure.KeyVault.KeyVaultClient client, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, Microsoft.Azure.KeyVault.KeyVaultClient client, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager, bool optional) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager, bool optional) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, bool optional) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager, bool optional) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool optional) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, string clientSecret) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, string clientSecret, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, string clientSecret, Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager manager, bool optional) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string vault, string clientId, string clientSecret, bool optional) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
@@ -20,11 +27,16 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
     public partial class AzureKeyVaultConfigurationOptions
     {
         public AzureKeyVaultConfigurationOptions() { }
+        public AzureKeyVaultConfigurationOptions(bool optional) { }
         public AzureKeyVaultConfigurationOptions(string vault) { }
+        public AzureKeyVaultConfigurationOptions(string vault, bool optional) { }
         public AzureKeyVaultConfigurationOptions(string vault, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public AzureKeyVaultConfigurationOptions(string vault, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool optional) { }
         public AzureKeyVaultConfigurationOptions(string vault, string clientId, string clientSecret) { }
+        public AzureKeyVaultConfigurationOptions(string vault, string clientId, string clientSecret, bool optional) { }
         public Microsoft.Azure.KeyVault.KeyVaultClient Client { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Extensions.Configuration.AzureKeyVault.IKeyVaultSecretManager Manager { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Optional { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.TimeSpan? ReloadInterval { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Vault { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationExtensions.cs
@@ -27,7 +27,26 @@ namespace Microsoft.Extensions.Configuration
             string clientId,
             string clientSecret)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, clientSecret));
+            return configurationBuilder.AddAzureKeyVault(vault, clientId, clientSecret, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">The Azure KeyVault uri.</param>
+        /// <param name="clientId">The application client id.</param>
+        /// <param name="clientSecret">The client secret to use for authentication.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            string clientId,
+            string clientSecret,
+            bool optional)
+        {
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, clientSecret, optional));
         }
 
         /// <summary>
@@ -46,7 +65,28 @@ namespace Microsoft.Extensions.Configuration
             string clientSecret,
             IKeyVaultSecretManager manager)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, clientSecret)
+            return configurationBuilder.AddAzureKeyVault(vault, clientId, clientSecret, manager, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">The Azure KeyVault uri.</param>
+        /// <param name="clientId">The application client id.</param>
+        /// <param name="clientSecret">The client secret to use for authentication.</param>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            string clientId,
+            string clientSecret,
+            IKeyVaultSecretManager manager,
+            bool optional)
+        {
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, clientSecret, optional)
             {
                 Manager = manager
             });
@@ -66,7 +106,26 @@ namespace Microsoft.Extensions.Configuration
             string clientId,
             X509Certificate2 certificate)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, certificate));
+            return configurationBuilder.AddAzureKeyVault(vault, clientId, certificate, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="clientId">The application client id.</param>
+        /// <param name="certificate">The <see cref="X509Certificate2"/> to use for authentication.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            string clientId,
+            X509Certificate2 certificate,
+            bool optional)
+        {
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, certificate, optional));
         }
 
         /// <summary>
@@ -85,7 +144,28 @@ namespace Microsoft.Extensions.Configuration
             X509Certificate2 certificate,
             IKeyVaultSecretManager manager)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, certificate)
+            return configurationBuilder.AddAzureKeyVault(vault, clientId, certificate, manager, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="clientId">The application client id.</param>
+        /// <param name="certificate">The <see cref="X509Certificate2"/> to use for authentication.</param>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            string clientId,
+            X509Certificate2 certificate,
+            IKeyVaultSecretManager manager,
+            bool optional)
+        {
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, clientId, certificate, optional)
             {
                 Manager = manager
             });
@@ -101,7 +181,22 @@ namespace Microsoft.Extensions.Configuration
             this IConfigurationBuilder configurationBuilder,
             string vault)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault));
+            return configurationBuilder.AddAzureKeyVault(vault, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            bool optional)
+        {
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, optional));
         }
 
         /// <summary>
@@ -116,7 +211,24 @@ namespace Microsoft.Extensions.Configuration
             string vault,
             IKeyVaultSecretManager manager)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault)
+            return configurationBuilder.AddAzureKeyVault(vault, manager, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            IKeyVaultSecretManager manager,
+            bool optional)
+        {
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vault, optional)
             {
                 Manager = manager
             });
@@ -136,11 +248,31 @@ namespace Microsoft.Extensions.Configuration
             KeyVaultClient client,
             IKeyVaultSecretManager manager)
         {
+            return configurationBuilder.AddAzureKeyVault(vault, client, manager, false);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="client">The <see cref="KeyVaultClient"/> to use for retrieving values.</param>
+        /// <param name="manager">The <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            string vault,
+            KeyVaultClient client,
+            IKeyVaultSecretManager manager,
+            bool optional)
+        {
             return configurationBuilder.Add(new AzureKeyVaultConfigurationSource(new AzureKeyVaultConfigurationOptions()
             {
                 Client = client,
                 Vault = vault,
-                Manager = manager
+                Manager = manager,
+                Optional = optional
             }));
         }
 

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationOptions.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationOptions.cs
@@ -18,11 +18,21 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         /// <summary>
         /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
         /// </summary>
-        public AzureKeyVaultConfigurationOptions()
+        public AzureKeyVaultConfigurationOptions() : this(false)
         {
-            Manager = DefaultKeyVaultSecretManager.Instance;
+
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
+        /// </summary>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        public AzureKeyVaultConfigurationOptions(bool optional)
+        {
+            Manager = DefaultKeyVaultSecretManager.Instance;
+            Optional = optional;
+        }
+        
         /// <summary>
         /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
         /// </summary>
@@ -32,26 +42,55 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         public AzureKeyVaultConfigurationOptions(
             string vault,
             string clientId,
-            X509Certificate2 certificate) : this()
+            X509Certificate2 certificate) : this(vault, clientId, certificate, false)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
+        /// </summary>
+        /// <param name="vault">Azure KeyVault uri.</param>
+        /// <param name="clientId">The application client id.</param>
+        /// <param name="certificate">The <see cref="X509Certificate2"/> to use for authentication.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        public AzureKeyVaultConfigurationOptions(
+            string vault,
+            string clientId,
+            X509Certificate2 certificate,
+            bool optional) : this()
         {
             KeyVaultClient.AuthenticationCallback authenticationCallback =
                 (authority, resource, scope) => GetTokenFromClientCertificate(authority, resource, clientId, certificate);
 
             Vault = vault;
             Client = new KeyVaultClient(authenticationCallback);
+            Optional = optional;
         }
 
         /// <summary>
         /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
         /// </summary>
         /// <param name="vault">The Azure KeyVault uri.</param>
-        public AzureKeyVaultConfigurationOptions(string vault) : this()
+        public AzureKeyVaultConfigurationOptions(string vault) : this(vault, false)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
+        /// </summary>
+        /// <param name="vault">The Azure KeyVault uri.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        public AzureKeyVaultConfigurationOptions(
+            string vault,
+            bool optional) : this()
         {
             var azureServiceTokenProvider = new AzureServiceTokenProvider();
             var authenticationCallback = new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback);
 
             Vault = vault;
             Client = new KeyVaultClient(authenticationCallback);
+            Optional = optional;
         }
 
         /// <summary>
@@ -63,7 +102,22 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         public AzureKeyVaultConfigurationOptions(
             string vault,
             string clientId,
-            string clientSecret) : this()
+            string clientSecret) : this(vault, clientId, clientSecret, false)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
+        /// </summary>
+        /// <param name="vault">The Azure KeyVault uri.</param>
+        /// <param name="clientId">The application client id.</param>
+        /// <param name="clientSecret">The client secret to use for authentication.</param>
+        /// <param name="optional">Whether reading from the key vault is optional.</param>
+        public AzureKeyVaultConfigurationOptions(
+            string vault,
+            string clientId,
+            string clientSecret,
+            bool optional) : this()
         {
             if (clientId == null)
             {
@@ -78,6 +132,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
                 (authority, resource, scope) => GetTokenFromClientSecret(authority, resource, clientId, clientSecret);
 
             Vault = vault;
+            Optional = optional;
             Client = new KeyVaultClient(authenticationCallback);
         }
 
@@ -90,6 +145,11 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         /// Gets or sets the vault uri.
         /// </summary>
         public string Vault { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether reading from this key vault is optional
+        /// </summary>
+        public bool Optional { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IKeyVaultSecretManager"/> instance used to control secret loading.

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationSource.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationSource.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
         /// <inheritdoc />
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureKeyVaultConfigurationProvider(new KeyVaultClientWrapper(_options.Client), _options.Vault, _options.Manager, _options.ReloadInterval);
+            return new AzureKeyVaultConfigurationProvider(new KeyVaultClientWrapper(_options.Client, _options.Optional), _options.Vault, _options.Manager, _options.ReloadInterval);
         }
     }
 }

--- a/src/Configuration/Config.AzureKeyVault/src/KeyVaultClientWrapper.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/KeyVaultClientWrapper.cs
@@ -1,6 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
@@ -11,21 +15,70 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
     /// <inheritdoc />
     internal class KeyVaultClientWrapper : IKeyVaultClient
     {
+        private sealed class EmptyPage : IPage<SecretItem>
+        {
+            public static readonly EmptyPage Instance = new EmptyPage();
+
+            public IEnumerator<SecretItem> GetEnumerator()
+            {
+                return Enumerable.Empty<SecretItem>().GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public string NextPageLink { get; } = null;
+        }
+
         private readonly KeyVaultClient _keyVaultClientImplementation;
+        private readonly bool _optional;
 
         /// <summary>
         /// Creates a new instance of <see cref="KeyVaultClientWrapper"/>.
         /// </summary>
         /// <param name="keyVaultClientImplementation">The <see cref="KeyVaultClient"/> instance to wrap.</param>
-        public KeyVaultClientWrapper(KeyVaultClient keyVaultClientImplementation)
+        /// <param name="optional">Whether GetSecretsAsync returns an empty page instead of throwing when retrieval fails.</param>
+        public KeyVaultClientWrapper(KeyVaultClient keyVaultClientImplementation, bool optional)
         {
             _keyVaultClientImplementation = keyVaultClientImplementation;
+            _optional = optional;
         }
 
         /// <inheritdoc />
-        public Task<IPage<SecretItem>> GetSecretsAsync(string vault)
+        public async Task<IPage<SecretItem>> GetSecretsAsync(string vault)
         {
-            return _keyVaultClientImplementation.GetSecretsAsync(vault);
+            try
+            {
+                return await _keyVaultClientImplementation.GetSecretsAsync(vault);
+            }
+            catch (System.Net.Http.HttpRequestException)
+            {
+                //Host unknown or not reachable.
+                if (!_optional)
+                {
+                    throw;
+                }
+            }
+            catch (Azure.Services.AppAuthentication.AzureServiceTokenProviderException)
+            {
+                //Not logged into Azure (locally) or no managed identity configured (Azure)
+                if (!_optional)
+                {
+                    throw;
+                }
+            }
+            catch (KeyVaultErrorException)
+            {
+                //No permission to read secret list from key vault.
+                if (!_optional)
+                {
+                    throw;
+                }
+            }
+
+            return EmptyPage.Instance;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
So far, most of the various configuration sources in aspnet/Extensions can be configured as optional, i.e. they won't throw in case configurations cannot be accessed. This PR adds this feature for Azure Key Vault.

There are 3 scenarios where secret retrieval from Key Vault might fail and you might want to continue anyway:

- Invalid or unreachable host name. This is much like a file that isn't there. Maybe you haven't set up a Key Vault yet and your host name says "https://invalid" or something else. 
- Failure to obtain a valid access token. This happens locally when the user hasn't logged into Azure with "az login" or in an Azure deployment when managed identity isn't configured. You might not want your app to crash then.
- Insufficient permissions (List/Get Secrets).