### PR TITLE
Provide new EventId implicitly with tuple syntax

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
+++ b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
@@ -170,13 +170,13 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
         internal static class EventIds
         {
-            public static readonly EventId HealthCheckProcessingBegin = new EventId(100, "HealthCheckProcessingBegin");
-            public static readonly EventId HealthCheckProcessingEnd = new EventId(101, "HealthCheckProcessingEnd");
+            public static readonly EventId HealthCheckProcessingBegin = (100, nameof(HealthCheckProcessingBegin));
+            public static readonly EventId HealthCheckProcessingEnd = (101, nameof(HealthCheckProcessingEnd));
 
-            public static readonly EventId HealthCheckBegin = new EventId(102, "HealthCheckBegin");
-            public static readonly EventId HealthCheckEnd = new EventId(103, "HealthCheckEnd");
-            public static readonly EventId HealthCheckError = new EventId(104, "HealthCheckError");
-            public static readonly EventId HealthCheckData = new EventId(105, "HealthCheckData");
+            public static readonly EventId HealthCheckBegin = (102, nameof(HealthCheckBegin));
+            public static readonly EventId HealthCheckEnd = (103, nameof(HealthCheckEnd));
+            public static readonly EventId HealthCheckError = (104, nameof(HealthCheckError));
+            public static readonly EventId HealthCheckData = (105, nameof(HealthCheckData));
         }
 
         private static class Log

--- a/src/HealthChecks/HealthChecks/src/HealthCheckPublisherHostedService.cs
+++ b/src/HealthChecks/HealthChecks/src/HealthCheckPublisherHostedService.cs
@@ -186,14 +186,14 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
         internal static class EventIds
         {
-            public static readonly EventId HealthCheckPublisherProcessingBegin = new EventId(100, "HealthCheckPublisherProcessingBegin");
-            public static readonly EventId HealthCheckPublisherProcessingEnd = new EventId(101, "HealthCheckPublisherProcessingEnd");
-            public static readonly EventId HealthCheckPublisherProcessingError = new EventId(101, "HealthCheckPublisherProcessingError");
+            public static readonly EventId HealthCheckPublisherProcessingBegin = (100, nameof(HealthCheckPublisherProcessingBegin));
+            public static readonly EventId HealthCheckPublisherProcessingEnd = (101, nameof(HealthCheckPublisherProcessingEnd));
+            public static readonly EventId HealthCheckPublisherProcessingError = (101, nameof(HealthCheckPublisherProcessingError));
 
-            public static readonly EventId HealthCheckPublisherBegin = new EventId(102, "HealthCheckPublisherBegin");
-            public static readonly EventId HealthCheckPublisherEnd = new EventId(103, "HealthCheckPublisherEnd");
-            public static readonly EventId HealthCheckPublisherError = new EventId(104, "HealthCheckPublisherError");
-            public static readonly EventId HealthCheckPublisherTimeout = new EventId(104, "HealthCheckPublisherTimeout");
+            public static readonly EventId HealthCheckPublisherBegin = (102, nameof(HealthCheckPublisherBegin));
+            public static readonly EventId HealthCheckPublisherEnd = (103, nameof(HealthCheckPublisherEnd));
+            public static readonly EventId HealthCheckPublisherError = (104, nameof(HealthCheckPublisherError));
+            public static readonly EventId HealthCheckPublisherTimeout = (104, nameof(HealthCheckPublisherTimeout));
         }
 
         private static class Logger

--- a/src/HttpClientFactory/Http/src/DefaultHttpClientFactory.cs
+++ b/src/HttpClientFactory/Http/src/DefaultHttpClientFactory.cs
@@ -334,10 +334,10 @@ namespace Microsoft.Extensions.Http
         {
             public static class EventIds
             {
-                public static readonly EventId CleanupCycleStart = new EventId(100, "CleanupCycleStart");
-                public static readonly EventId CleanupCycleEnd = new EventId(101, "CleanupCycleEnd");
-                public static readonly EventId CleanupItemFailed = new EventId(102, "CleanupItemFailed");
-                public static readonly EventId HandlerExpired = new EventId(103, "HandlerExpired");
+                public static readonly EventId CleanupCycleStart = (100, nameof(CleanupCycleStart));
+                public static readonly EventId CleanupCycleEnd = (101, nameof(CleanupCycleEnd));
+                public static readonly EventId CleanupItemFailed = (102, nameof(CleanupItemFailed));
+                public static readonly EventId HandlerExpired = (103, nameof(HandlerExpired));
             }
 
             private static readonly Action<ILogger, int, Exception> _cleanupCycleStart = LoggerMessage.Define<int>(

--- a/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Extensions.Http.Logging
         {
             public static class EventIds
             {
-                public static readonly EventId RequestStart = new EventId(100, "RequestStart");
-                public static readonly EventId RequestEnd = new EventId(101, "RequestEnd");
+                public static readonly EventId RequestStart = (100, nameof(RequestStart));
+                public static readonly EventId RequestEnd = (101, nameof(RequestEnd));
 
-                public static readonly EventId RequestHeader = new EventId(102, "RequestHeader");
-                public static readonly EventId ResponseHeader = new EventId(103, "ResponseHeader");
+                public static readonly EventId RequestHeader = (102, nameof(RequestHeader));
+                public static readonly EventId ResponseHeader = (103, nameof(ResponseHeader));
             }
 
             private static readonly Action<ILogger, HttpMethod, Uri, Exception> _requestStart = LoggerMessage.Define<HttpMethod, Uri>(

--- a/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -49,23 +49,23 @@ namespace Microsoft.Extensions.Http.Logging
         {
             public static class EventIds
             {
-                public static readonly EventId PipelineStart = new EventId(100, "RequestPipelineStart");
-                public static readonly EventId PipelineEnd = new EventId(101, "RequestPipelineEnd");
+                public static readonly EventId RequestPipelineStart = (100, nameof(RequestPipelineStart));
+                public static readonly EventId RequestPipelineEnd = (101, nameof(RequestPipelineEnd));
 
-                public static readonly EventId RequestHeader = new EventId(102, "RequestPipelineRequestHeader");
-                public static readonly EventId ResponseHeader = new EventId(103, "RequestPipelineResponseHeader");
+                public static readonly EventId RequestPipelineRequestHeader = (102, nameof(RequestPipelineRequestHeader));
+                public static readonly EventId RequestPipelineResponseHeader = (103, nameof(RequestPipelineResponseHeader));
             }
 
             private static readonly Func<ILogger, HttpMethod, Uri, IDisposable> _beginRequestPipelineScope = LoggerMessage.DefineScope<HttpMethod, Uri>("HTTP {HttpMethod} {Uri}");
 
             private static readonly Action<ILogger, HttpMethod, Uri, Exception> _requestPipelineStart = LoggerMessage.Define<HttpMethod, Uri>(
                 LogLevel.Information, 
-                EventIds.PipelineStart, 
+                EventIds.RequestPipelineStart, 
                 "Start processing HTTP request {HttpMethod} {Uri}");
 
             private static readonly Action<ILogger, double, HttpStatusCode, Exception> _requestPipelineEnd = LoggerMessage.Define<double, HttpStatusCode>(
                 LogLevel.Information,
-                EventIds.PipelineEnd,
+                EventIds.RequestPipelineEnd,
                 "End processing HTTP request after {ElapsedMilliseconds}ms - {StatusCode}");
 
             public static IDisposable BeginRequestPipelineScope(ILogger logger, HttpRequestMessage request)
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.Http.Logging
                 {
                     logger.Log(
                         LogLevel.Trace,
-                        EventIds.RequestHeader,
+                        EventIds.RequestPipelineRequestHeader,
                         new HttpHeadersLogValue(HttpHeadersLogValue.Kind.Request, request.Headers, request.Content?.Headers),
                         null,
                         (state, ex) => state.ToString());
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Http.Logging
                 {
                     logger.Log(
                         LogLevel.Trace,
-                        EventIds.ResponseHeader,
+                        EventIds.RequestPipelineResponseHeader,
                         new HttpHeadersLogValue(HttpHeadersLogValue.Kind.Response, response.Headers, response.Content?.Headers),
                         null,
                         (state, ex) => state.ToString());

--- a/src/Localization/Localization/src/Internal/ResourceManagerStringLocalizerLoggerExtensions.cs
+++ b/src/Localization/Localization/src/Internal/ResourceManagerStringLocalizerLoggerExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Localization.Internal
         {
             _searchedLocation = LoggerMessage.Define<string, string, CultureInfo>(
                 LogLevel.Debug,
-                new EventId(1, "SearchedLocation"),
+                (1, nameof(SearchedLocation)),
                 $"{nameof(ResourceManagerStringLocalizer)} searched for '{{Key}}' in '{{LocationSearched}}' with culture '{{Culture}}'.");
         }
 

--- a/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
+++ b/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Logging
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Microsoft.Extensions.Logging.EventId left, Microsoft.Extensions.Logging.EventId right) { throw null; }
         public static implicit operator Microsoft.Extensions.Logging.EventId (int i) { throw null; }
+        public static implicit operator Microsoft.Extensions.Logging.EventId ((int id, string name) properties) { throw null; }
         public static bool operator !=(Microsoft.Extensions.Logging.EventId left, Microsoft.Extensions.Logging.EventId right) { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/Logging/Logging.Abstractions/src/EventId.cs
+++ b/src/Logging/Logging.Abstractions/src/EventId.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -15,6 +17,15 @@ namespace Microsoft.Extensions.Logging
         public static implicit operator EventId(int i)
         {
             return new EventId(i);
+        }
+
+        /// <summary>
+        /// Implicitly creates an EventId from the given <see cref="ValueTuple{Int32, String}"/> properties.
+        /// </summary>
+        /// <param name="properties">The <see cref="ValueTuple{Int32, String}"/> properties to convert to an EventId.</param>
+        public static implicit operator EventId((int id, string name) properties)
+        {
+            return new EventId(properties.id, properties.name);
         }
 
         /// <summary>

--- a/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
+++ b/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
@@ -421,7 +421,7 @@ namespace Microsoft.Extensions.Logging.Test
 
                 Dispose();
 
-                logger.LogDebug(new EventId(1), "Logger1 Event1 Debug {intParam}", 1);
+                logger.LogDebug(1, "Logger1 Event1 Debug {intParam}", 1);
 
                 VerifyEvents(testListener);
             }
@@ -433,26 +433,26 @@ namespace Microsoft.Extensions.Logging.Test
             var logger2 = factory.CreateLogger("Logger2");
             var logger3 = factory.CreateLogger("Logger3");
 
-            logger1.LogDebug(new EventId(1), "Logger1 Event1 Debug {intParam}", 1);
-            logger2.LogTrace(new EventId(2), "Logger2 Event2 Trace {doubleParam} {timeParam} {doubleParam2}", DoubleParam1, TimeParam.ToString("O"), DoubleParam2);
-            logger3.LogInformation(new EventId(3), "Logger3 Event3 Information {string1Param} {string2Param} {string3Param}", "foo", "bar", "baz");
+            logger1.LogDebug(1, "Logger1 Event1 Debug {intParam}", 1);
+            logger2.LogTrace(2, "Logger2 Event2 Trace {doubleParam} {timeParam} {doubleParam2}", DoubleParam1, TimeParam.ToString("O"), DoubleParam2);
+            logger3.LogInformation(3, "Logger3 Event3 Information {string1Param} {string2Param} {string3Param}", "foo", "bar", "baz");
 
             using (logger1.BeginScope("Outer scope {stringParam} {intParam} {doubleParam}", "scoped foo", 13, DoubleParam1))
             {
-                logger1.LogError(new EventId(4, "ErrorEvent"), "Logger1 Event4 Error {stringParam} {guidParam}", "foo", GuidParam);
+                logger1.LogError((4, "ErrorEvent"), "Logger1 Event4 Error {stringParam} {guidParam}", "foo", GuidParam);
 
-                logger2.LogCritical(new EventId(5), new Exception("oops", new Exception("inner oops")),
+                logger2.LogCritical(5, new Exception("oops", new Exception("inner oops")),
                     "Logger2 Event5 Critical {stringParam} {int1Param} {int2Param}", "bar", 23, 45);
 
                 using (logger3.BeginScope("Inner scope {timeParam} {guidParam}", TimeParam, GuidParam))
                 {
-                    logger2.LogWarning(new EventId(6), "Logger2 Event6 Warning NoParams");
+                    logger2.LogWarning(6, "Logger2 Event6 Warning NoParams");
                 }
 
-                logger3.LogInformation(new EventId(7), "Logger3 Event7 Information {stringParam} {doubleParam} {intParam}", "inner scope closed", DoubleParam2, 37);
+                logger3.LogInformation(7, "Logger3 Event7 Information {stringParam} {doubleParam} {intParam}", "inner scope closed", DoubleParam2, 37);
             }
 
-            logger2.LogWarning(new EventId(8), "Logger2 Event8 Warning {stringParam} {timeParam}", "Outer scope closed", TimeParam.ToString("O"));
+            logger2.LogWarning(8, "Logger2 Event8 Warning {stringParam} {timeParam}", "Outer scope closed", TimeParam.ToString("O"));
         }
 
         private static void VerifyEvents(TestEventListener eventListener, params string[] verifierIDs)

--- a/src/Logging/test/EventIdTest.cs
+++ b/src/Logging/test/EventIdTest.cs
@@ -33,5 +33,37 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.True(new EventId(1).GetHashCode() != new EventId(2).GetHashCode());
             Assert.True(new EventId(1, "Foo").GetHashCode() != new EventId(2, "Foo").GetHashCode());
         }
+
+
+        [Fact]
+        public void Equality_operations_implicit_eventid()
+        {
+            EventId one = 1;
+            EventId bar = (1, "Bar");
+            EventId foo = (1, "Foo");
+
+            Assert.True(one.Equals(1));
+            Assert.True(one.Equals((object)new EventId(1)));
+            Assert.True(one.Equals(foo));
+            Assert.True(bar.Equals(foo));
+
+            Assert.False(one.Equals(2));
+            Assert.False(one.Equals(null));
+            Assert.False(foo.Equals((2, "Foo")));
+
+            Assert.True(one == 1);
+            Assert.True(one == (1, "Foo"));
+            Assert.True(bar == (1, "Foo"));
+
+            Assert.True(one != 2);
+            Assert.True(foo != (2, "Foo"));
+
+            Assert.True(one.GetHashCode() == new EventId(1).GetHashCode());
+            Assert.True(one.GetHashCode() == new EventId(1, "Foo").GetHashCode());
+            Assert.True(bar.GetHashCode() == new EventId(1, "Foo").GetHashCode());
+
+            Assert.True(one.GetHashCode() != new EventId(2).GetHashCode());
+            Assert.True(foo.GetHashCode() != new EventId(2, "Foo").GetHashCode());
+        }
     }
 }

--- a/src/Logging/test/EventLogLoggerTest.cs
+++ b/src/Logging/test/EventLogLoggerTest.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Extensions.Logging
             var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
 
             // Act
-            logger.LogInformation(new EventId(1, "FooEvent"), "Message");
+            logger.LogInformation((1, "FooEvent"), "Message");
 
             // Assert
             Assert.Single(testEventLog.Messages);
@@ -223,7 +223,7 @@ namespace Microsoft.Extensions.Logging
             var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
 
             // Act
-            logger.LogInformation(new EventId(1, "FooEvent"), "Message");
+            logger.LogInformation((1, "FooEvent"), "Message");
 
             // Assert
             Assert.Single(testEventLog.Messages);


### PR DESCRIPTION
An `(int, string)` tuple may be provided where an `EventId` parameter is expected.
- Encourages use of named events by reducing typing
- Compatible with EventId flavor of existing extension methods

Fixes #2542
