### PR TITLE
Add support In-Memory Table For SQL Server Cache 

### DIFF
--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -228,8 +228,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
                     {
                         var id = reader.GetFieldValue<string>(Columns.Indexes.CacheItemIdIndex);
 
-                        var expirationTimeStr = reader.GetFieldValue<string>(Columns.Indexes.ExpiresAtTimeIndex);
-                        DateTimeOffset.TryParse(expirationTimeStr, out expirationTime);
+                        var expirationTimeStr = reader.GetFieldValue<object>(Columns.Indexes.ExpiresAtTimeIndex);
+                        DateTimeOffset.TryParse(expirationTimeStr?.ToString(), out expirationTime);
 
                         if (!reader.IsDBNull(Columns.Indexes.SlidingExpirationInSecondsIndex))
                         {
@@ -239,9 +239,9 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
                         if (!reader.IsDBNull(Columns.Indexes.AbsoluteExpirationIndex))
                         {
-                            var absoluteExpirationStr = reader.GetFieldValue<string>(
+                            var absoluteExpirationStr = reader.GetFieldValue<object>(
                                 Columns.Indexes.AbsoluteExpirationIndex);
-                            DateTimeOffset.TryParse(absoluteExpirationStr, out var currentAbsoluteExpiration);
+                            DateTimeOffset.TryParse(absoluteExpirationStr?.ToString(), out var currentAbsoluteExpiration);
                             absoluteExpiration = currentAbsoluteExpiration;
                         }
 
@@ -297,9 +297,9 @@ namespace Microsoft.Extensions.Caching.SqlServer
                     {
                         var id = await reader.GetFieldValueAsync<string>(Columns.Indexes.CacheItemIdIndex, token);
 
-                        var expirationTimeStr = await reader.GetFieldValueAsync<string>(
+                        var expirationTimeStr = await reader.GetFieldValueAsync<object>(
                             Columns.Indexes.ExpiresAtTimeIndex, token);
-                        DateTimeOffset.TryParse(expirationTimeStr, out expirationTime);
+                        DateTimeOffset.TryParse(expirationTimeStr?.ToString(), out expirationTime);
 
                         if (!await reader.IsDBNullAsync(Columns.Indexes.SlidingExpirationInSecondsIndex, token))
                         {
@@ -309,10 +309,10 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
                         if (!await reader.IsDBNullAsync(Columns.Indexes.AbsoluteExpirationIndex, token))
                         {
-                            var absoluteExpirationStr = await reader.GetFieldValueAsync<string>(
+                            var absoluteExpirationStr = await reader.GetFieldValueAsync<object>(
                                 Columns.Indexes.AbsoluteExpirationIndex,
                                 token);
-                            DateTimeOffset.TryParse(absoluteExpirationStr, out var currentAbsoluteExpiration);
+                            DateTimeOffset.TryParse(absoluteExpirationStr?.ToString(), out var currentAbsoluteExpiration);
                             absoluteExpiration = currentAbsoluteExpiration;
                         }
 

--- a/src/Caching/SqlServer/src/MonoSqlParameterCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/MonoSqlParameterCollectionExtensions.cs
@@ -22,9 +22,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
             this SqlParameterCollection parameters,
             DateTimeOffset utcTime)
         {
-            return parameters.AddWithValue(Columns.Names.ExpiresAtTime, SqlDbType.DateTime, utcTime.UtcDateTime);
+            return parameters.AddWithValue(Columns.Names.ExpiresAtTime, SqlDbType.VarChar, utcTime.UtcDateTime.ToString());
         }
-
 
         public static SqlParameterCollection AddAbsoluteExpirationMono(
                     this SqlParameterCollection parameters,
@@ -33,12 +32,12 @@ namespace Microsoft.Extensions.Caching.SqlServer
             if (utcTime.HasValue)
             {
                 return parameters.AddWithValue(
-                    Columns.Names.AbsoluteExpiration, SqlDbType.DateTime, utcTime.Value.UtcDateTime);
+                    Columns.Names.AbsoluteExpiration, SqlDbType.VarChar, utcTime.Value.UtcDateTime.ToString());
             }
             else
             {
                 return parameters.AddWithValue(
-                Columns.Names.AbsoluteExpiration, SqlDbType.DateTime, DBNull.Value);
+                Columns.Names.AbsoluteExpiration, SqlDbType.VarChar, DBNull.Value);
             }
         }
     }

--- a/src/Caching/SqlServer/src/SqlParameterCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/SqlParameterCollectionExtensions.cs
@@ -61,12 +61,12 @@ namespace Microsoft.Extensions.Caching.SqlServer
             if (utcTime.HasValue)
             {
                 return parameters.AddWithValue(
-                    Columns.Names.AbsoluteExpiration, SqlDbType.DateTimeOffset, utcTime.Value);
+                    Columns.Names.AbsoluteExpiration, SqlDbType.VarChar, utcTime.Value.ToString());
             }
             else
             {
                 return parameters.AddWithValue(
-                    Columns.Names.AbsoluteExpiration, SqlDbType.DateTimeOffset, DBNull.Value);
+                    Columns.Names.AbsoluteExpiration, SqlDbType.VarChar, DBNull.Value);
             }
         }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - use object instead of explicit type

I think In-memory table better than disk table for Caching item.

My sql's script of test as below

`
--Add MEMORY_OPTIMIZED_DATA filegroup to the database.
ALTER DATABASE ricoCacheDB
ADD FILEGROUP MemoryFG CONTAINS MEMORY_OPTIMIZED_DATA

--Add file to the MEMORY_OPTIMIZED_DATA filegroup.
ALTER DATABASE ricoCacheDB
ADD FILE
	( NAME = ricoCacheDB_File1,
	  FILENAME = N'/var/opt/mssql/data/ricoCacheDB_File1')
TO FILEGROUP MemoryFG

--Drop table if it already exists.
IF OBJECT_ID('dbo.AllCacheMem','U') IS NOT NULL
	DROP TABLE [dbo].AllCacheMem
GO

--Create memory optimized table and indexes on the memory optimized table.
CREATE TABLE [dbo].[AllCacheMem]
(
	[Id] [nvarchar] (449) NOT NULL,
	[Value] [varbinary] (max) NOT NULL,
	[ExpiresAtTime] varchar(64) not null,
	[SlidingExpirationInSeconds] [bigint] NULL,
	[AbsoluteExpiration] varchar (64) null,
	CONSTRAINT PK_AllCache PRIMARY KEY NONCLUSTERED (id),
	INDEX IX_ExpiresAtTime (ExpiresAtTime)
) WITH (MEMORY_OPTIMIZED = ON, DURABILITY = SCHEMA_ONLY)
GO
`