### PR TITLE
XML documentation comments for StringValues.

### DIFF
--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -15,40 +15,76 @@ namespace Microsoft.Extensions.Primitives
     /// </summary>
     public readonly struct StringValues : IList<string>, IReadOnlyList<string>, IEquatable<StringValues>, IEquatable<string>, IEquatable<string[]>
     {
+        /// <summary>
+        /// A readonly instance of the <see cref="StringValues"/> struct whose value is an empty string array.
+        /// </summary>
+        /// <remarks>
+        /// In application code, this field is most commonly used to safely represent a <see cref="StringValues"/> that has null string values.
+        /// </remarks>
         public static readonly StringValues Empty = new StringValues(Array.Empty<string>());
 
         private readonly object _values;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringValues"/> structure using the specified string.
+        /// </summary>
+        /// <param name="value">A string value.</param>
         public StringValues(string value)
         {
             _values = value;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringValues"/> structure using the specified array of strings.
+        /// </summary>
+        /// <param name="values">A string array.</param>
         public StringValues(string[] values)
         {
             _values = values;
         }
 
+        /// <summary>
+        /// Defines an implicit conversion of a given string to a <see cref="StringValues"/>.
+        /// </summary>
+        /// <param name="value">A string to implicitly convert.</param>
         public static implicit operator StringValues(string value)
         {
             return new StringValues(value);
         }
 
+        /// <summary>
+        /// Defines an implicit conversion of a given string array to a <see cref="StringValues"/>.
+        /// </summary>
+        /// <param name="values">A string array to implicitly convert.</param>
         public static implicit operator StringValues(string[] values)
         {
             return new StringValues(values);
         }
 
+        /// <summary>
+        /// Defines an implicit conversion of a given <see cref="StringValues"/> to a string.
+        /// </summary>
+        /// <remarks>
+        /// Returns <c>null</c> where <see cref="StringValues"/> has been initialized from an empty string array or is <see cref="StringValues.Empty"/>.
+        /// </remarks>
+        /// <param name="values">A <see cref="StringValues"/> to implicitly convert.</param>
         public static implicit operator string (StringValues values)
         {
             return values.GetStringValue();
         }
 
+        /// <summary>
+        /// Defines an implicit conversion of a given <see cref="StringValues"/> to a string array.
+        /// </summary>
+        /// <param name="value">A <see cref="StringValues"/> to implicitly convert.</param>
         public static implicit operator string[] (StringValues value)
         {
             return value.GetArrayValue();
         }
 
+        /// <summary>
+        /// Gets the number of <see cref="string"/> elements contained in this <see cref="StringValues" />.
+        /// </summary>
         public int Count
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -77,12 +113,23 @@ namespace Microsoft.Extensions.Primitives
             get { return true; }
         }
 
+        /// <summary>
+        /// Gets the <see cref="string"/> at index.
+        /// </summary>
+        /// <value>The string at the specified index.</value>
+        /// <param name="index">The zero-based index of the element to get.</param>
+        /// <exception cref="NotSupportedException">Set operations are not supported on readonly <see cref="StringValues"/>.</exception>
         string IList<string>.this[int index]
         {
             get { return this[index]; }
             set { throw new NotSupportedException(); }
         }
 
+        /// <summary>
+        /// Gets the <see cref="string"/> at index.
+        /// </summary>
+        /// <value>The string at the specified index.</value>
+        /// <param name="index">The zero-based index of the element to get.</param>
         public string this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -112,6 +159,10 @@ namespace Microsoft.Extensions.Primitives
             return Array.Empty<string>()[0]; // throws
         }
 
+        /// <summary>
+        /// Converts the value of the current <see cref="StringValues"/> object to its equivalent string representation.
+        /// </summary>
+        /// <returns>A string representation of the value of the current <see cref="StringValues"/> object.</returns>
         public override string ToString()
         {
             return GetStringValue() ?? string.Empty;
@@ -216,6 +267,14 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Creates a string array from the current <see cref="StringValues"/> object.
+        /// </summary>
+        /// <returns>A string array represented by this instance.</returns>
+        /// <remarks>
+        /// <para>If the <see cref="StringValues"/> contains a string internally, it is copied to a new array.</para>
+        /// <para>If the <see cref="StringValues"/> contains an array internally it returns that array instance.</para>
+        /// </remarks>
         public string[] ToArray()
         {
             return GetArrayValue() ?? Array.Empty<string>();
@@ -240,6 +299,11 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Returns the zero-based index of the first occurrence of a item in the <see cref="StringValues" />.
+        /// </summary>
+        /// <param name="item">The string to locate in the <see cref="StringValues"></see>.</param>
+        /// <returns>the zero-based index of the first occurrence of <paramref name="item" /> within the <see cref="StringValues"></see>, if found; otherwise, –1.</returns>
         int IList<string>.IndexOf(string item)
         {
             return IndexOf(item);
@@ -270,11 +334,22 @@ namespace Microsoft.Extensions.Primitives
             return -1;
         }
 
+        /// <summary>Determines whether a string is in the <see cref="StringValues" />.</summary>
+        /// <param name="item">The <see cref="string"/> to locate in the <see cref="StringValues" />.</param>
+        /// <returns>true if <paramref name="item">item</paramref> is found in the <see cref="StringValues" />; otherwise, false.</returns>
         bool ICollection<string>.Contains(string item)
         {
             return IndexOf(item) >= 0;
         }
 
+        /// <summary>
+        /// Copies the entire <see cref="StringValues" />to a string array, starting at the specified index of the target array.
+        /// </summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from. The <see cref="T:System.Array" /> must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in the destination array at which copying begins.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="arrayIndex">arrayIndex</paramref> is less than 0.</exception>
+        /// <exception cref="T:System.ArgumentException">The number of elements in the source <see cref="StringValues"></see> is greater than the available space from <paramref name="arrayIndex">arrayIndex</paramref> to the end of the destination <paramref name="array">array</paramref>.</exception>
         void ICollection<string>.CopyTo(string[] array, int arrayIndex)
         {
             CopyTo(array, arrayIndex);
@@ -311,46 +386,40 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
-        void ICollection<string>.Add(string item)
-        {
-            throw new NotSupportedException();
-        }
+        void ICollection<string>.Add(string item) => throw new NotSupportedException();
 
-        void IList<string>.Insert(int index, string item)
-        {
-            throw new NotSupportedException();
-        }
+        void IList<string>.Insert(int index, string item) => throw new NotSupportedException();
 
-        bool ICollection<string>.Remove(string item)
-        {
-            throw new NotSupportedException();
-        }
+        bool ICollection<string>.Remove(string item) => throw new NotSupportedException();
 
-        void IList<string>.RemoveAt(int index)
-        {
-            throw new NotSupportedException();
-        }
+        void IList<string>.RemoveAt(int index) => throw new NotSupportedException();
 
-        void ICollection<string>.Clear()
-        {
-            throw new NotSupportedException();
-        }
+        void ICollection<string>.Clear() => throw new NotSupportedException();
 
+        /// <summary>Retrieves an object that can iterate through the individual strings in this <see cref="StringValues" />.</summary>
+        /// <returns>An enumerator that can be used to iterate through the <see cref="StringValues" />.</returns>
         public Enumerator GetEnumerator()
         {
             return new Enumerator(_values);
         }
 
+        /// <inheritdoc cref="GetEnumerator()" />
         IEnumerator<string> IEnumerable<string>.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        /// <inheritdoc cref="GetEnumerator()" />
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Indicates whether the specified <see cref="StringValues"/> contains no string values.
+        /// </summary>
+        /// <param name="value">The <see cref="StringValues"/> to test.</param>
+        /// <returns>true if <paramref name="value">value</paramref> contains a single null string or empty array; otherwise, false.</returns>
         public static bool IsNullOrEmpty(StringValues value)
         {
             var data = value._values;
@@ -374,6 +443,12 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Concatenates two specified instances of <see cref="StringValues"/>.
+        /// </summary>
+        /// <param name="values1">The first <see cref="StringValues"/> to concatenate.</param>
+        /// <param name="values2">The second <see cref="StringValues"/> to concatenate.</param>
+        /// <returns>The concatenation of <paramref name="values1"/> and <paramref name="values2"/>.</returns>
         public static StringValues Concat(StringValues values1, StringValues values2)
         {
             var count1 = values1.Count;
@@ -395,6 +470,12 @@ namespace Microsoft.Extensions.Primitives
             return new StringValues(combined);
         }
 
+        /// <summary>
+        /// Concatenates specified instance of <see cref="StringValues"/> with specified <see cref="string"/>.
+        /// </summary>
+        /// <param name="values">The <see cref="StringValues"/> to concatenate.</param>
+        /// <param name="value">The <see cref="string" /> to concatenate.</param>
+        /// <returns>The concatenation of <paramref name="values"/> and <paramref name="value"/>.</returns>
         public static StringValues Concat(in StringValues values, string value)
         {
             if (value == null)
@@ -414,6 +495,12 @@ namespace Microsoft.Extensions.Primitives
             return new StringValues(combined);
         }
 
+        /// <summary>
+        /// Concatenates specified instance of <see cref="string"/> with specified <see cref="StringValues"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="string" /> to concatenate.</param>
+        /// <param name="values">The <see cref="StringValues"/> to concatenate.</param>
+        /// <returns>The concatenation of <paramref name="values"/> and <paramref name="values"/>.</returns>
         public static StringValues Concat(string value, in StringValues values)
         {
             if (value == null)
@@ -433,6 +520,12 @@ namespace Microsoft.Extensions.Primitives
             return new StringValues(combined);
         }
 
+        /// <summary>
+        /// Determines whether two specified <see cref="StringValues"/> objects have the same values. 
+        /// </summary>
+        /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The second <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool Equals(StringValues left, StringValues right)
         {
             var count = left.Count;
@@ -453,110 +546,166 @@ namespace Microsoft.Extensions.Primitives
             return true;
         }
 
+        /// <summary>
+        /// Determines whether two specified <see cref="StringValues"/> have the same values. 
+        /// </summary>
+        /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The second <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator ==(StringValues left, StringValues right)
         {
             return Equals(left, right);
         }
 
+        /// <summary>
+        /// Determines whether two specified <see cref="StringValues"/> have different values.
+        /// </summary>
+        /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The second <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator !=(StringValues left, StringValues right)
         {
             return !Equals(left, right);
         }
 
-        public bool Equals(StringValues other)
-        {
-            return Equals(this, other);
-        }
+        /// <summary>
+        /// Determines whether this instance and another specified <see cref="StringValues"/> object have the same values.
+        /// </summary>
+        /// <param name="other">The string to compare to this instance.</param>
+        /// <returns><c>true</c> if the value of <paramref name="other"/> is the same as the value of this instance; otherwise, <c>false</c>.</returns>
+        public bool Equals(StringValues other) => Equals(this, other);
 
-        public static bool Equals(string left, StringValues right)
-        {
-            return Equals(new StringValues(left), right);
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="string"/> and <see cref="StringValues"/> objects have the same values.
+        /// </summary>
+        /// <param name="left">The <see cref="string"/> to compare.</param>
+        /// <param name="right">The <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>. If <paramref name="left"/> is <c>null</c>, the method returns <c>false</c>.</returns>
+        public static bool Equals(string left, StringValues right) => Equals(new StringValues(left), right);
 
-        public static bool Equals(StringValues left, string right)
-        {
-            return Equals(left, new StringValues(right));
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="StringValues"/> and <see cref="string"/> objects have the same values.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The <see cref="string"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>. If <paramref name="right"/> is <c>null</c>, the method returns <c>false</c>.</returns>
+        public static bool Equals(StringValues left, string right) => Equals(left, new StringValues(right));
 
-        public bool Equals(string other)
-        {
-            return Equals(this, new StringValues(other));
-        }
+        /// <summary>
+        /// Determines whether this instance and a specified <see cref="string"/>, have the same value.
+        /// </summary>
+        /// <param name="other">The <see cref="string"/> to compare to this instance.</param>
+        /// <returns><c>true</c> if the value of <paramref name="other"/> is the same as this instance; otherwise, <c>false</c>. If <paramref name="other"/> is <c>null</c>, returns <c>false</c>.</returns>
+        public bool Equals(string other) => Equals(this, new StringValues(other));
 
-        public static bool Equals(string[] left, StringValues right)
-        {
-            return Equals(new StringValues(left), right);
-        }
+        /// <summary>
+        /// Determines whether the specified string array and <see cref="StringValues"/> objects have the same values.
+        /// </summary>
+        /// <param name="left">The string array to compare.</param>
+        /// <param name="right">The <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool Equals(string[] left, StringValues right) => Equals(new StringValues(left), right);
 
-        public static bool Equals(StringValues left, string[] right)
-        {
-            return Equals(left, new StringValues(right));
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="StringValues"/> and string array objects have the same values.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The string array to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool Equals(StringValues left, string[] right) => Equals(left, new StringValues(right));
 
-        public bool Equals(string[] other)
-        {
-            return Equals(this, new StringValues(other));
-        }
+        /// <summary>
+        /// Determines whether this instance and a specified string array have the same values.
+        /// </summary>
+        /// <param name="other">The string array to compare to this instance.</param>
+        /// <returns><c>true</c> if the value of <paramref name="other"/> is the same as this instance; otherwise, <c>false</c>.</returns>
+        public bool Equals(string[] other) => Equals(this, new StringValues(other));
 
-        public static bool operator ==(StringValues left, string right)
-        {
-            return Equals(left, new StringValues(right));
-        }
 
-        public static bool operator !=(StringValues left, string right)
-        {
-            return !Equals(left, new StringValues(right));
-        }
+        /// <inheritdoc cref="Equals(StringValues, string)" />
+        public static bool operator ==(StringValues left, string right) => Equals(left, new StringValues(right));
 
-        public static bool operator ==(string left, StringValues right)
-        {
-            return Equals(new StringValues(left), right);
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="StringValues"/> and <see cref="string"/> objects have different values.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The <see cref="string"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(StringValues left, string right) => !Equals(left, new StringValues(right));
 
-        public static bool operator !=(string left, StringValues right)
-        {
-            return !Equals(new StringValues(left), right);
-        }
+        /// <inheritdoc cref="Equals(string, StringValues)" />
+        public static bool operator ==(string left, StringValues right) => Equals(new StringValues(left), right);
 
-        public static bool operator ==(StringValues left, string[] right)
-        {
-            return Equals(left, new StringValues(right));
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="string"/> and <see cref="StringValues"/> objects have different values.
+        /// </summary>
+        /// <param name="left">The <see cref="string"/> to compare.</param>
+        /// <param name="right">The <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(string left, StringValues right) => !Equals(new StringValues(left), right);
 
-        public static bool operator !=(StringValues left, string[] right)
-        {
-            return !Equals(left, new StringValues(right));
-        }
+        /// <inheritdoc cref="Equals(StringValues, string[])" />
+        public static bool operator ==(StringValues left, string[] right) => Equals(left, new StringValues(right));
 
-        public static bool operator ==(string[] left, StringValues right)
-        {
-            return Equals(new StringValues(left), right);
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="StringValues"/> and string array have different values.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The string array to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(StringValues left, string[] right) => !Equals(left, new StringValues(right));
 
-        public static bool operator !=(string[] left, StringValues right)
-        {
-            return !Equals(new StringValues(left), right);
-        }
+        /// <inheritdoc cref="Equals(string[], StringValues)" />
+        public static bool operator ==(string[] left, StringValues right) => Equals(new StringValues(left), right);
 
-        public static bool operator ==(StringValues left, object right)
-        {
-            return left.Equals(right);
-        }
+        /// <summary>
+        /// Determines whether the specified string array and <see cref="StringValues"/> have different values.
+        /// </summary>
+        /// <param name="left">The string array to compare.</param>
+        /// <param name="right">The <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the value of <paramref name="left"/> is different to the value of <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(string[] left, StringValues right) => !Equals(new StringValues(left), right);
 
-        public static bool operator !=(StringValues left, object right)
-        {
-            return !left.Equals(right);
-        }
-        public static bool operator ==(object left, StringValues right)
-        {
-            return right.Equals(left);
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="StringValues"/> and <see cref="System.Object"/>, which must be a 
+        /// <see cref="StringValues"/>, <see cref="string"/>, or array of <see cref="string"/>, have the same value.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The <see cref="System.Object"/> to compare.</param>
+        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(StringValues left, object right) => left.Equals(right);
 
-        public static bool operator !=(object left, StringValues right)
-        {
-            return !right.Equals(left);
-        }
+        /// <summary>
+        /// Determines whether the specified <see cref="StringValues"/> and <see cref="System.Object"/>, which must be a 
+        /// <see cref="StringValues"/>, <see cref="string"/>, or array of <see cref="string"/>, have different values.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The <see cref="System.Object"/> to compare.</param>
+        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(StringValues left, object right) => !left.Equals(right);
 
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/>, which must be a 
+        /// <see cref="StringValues"/>, <see cref="string"/>, or array of <see cref="string"/>, and specified <see cref="StringValues"/>,  have the same value.
+        /// </summary>
+        /// <param name="left">The <see cref="StringValues"/> to compare.</param>
+        /// <param name="right">The <see cref="System.Object"/> to compare.</param>
+        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(object left, StringValues right) => right.Equals(left);
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/> and <see cref="StringValues"/> object have the same values.
+        /// </summary>
+        /// <param name="left">The <see cref="System.Object"/> to compare.</param>
+        /// <param name="right">The <see cref="StringValues"/> to compare.</param>
+        /// <returns><c>true</c> if the <paramref name="left"/> object is equal to the <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(object left, StringValues right) => !right.Equals(left);
+
+        /// <summary>
+        /// Determines whether this instance and a specified object have the same value.
+        /// </summary>
+        /// <param name="obj">An object to compare with this object.</param>
+        /// <returns><c>true</c> if the current object is equal to <paramref name="obj"/>; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (obj == null)
@@ -582,6 +731,7 @@ namespace Microsoft.Extensions.Primitives
             return false;
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             var value = _values;
@@ -604,6 +754,9 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Enumerates the string values of a <see cref="StringValues" />.
+        /// </summary>
         public struct Enumerator : IEnumerator<string>
         {
             private readonly string[] _values;

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Defines an implicit conversion of a given <see cref="StringValues"/> to a string.
+        /// Defines an implicit conversion of a given <see cref="StringValues"/> to a string, with multiple values joined as a comma separated string.
         /// </summary>
         /// <remarks>
         /// Returns <c>null</c> where <see cref="StringValues"/> has been initialized from an empty string array or is <see cref="StringValues.Empty"/>.
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Converts the value of the current <see cref="StringValues"/> object to its equivalent string representation.
+        /// Converts the value of the current <see cref="StringValues"/> object to its equivalent string representation, with multiple values joined as a comma separated string.
         /// </summary>
         /// <returns>A string representation of the value of the current <see cref="StringValues"/> object.</returns>
         public override string ToString()

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <returns>A string array represented by this instance.</returns>
         /// <remarks>
-        /// <para>If the <see cref="StringValues"/> contains a string internally, it is copied to a new array.</para>
+        /// <para>If the <see cref="StringValues"/> contains a single string internally, it is copied to a new array.</para>
         /// <para>If the <see cref="StringValues"/> contains an array internally it returns that array instance.</para>
         /// </remarks>
         public string[] ToArray()
@@ -300,7 +300,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Returns the zero-based index of the first occurrence of a item in the <see cref="StringValues" />.
+        /// Returns the zero-based index of the first occurrence of an item in the <see cref="StringValues" />.
         /// </summary>
         /// <param name="item">The string to locate in the <see cref="StringValues"></see>.</param>
         /// <returns>the zero-based index of the first occurrence of <paramref name="item" /> within the <see cref="StringValues"></see>, if found; otherwise, –1.</returns>
@@ -521,7 +521,7 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Determines whether two specified <see cref="StringValues"/> objects have the same values. 
+        /// Determines whether two specified <see cref="StringValues"/> objects have the same values in the same order. 
         /// </summary>
         /// <param name="left">The first <see cref="StringValues"/> to compare.</param>
         /// <param name="right">The second <see cref="StringValues"/> to compare.</param>


### PR DESCRIPTION
- Add XML comment to clarify behaviour casting to string as per issue.
- Add XML across StringValues members.
- Minor tidy with some expression bodies.

Addresses #2662 