### PR TITLE
Add support for dependency injection of Func<TService> parameters

### DIFF
--- a/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
@@ -172,6 +172,25 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
+        public void SingleServiceCanBeFuncResolved()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddTransient(typeof(IFakeService), typeof(FakeService));
+            var provider = CreateServiceProvider(collection);
+
+            // Act
+            var func = provider.GetService<Func<IFakeService>>();
+            var service = func();
+
+            // Assert
+            Assert.NotNull(func);
+            Assert.NotNull(service);
+            Assert.IsAssignableFrom<Func<IFakeService>>(func);
+            Assert.IsType<FakeService>(service);
+        }
+
+        [Fact]
         public void MultipleServiceCanBeIEnumerableResolved()
         {
             // Arrange
@@ -187,6 +206,24 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             Assert.Collection(services.OrderBy(s => s.GetType().FullName),
                 service => Assert.IsType<FakeOneMultipleService>(service),
                 service => Assert.IsType<FakeTwoMultipleService>(service));
+        }
+
+        [Fact]
+        public void LastRegisteredServiceWillBeFuncResolved()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddTransient(typeof(IFakeMultipleService), typeof(FakeOneMultipleService));
+            collection.AddTransient(typeof(IFakeMultipleService), typeof(FakeTwoMultipleService));
+            var provider = CreateServiceProvider(collection);
+
+            // Act
+            var func = provider.GetService<Func<IFakeMultipleService>>();
+            var service = func();
+
+            // Assert
+            Assert.IsAssignableFrom<Func<IFakeMultipleService>>(func);
+            Assert.IsType<FakeTwoMultipleService>(service);
         }
 
         [Fact]

--- a/src/DependencyInjection/DI/src/CallSiteJsonFormatter.cs
+++ b/src/DependencyInjection/DI/src/CallSiteJsonFormatter.cs
@@ -113,6 +113,15 @@ namespace Microsoft.Extensions.DependencyInjection
             return null;
         }
 
+        protected override object VisitFunc(FuncCallSite funcCallSite, CallSiteFormatterContext argument)
+        {
+            argument.WriteProperty("itemType", funcCallSite.ItemType);
+            argument.StartProperty("itemCallSite");
+            VisitCallSite(funcCallSite.ItemCallSite, argument);
+
+            return null;
+        }
+
         internal struct CallSiteFormatterContext
         {
             private readonly HashSet<ServiceCallSite> _processedCallSites;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteKind.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteKind.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         ServiceScopeFactory,
 
-        Singleton
+        Singleton,
+
+        Func
     }
 }

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -140,6 +140,19 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             return factoryCallSite.Factory(context.Scope);
         }
+
+        protected override object VisitFunc(FuncCallSite funcCallSite, RuntimeResolverContext argument)
+        {
+            return this.GetType()
+                .GetMethod(nameof(CreateFunc), BindingFlags.NonPublic | BindingFlags.Static)
+                .MakeGenericMethod(funcCallSite.ItemType)
+                .Invoke(null, new object[] { argument.Scope });
+        }
+
+        private static Func<T> CreateFunc<T>(IServiceProvider collection)
+        {
+            return collection.GetService<T>;
+        }
     }
 
     internal struct RuntimeResolverContext

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
@@ -104,6 +104,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         protected override Type VisitFactory(FactoryCallSite factoryCallSite, CallSiteValidatorState state) => null;
 
+        protected override Type VisitFunc(FuncCallSite funcCallSite, CallSiteValidatorState argument) => null;
+
         internal struct CallSiteValidatorState
         {
             public ServiceCallSite Singleton { get; set; }

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteVisitor.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     return VisitServiceProvider((ServiceProviderCallSite)callSite, argument);
                 case CallSiteKind.ServiceScopeFactory:
                     return VisitServiceScopeFactory((ServiceScopeFactoryCallSite)callSite, argument);
+                case CallSiteKind.Func:
+                    return VisitFunc((FuncCallSite)callSite, argument);
                 default:
                     throw new NotSupportedException($"Call site type {callSite.GetType()} is not supported");
             }
@@ -86,5 +88,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected abstract TResult VisitIEnumerable(IEnumerableCallSite enumerableCallSite, TArgument argument);
 
         protected abstract TResult VisitFactory(FactoryCallSite factoryCallSite, TArgument argument);
+
+        protected abstract TResult VisitFunc(FuncCallSite funcCallSite, TArgument argument);
     }
 }

--- a/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -128,6 +128,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return Expression.Invoke(Expression.Constant(factoryCallSite.Factory), ScopeParameter);
         }
 
+        protected override Expression VisitFunc(FuncCallSite funcCallSite, object argument)
+        {
+            return Expression.Lambda(Expression.Convert(Expression.Call(ScopeParameter, typeof(IServiceProvider).GetMethod(nameof(IServiceProvider.GetService)), Expression.Constant(funcCallSite.ItemType)), funcCallSite.ItemType));
+        }
+
         protected override Expression VisitIEnumerable(IEnumerableCallSite callSite, object context)
         {
             if (callSite.ServiceCallSites.Length == 0)

--- a/src/DependencyInjection/DI/src/ServiceLookup/FuncCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/FuncCallSite.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal class FuncCallSite : ServiceCallSite
+    {
+        internal Type ItemType { get; }
+        internal ServiceCallSite ItemCallSite { get; }
+
+        public FuncCallSite(ResultCache cache, Type itemType, ServiceCallSite itemCallSite) : base(cache)
+        {
+            ItemType = itemType;
+            ItemCallSite = itemCallSite;
+        }
+
+        public override Type ServiceType => typeof(IEnumerable<>).MakeGenericType(ItemType);
+        public override Type ImplementationType => typeof(Func<>).MakeGenericType(ItemType);
+        public override CallSiteKind Kind { get; } = CallSiteKind.Func;
+    }
+}

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         protected override ILEmitCallSiteAnalysisResult VisitFactory(FactoryCallSite factoryCallSite, object argument) => new ILEmitCallSiteAnalysisResult(FactoryILSize);
 
+        protected override ILEmitCallSiteAnalysisResult VisitFunc(FuncCallSite funcCallSite, object argument) => new ILEmitCallSiteAnalysisResult(6);
+
         public ILEmitCallSiteAnalysisResult CollectGenerationInfo(ServiceCallSite callSite) => VisitCallSite(callSite, null);
     }
 }

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -255,6 +255,19 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return null;
         }
 
+        protected override object VisitFunc(FuncCallSite funcCallSite, ILEmitResolverBuilderContext argument)
+        {
+            argument.Generator.Emit(OpCodes.Ldarg_1);
+            argument.Generator.Emit(
+                OpCodes.Call,
+                this
+                    .GetType()
+                    .GetMethod(nameof(GetFunc), BindingFlags.NonPublic | BindingFlags.Static)
+                    .MakeGenericMethod(funcCallSite.ItemType));
+
+            return null;
+        }
+
         private void AddConstant(ILEmitResolverBuilderContext argument, object value)
         {
             if (argument.Constants == null)
@@ -465,6 +478,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
 
             generator.Emit(OpCodes.Stloc, index);
+        }
+
+        private static Func<T> GetFunc<T>(IServiceProvider provider)
+        {
+            return provider.GetService<T>;
         }
     }
 }


### PR DESCRIPTION
Adds out-of-the-box support for resolution of dependencies of type Func&lt;TService>, given that an implementation for TService has been registered with the DI container. For me personally, this was the only reason I would, until now, rely on the Autofac-plugin. Most other DI framework support the same or a similar notion.