### PR TITLE
[Host] Allow disabling reloadOnChange for Host's CreateDefaultBuilder

### DIFF
--- a/src/Hosting/Hosting/src/Host.cs
+++ b/src/Hosting/Hosting/src/Host.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -71,9 +70,8 @@ namespace Microsoft.Extensions.Hosting
             builder.ConfigureAppConfiguration((hostingContext, config) =>
             {
                 var env = hostingContext.HostingEnvironment;
-
-                var reloadOnChange = Convert.ToBoolean(
-                    Environment.GetEnvironmentVariable("ASPNETCORE_BUILDER_CONFIG_RELOAD") ?? "true");
+                
+                var reloadOnChange = hostingContext.Configuration.GetValue("HOSTBUILDER_CONFIG_RELOAD", true);
 
                 config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
                       .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);

--- a/src/Hosting/Hosting/src/Host.cs
+++ b/src/Hosting/Hosting/src/Host.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = hostingContext.HostingEnvironment;
                 
-                var reloadOnChange = hostingContext.Configuration.GetValue("HOSTBUILDER_CONFIG_RELOAD", true);
+                var reloadOnChange = hostingContext.Configuration.GetValue("hostbuilder:configreload", true);
 
                 config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
                       .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);

--- a/src/Hosting/Hosting/src/Host.cs
+++ b/src/Hosting/Hosting/src/Host.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -71,8 +72,11 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = hostingContext.HostingEnvironment;
 
-                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+                var reloadOnChange = Convert.ToBoolean(
+                    Environment.GetEnvironmentVariable("ASPNETCORE_BUILDER_CONFIG_RELOAD") ?? "true");
+
+                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
+                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
 
                 if (env.IsDevelopment() && !string.IsNullOrEmpty(env.ApplicationName))
                 {

--- a/src/Hosting/Hosting/src/Host.cs
+++ b/src/Hosting/Hosting/src/Host.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = hostingContext.HostingEnvironment;
                 
-                var reloadOnChange = hostingContext.Configuration.GetValue("hostbuilder:configreload", true);
+                var reloadOnChange = hostingContext.Configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
 
                 config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
                       .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);

--- a/src/Hosting/Hosting/test/HostTests.cs
+++ b/src/Hosting/Hosting/test/HostTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Hosting
 
             config.GetReloadToken().RegisterChangeCallback(o =>
             {
-                //configReloadedCancelTokenSource.Cancel();
+                configReloadedCancelTokenSource.Cancel();
             }, null);
             // Wait for up to 10 seconds, if config reloads at any time, cancel the wait.
             await Task.WhenAny(Task.Delay(10000, configReloadedCancelToken)); // Task.WhenAny ignores the task throwing on cancellation.

--- a/src/Hosting/Hosting/test/HostTests.cs
+++ b/src/Hosting/Hosting/test/HostTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Hosting
         [Fact]
         public async Task CreateDefaultBuilder_ConfigJsonDoesNotReload()
         {
-            var reloadFlagConfig = new Dictionary<string, string>() {{ "hostbuilder:configreload", "false" }};
+            var reloadFlagConfig = new Dictionary<string, string>() {{ "hostbuilder:reloadConfigOnChange", "false" }};
             var appSettingsPath = Path.Combine(Path.GetTempPath(), "appsettings.json");
 
             string SaveRandomConfig()
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.Hosting
         [Fact]
         public async Task CreateDefaultBuilder_ConfigJsonDoesReload()
         {
-            var reloadFlagConfig = new Dictionary<string, string>() { { "hostbuilder:configreload", "true" } };
+            var reloadFlagConfig = new Dictionary<string, string>() { { "hostbuilder:reloadConfigOnChange", "true" } };
             var appSettingsPath = Path.Combine(Path.GetTempPath(), "appsettings.json");
 
             string SaveRandomConfig()

--- a/src/Hosting/Hosting/test/HostTests.cs
+++ b/src/Hosting/Hosting/test/HostTests.cs
@@ -85,21 +85,23 @@ namespace Microsoft.Extensions.Hosting
         [Fact]
         public void CreateDefaultBuilder_ConfigJsonDoesNotReload()
         {
-            Environment.SetEnvironmentVariable("ASPNETCORE_BUILDER_CONFIG_RELOAD", "false");
+            Environment.SetEnvironmentVariable("DOTNET_HOSTBUILDER_CONFIG_RELOAD", "false");
             Environment.CurrentDirectory = Path.GetTempPath();
-            Func<string> saveRandomConfig = () =>
+
+            string SaveRandomConfig()
             {
                 var newMessage = $"Hello ASP.NET Core: {Guid.NewGuid():N}";
                 File.WriteAllText(Path.Combine(Path.GetTempPath(), "appsettings.json"), $"{{ \"Hello\": \"{newMessage}\" }}");
                 return newMessage;
-            };
-            var dynamicConfigMessage1 = saveRandomConfig();
+            }
+
+            var dynamicConfigMessage1 = SaveRandomConfig();
             var host = Host.CreateDefaultBuilder().Build();
             var config = host.Services.GetRequiredService<IConfiguration>();
 
             Assert.Equal(dynamicConfigMessage1, config["Hello"]);
 
-            var dynamicConfigMessage2 = saveRandomConfig();
+            var dynamicConfigMessage2 = SaveRandomConfig();
             Task.Delay(1000).Wait(); // Give reload time to fire if it's going to.
             Assert.NotEqual(dynamicConfigMessage1, dynamicConfigMessage2); // Messages are different.
             Assert.Equal(dynamicConfigMessage1, config["Hello"]); // Config did not reload
@@ -108,21 +110,23 @@ namespace Microsoft.Extensions.Hosting
         [Fact]
         public void CreateDefaultBuilder_ConfigJsonDoesReload()
         {
-            Environment.SetEnvironmentVariable("ASPNETCORE_BUILDER_CONFIG_RELOAD", "true");
+            Environment.SetEnvironmentVariable("DOTNET_HOSTBUILDER_CONFIG_RELOAD", "true");
             Environment.CurrentDirectory = Path.GetTempPath();
-            Func<string> saveRandomConfig = () =>
+
+            string SaveRandomConfig()
             {
                 var newMessage = $"Hello ASP.NET Core: {Guid.NewGuid():N}";
                 File.WriteAllText(Path.Combine(Path.GetTempPath(), "appsettings.json"), $"{{ \"Hello\": \"{newMessage}\" }}");
                 return newMessage;
-            };
-            var dynamicConfigMessage1 = saveRandomConfig();
+            }
+
+            var dynamicConfigMessage1 = SaveRandomConfig();
             var host = Host.CreateDefaultBuilder().Build();
             var config = host.Services.GetRequiredService<IConfiguration>();
 
             Assert.Equal(dynamicConfigMessage1, config["Hello"]);
 
-            var dynamicConfigMessage2 = saveRandomConfig();
+            var dynamicConfigMessage2 = SaveRandomConfig();
             Task.Delay(1000).Wait(); // Give reload time to fire if it's going to.
             Assert.NotEqual(dynamicConfigMessage1, dynamicConfigMessage2); // Messages are different.
             Assert.Equal(dynamicConfigMessage2, config["Hello"]); // Config DID reload.


### PR DESCRIPTION
* Add ASPNETCORE_BUILDER_CONFIG_RELOAD environment flag to allow disabling live reload in builder.
* Add two tests to assert two different cases (live reload on, live reload off) work.

Addresses https://github.com/dotnet/extensions/issues/2939
