### PR TITLE
Fixes for some servicing-proposed HttpClient Factory issues

### DIFF
--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -323,7 +323,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            ReserveClient(builder, typeof(TClient), builder.Name);
+            return AddTypedClientCore<TClient>(builder, validateSingleType: false);
+        }
+
+        internal static IHttpClientBuilder AddTypedClientCore<TClient>(this IHttpClientBuilder builder, bool validateSingleType)
+            where TClient : class
+        {
+            ReserveClient(builder, typeof(TClient), builder.Name, validateSingleType);
 
             builder.Services.AddTransient<TClient>(s =>
             {
@@ -377,7 +383,14 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            ReserveClient(builder, typeof(TClient), builder.Name);
+            return AddTypedClientCore<TClient, TImplementation>(builder, validateSingleType: false);
+        }
+
+        internal static IHttpClientBuilder AddTypedClientCore<TClient, TImplementation>(this IHttpClientBuilder builder, bool validateSingleType)
+            where TClient : class
+            where TImplementation : class, TClient
+        {
+            ReserveClient(builder, typeof(TClient), builder.Name, validateSingleType);
 
             builder.Services.AddTransient<TClient>(s =>
             {
@@ -425,7 +438,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            ReserveClient(builder, typeof(TClient), builder.Name);
+            return AddTypedClientCore<TClient>(builder, factory, validateSingleType: false);
+        }
+
+        internal static IHttpClientBuilder AddTypedClientCore<TClient>(this IHttpClientBuilder builder, Func<HttpClient, TClient> factory, bool validateSingleType)
+            where TClient : class
+        {
+            ReserveClient(builder, typeof(TClient), builder.Name, validateSingleType);
 
             builder.Services.AddTransient<TClient>(s =>
             {
@@ -472,7 +491,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            ReserveClient(builder, typeof(TClient), builder.Name);
+            return AddTypedClientCore<TClient>(builder, factory, validateSingleType: false);
+        }
+
+        internal static IHttpClientBuilder AddTypedClientCore<TClient>(this IHttpClientBuilder builder, Func<HttpClient, IServiceProvider, TClient> factory, bool validateSingleType)
+            where TClient : class
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            ReserveClient(builder, typeof(TClient), builder.Name, validateSingleType);
 
             builder.Services.AddTransient<TClient>(s =>
             {
@@ -526,7 +561,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         // See comments on HttpClientMappingRegistry.
-        private static void ReserveClient(IHttpClientBuilder builder, Type type, string name)
+        private static void ReserveClient(IHttpClientBuilder builder, Type type, string name, bool validateSingleType)
         {
             var registry = (HttpClientMappingRegistry)builder.Services.Single(sd => sd.ServiceType == typeof(HttpClientMappingRegistry)).ImplementationInstance;
             Debug.Assert(registry != null);
@@ -548,6 +583,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Check for same name registered to two types. This won't work because we rely on named options for the configuration.
             if (registry.NamedClientRegistrations.TryGetValue(name, out var otherType) &&
+
+                // Allow using the same name with multiple types in some cases (see callers).
+                validateSingleType &&
 
                 // Allow registering the same name twice to the same type (see above).
                 type != otherType)

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
             var builder = new DefaultHttpClientBuilder(services, name);
-            builder.AddTypedClient<TClient>();
+            builder.AddTypedClientCore<TClient>(validateSingleType: true);
             return builder;
         }
 
@@ -247,7 +247,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
             var builder = new DefaultHttpClientBuilder(services, name);
-            builder.AddTypedClient<TClient, TImplementation>();
+            builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: true);
             return builder;
         }
 
@@ -292,7 +292,7 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             var builder = new DefaultHttpClientBuilder(services, name);
-            builder.AddTypedClient<TClient>();
+            builder.AddTypedClientCore<TClient>(validateSingleType: false); // Name was explicitly provided.
             return builder;
         }
 
@@ -343,7 +343,7 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             var builder = new DefaultHttpClientBuilder(services, name);
-            builder.AddTypedClient<TClient, TImplementation>();
+            builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: false); // name was explicitly provided
             return builder;
         }
 
@@ -388,7 +388,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient>();
+            builder.AddTypedClientCore<TClient>(validateSingleType: true);
             return builder;
         }
 
@@ -433,7 +433,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient>();
+            builder.AddTypedClientCore<TClient>(validateSingleType: true);
             return builder;
         }
 
@@ -483,7 +483,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient, TImplementation>();
+            builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: true);
             return builder;
         }
 
@@ -533,7 +533,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient, TImplementation>();
+            builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: true);
             return builder;
         }
 
@@ -585,7 +585,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient>();
+            builder.AddTypedClientCore<TClient>(validateSingleType: false); // name was explicitly provided
             return builder;
         }
 
@@ -637,7 +637,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient>();
+            builder.AddTypedClientCore<TClient>(validateSingleType: false); // name was explictly provided
             return builder;
         }
 
@@ -694,7 +694,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient, TImplementation>();
+            builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: false); // name was explicitly provided
             return builder;
         }
 
@@ -751,7 +751,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
-            builder.AddTypedClient<TClient, TImplementation>();
+            builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: false); // name was explicitly provided
             return builder;
         }
     }

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientMappingRegistry.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientMappingRegistry.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Extensions.DependencyInjection
     // See: https://github.com/aspnet/Extensions/issues/960
     internal class HttpClientMappingRegistry
     {
-        public Dictionary<Type, string> TypedClientRegistrations { get; } = new Dictionary<Type, string>();
-
         public Dictionary<string, Type> NamedClientRegistrations { get; } = new Dictionary<string, Type>();
     }
 }

--- a/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -347,7 +347,52 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
-        public void AddHttpClient_AddSameTypedClientTwice_ThrowsError()
+        public void AddHttpClient_AddSameTypedClientTwice_WithSameName_Works()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient<TestTypedClient>();
+
+            // Act
+            serviceCollection.AddHttpClient<TestTypedClient>(c =>
+            {
+                c.BaseAddress = new Uri("http://example.com");
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<TestTypedClient>();
+
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddHttpClient_AddSameTypedClientTwice_WithSameName_WithAddTypedClient_Works()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient<TestTypedClient>();
+
+            // Act
+            serviceCollection.AddHttpClient(nameof(TestTypedClient), c =>
+            {
+                c.BaseAddress = new Uri("http://example.com");
+            })
+            .AddTypedClient<TestTypedClient>();
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<TestTypedClient>();
+
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddHttpClient_AddSameTypedClientTwice_WithDifferentNames_ThrowsError()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
@@ -365,7 +410,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
-        public void AddHttpClient_AddSameTypedClientTwice_WithAddTypedClient_ThrowsError()
+        public void AddHttpClient_AddSameTypedClientTwice_WithDifferentNames_WithAddTypedClient_ThrowsError()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();

--- a/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -392,39 +393,37 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
-        public void AddHttpClient_AddSameTypedClientTwice_WithDifferentNames_ThrowsError()
+        public void AddHttpClient_AddSameTypedClientTwice_WithDifferentNames_IsAllowed()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddHttpClient<TestTypedClient>();
+            serviceCollection.AddHttpClient<TestTypedClient>("Test1");
+            serviceCollection.AddHttpClient<TestTypedClient>("Test2");
+
+            var services = serviceCollection.BuildServiceProvider();
 
             // Act
-            var ex = Assert.Throws<InvalidOperationException>(() => serviceCollection.AddHttpClient<TestTypedClient>("Test"));
+            var clients = services.GetRequiredService<IEnumerable<TestTypedClient>>();
 
             // Assert
-            Assert.Equal(
-                "The HttpClient factory already has a registered client with the type 'Microsoft.Extensions.Http.TestTypedClient'. " +
-                "Client types must be unique. " +
-                "Consider using inheritance to create multiple unique types with the same API surface.",
-                ex.Message);
+            Assert.Equal(2, clients.Count());
         }
 
         [Fact]
-        public void AddHttpClient_AddSameTypedClientTwice_WithDifferentNames_WithAddTypedClient_ThrowsError()
+        public void AddHttpClient_AddSameTypedClientTwice_WithDifferentNames_WithAddTypedClient_IsAllowed()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddHttpClient<TestTypedClient>();
+            serviceCollection.AddHttpClient("Test").AddTypedClient<TestTypedClient>();
+
+            var services = serviceCollection.BuildServiceProvider();
 
             // Act
-            var ex = Assert.Throws<InvalidOperationException>(() => serviceCollection.AddHttpClient("Test").AddTypedClient<TestTypedClient>());
+            var clients = services.GetRequiredService<IEnumerable<TestTypedClient>>();
 
             // Assert
-            Assert.Equal(
-                "The HttpClient factory already has a registered client with the type 'Microsoft.Extensions.Http.TestTypedClient'. " +
-                "Client types must be unique. " +
-                "Consider using inheritance to create multiple unique types with the same API surface.",
-                ex.Message);
+            Assert.Equal(2, clients.Count());
         }
 
         [Fact]


### PR DESCRIPTION
#### Description

In 3.0 we added validation to HttpClient Factory's registration code path to prevent some common mistakes. This new validation code blocks some valid use cases that we didn't know about.

#### Customer Impact

aspnet/AspNetCore#13346 Attempting to call `AddTypedClient<T>` twice on the same builder with different types throws an exception. This is a valuable shorthand way of expressing a configuration once and then binding it to multiple types.

#2077 Attempting to call `AddHttpClient<T>` twice with the same `T` throws an exception. This pattern is used when both library code and user code want to collaborate on configuration of a client type.
		
#### Regression?

Yes, this is a regression from 2.2
		
#### Risk

Low. This add special casing to our validation code path to allow more patterns. The impact of this is that cases that are explicitly blocked by an exception in 3.0 (but were allowed in 2.2) will be allowed again.