### PR TITLE
Add custom attribute property name lookup to configuration binder.

### DIFF
--- a/src/Configuration/Config.Binder/src/BinderOptions.cs
+++ b/src/Configuration/Config.Binder/src/BinderOptions.cs
@@ -13,5 +13,11 @@ namespace Microsoft.Extensions.Configuration
         /// If true, the binder will attempt to set all non read-only properties.
         /// </summary>
         public bool BindNonPublicProperties { get; set; }
+
+        /// <summary>
+        /// When false (the default), the binder will only attempt to set property values by property name lookup.
+        /// If true, the binder will attempt to use the custom property attribute names available to bind property values.
+        /// </summary>
+        public bool BindPropertyUsingAttributeNames { get; set; }
     }
 }

--- a/src/Configuration/Config.Binder/test/ConfigurationBinderTests.cs
+++ b/src/Configuration/Config.Binder/test/ConfigurationBinderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
@@ -34,12 +35,17 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             internal string InternalProperty { get; set; }
             protected string ProtectedProperty { get; set; }
 
+            [DataMember(Name = "Named_Property")]
+            public string NamedProperty { get; set; }
+
+
             protected string ProtectedPrivateSet { get; private set; }
 
             private string PrivateReadOnly { get; }
             internal string InternalReadOnly { get; }
             protected string ProtectedReadOnly { get; }
 
+            
             public string ReadOnly
             {
                 get { return null; }
@@ -130,6 +136,38 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("Section", options.Section.Path);
             Assert.Null(options.Section.Value);
         }
+
+        [Fact]
+        public void CanBindAttributesIConfigurationSection()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Section:Integer", "-2"},
+                {"Section:Boolean", "TRUe"},
+                {"Section:Nested:Integer", "11"},
+                {"Section:Virtual", "Sup"},
+                {"Section:Named_Property", "Yo"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<ConfigurationInterfaceOptions>();
+
+            var childOptions = options.Section.Get<DerivedOptions>(binderOptions =>
+                binderOptions.BindPropertyUsingAttributeName = true);
+
+            Assert.True(childOptions.Boolean);
+            Assert.Equal(-2, childOptions.Integer);
+            Assert.Equal(11, childOptions.Nested.Integer);
+            Assert.Equal("Derived:Sup", childOptions.Virtual);
+            Assert.Equal("Yo", childOptions.NamedProperty);
+
+            Assert.Equal("Section", options.Section.Key);
+            Assert.Equal("Section", options.Section.Path);
+            Assert.Null(options.Section.Value);
+        }
+
 
         [Fact]
         public void CanBindWithKeyOverload()


### PR DESCRIPTION
Took a swag at addressing the gap between the Json source and the Binder projects. The Json settings I work with contain names that don't match the setting classes. Those are mapped by JsonProperty or DataMember where a name is given that can be mapped.

The binder project, rightfully, doesn't know about Json or any other formats. The one area where it could be built up more is around looking at the attributes associated with the properties of the object it's attempting to bind to the configuration dictionary. This is an attempt to try to just that.

Summary of the changes (Less than 80 chars)
 - Added new BindingOption flag for binding by attribute names
 - Broke out the property value lookup into a standalone function
 - Added a function to return "name" values from custom attribute data from the PropertyType

Addresses #2809 (in this specific format)
