### PR TITLE
Change CtorUsed to reflect the correct ctor types arguments

### DIFF
--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithAmbiguousCtors.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithAmbiguousCtors.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
             Data1 = data1;
             Data2 = data2;
 
-            CtorUsed = "IFakeService, string, string";
+            CtorUsed = "IFakeService, string, int";
         }
 
         public IFakeService FakeService { get; }


### PR DESCRIPTION
Summary of the changes
 - A small change in CtorUsed string property

The CtorUsed is being set to `"IFakeService, string, string"` in the `public ClassWithAmbiguousCtors(IFakeService service, string data1, int data2)` constructor but it should have been set to `"IFakeService, string, int"`. The PR addresses this small issue.
