### PR TITLE
Set argument if no option has found

### DIFF
--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -172,12 +172,12 @@ namespace Microsoft.Extensions.CommandLineUtils
                             {
                                 processed = true;
                                 arguments.Current.Values.Add(arg);
-                                argumentsAssigned = true;
+                                argumentsAssigned = false;
                                 continue;
                             }
                             else
                             {
-                                argumentsAssigned = false;
+                                argumentsAssigned = true;
                             }
                         }
 
@@ -251,12 +251,12 @@ namespace Microsoft.Extensions.CommandLineUtils
                             {
                                 processed = true;
                                 arguments.Current.Values.Add(arg);
-                                argumentsAssigned = true;
+                                argumentsAssigned = false;
                                 continue;
                             }
                             else
                             {
-                                argumentsAssigned = false;
+                                argumentsAssigned = true;
                             }
                         }
 

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -163,6 +163,20 @@ namespace Microsoft.Extensions.CommandLineUtils
 
                         if (option == null)
                         {
+                            if (arguments == null)
+                            {
+                                arguments = new CommandArgumentEnumerator(command.Arguments.GetEnumerator());
+                            }
+                            if (arguments.MoveNext())
+                            {
+                                processed = true;
+                                arguments.Current.Values.Add(arg);
+                                continue;
+                            }
+                        }
+
+                        if (option == null)
+                        {
                             var ignoreContinueAfterUnexpectedArg = false;
                             if (string.IsNullOrEmpty(longOptionName) &&
                                 !command._throwOnUnexpectedArg &&
@@ -220,6 +234,20 @@ namespace Microsoft.Extensions.CommandLineUtils
                     {
                         processed = true;
                         option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.ShortName, shortOption[0], StringComparison.Ordinal));
+
+                        if (option == null)
+                        {
+                            if (arguments == null)
+                            {
+                                arguments = new CommandArgumentEnumerator(command.Arguments.GetEnumerator());
+                            }
+                            if (arguments.MoveNext())
+                            {
+                                processed = true;
+                                arguments.Current.Values.Add(arg);
+                                continue;
+                            }
+                        }
 
                         // If not a short option, try symbol option
                         if (option == null)

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             CommandLineApplication command = this;
             CommandOption option = null;
             IEnumerator<CommandArgument> arguments = null;
+            var argumentsAssigned = false;
 
             for (var index = 0; index < args.Length; index++)
             {
@@ -171,6 +172,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                             {
                                 processed = true;
                                 arguments.Current.Values.Add(arg);
+                                argumentsAssigned = true;
                                 continue;
                             }
                         }
@@ -245,6 +247,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                             {
                                 processed = true;
                                 arguments.Current.Values.Add(arg);
+                                argumentsAssigned = true;
                                 continue;
                             }
                         }
@@ -306,7 +309,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                     option = null;
                 }
 
-                if (!processed && arguments == null)
+                if (!processed && argumentsAssigned)
                 {
                     var currentCommand = command;
                     foreach (var subcommand in command.Commands)

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             CommandLineApplication command = this;
             CommandOption option = null;
             IEnumerator<CommandArgument> arguments = null;
-            var argumentsAssigned = false;
+            var argumentsAssigned = true;
 
             for (var index = 0; index < args.Length; index++)
             {
@@ -174,6 +174,10 @@ namespace Microsoft.Extensions.CommandLineUtils
                                 arguments.Current.Values.Add(arg);
                                 argumentsAssigned = true;
                                 continue;
+                            }
+                            else
+                            {
+                                argumentsAssigned = false;
                             }
                         }
 
@@ -249,6 +253,10 @@ namespace Microsoft.Extensions.CommandLineUtils
                                 arguments.Current.Values.Add(arg);
                                 argumentsAssigned = true;
                                 continue;
+                            }
+                            else
+                            {
+                                argumentsAssigned = false;
                             }
                         }
 

--- a/src/Shared/test/CommandLineApplicationTests.cs
+++ b/src/Shared/test/CommandLineApplicationTests.cs
@@ -1166,5 +1166,28 @@ Examples:
 
             Assert.Equal($"Unrecognized option '{inputOption}'", exception.Message);
         }
+
+        [Fact]
+        public void TreatUnmatchedOptionsAsArguments()
+        {
+            CommandArgument first = null;
+            CommandArgument second = null;
+
+            var firstOption = "-firstUnmatchedOption";
+            var secondOption = "--secondUnmatchedOption";
+
+            var app = new CommandLineApplication(treatUnmatchedOptionsAsArguments: true);
+            app.Command("test", c =>
+            {
+                first = c.Argument("first", "First argument");
+                second = c.Argument("second", "Second argument");
+                c.OnExecute(() => 0);
+            });
+
+            app.Execute("test", firstOption, secondOption);
+
+            Assert.Equal(firstOption, first.Value);
+            Assert.Equal(secondOption, second.Value);
+        }
     }
 }

--- a/src/Shared/test/CommandLineApplicationTests.cs
+++ b/src/Shared/test/CommandLineApplicationTests.cs
@@ -1173,21 +1173,52 @@ Examples:
             CommandArgument first = null;
             CommandArgument second = null;
 
-            var firstOption = "-firstUnmatchedOption";
-            var secondOption = "--secondUnmatchedOption";
+            CommandOption firstOption = null;
+            CommandOption secondOption = null;
+
+            var firstUnmatchedOption = "-firstUnmatchedOption";
+            var firstActualOption = "-firstActualOption";
+            var seconUnmatchedOption = "--secondUnmatchedOption";
+            var secondActualOption = "--secondActualOption";
 
             var app = new CommandLineApplication(treatUnmatchedOptionsAsArguments: true);
+
             app.Command("test", c =>
             {
+                firstOption = c.Option("-firstActualOption", "first option", CommandOptionType.NoValue);
+                secondOption = c.Option("--secondActualOption", "second option", CommandOptionType.NoValue);
+
                 first = c.Argument("first", "First argument");
                 second = c.Argument("second", "Second argument");
                 c.OnExecute(() => 0);
             });
 
-            app.Execute("test", firstOption, secondOption);
+            app.Execute("test", firstUnmatchedOption, firstActualOption, seconUnmatchedOption, secondActualOption);
 
-            Assert.Equal(firstOption, first.Value);
-            Assert.Equal(secondOption, second.Value);
+            Assert.Equal(firstUnmatchedOption, first.Value);
+            Assert.Equal(seconUnmatchedOption, second.Value);
+
+            Assert.Equal(firstActualOption, firstOption.Template);
+            Assert.Equal(secondActualOption, secondOption.Template);
+        }
+
+        [Fact]
+        public void ThrowExceptionWhenUnmatchedOptionAndTreatUnmatchedOptionsAsArgumentsIsFalse()
+        {
+            CommandArgument first = null;
+
+            var firstOption = "-firstUnmatchedOption";
+
+            var app = new CommandLineApplication(treatUnmatchedOptionsAsArguments: false);
+            app.Command("test", c =>
+            {
+                first = c.Argument("first", "First argument");
+                c.OnExecute(() => 0);
+            });
+
+            var exception = Assert.Throws<CommandParsingException>(() => app.Execute("test", firstOption));
+
+            Assert.Equal($"Unrecognized option '{firstOption}'", exception.Message);
         }
     }
 }


### PR DESCRIPTION
I changed the behavior so the `CommandLineApplication` couldn't found the available option, it tries to add the `arg` to the `Arguments` list.

Addresses https://github.com/aspnet/AspNetCore/issues/18095
