### PR TITLE
[release/3.0] Pin dependency on Microsoft.Win32.Registry

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,7 +10,7 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/18519

We depend on this package in order to get the ref assembly out of it, which will not be serviced. We should pin the dependency in order to avoid a conflict between the implementation assembly in the package from patch `x.y.z+1`, and the shared framework from patch `x.y.z+2` (where the package is not patched).

CC @JunTaoLuo @dougbu @ericstj @nguerrera @mmitche 

Also CC @Pilchie to confirm we can take this as tell-mode for March