### PR TITLE
chore(Microsoft.JSInterop): definition type file extension fix

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0-dev",
   "description": "Provides abstractions and features for interop between .NET and JavaScript code.",
   "main": "dist/Microsoft.JSInterop.js",
-  "types": "dist/Microsoft.JSInterop.d.js",
+  "types": "dist/Microsoft.JSInterop.d.ts",
   "scripts": {
     "clean": "node node_modules/rimraf/bin.js ./dist",
     "build": "npm run clean && npm run build:esm",


### PR DESCRIPTION
This is a minor change, correcting name of the file pointed as explicit
type definition file (`d.ts`). On most installations (VSCode) the type definition
lookup works correctly anyway:
- extension of the type defintion file corrected: `.d.js` > `.d.ts`

Thanks!