### PR TITLE
Changed volatile variable in Redis cache

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         private const string DataKey = "data";
         private const long NotPresent = -1;
 
-        private volatile ConnectionMultiplexer _connection;
-        private IDatabase _cache;
+        private ConnectionMultiplexer _connection;
+        private volatile IDatabase _cache;
 
         private readonly RedisCacheOptions _options;
         private readonly string _instance;


### PR DESCRIPTION
...from _connection to _cache. 

Summary of the changes (Less than 80 chars)
 - The declared volatile variable is currently _connection, but the variable that can gain from being volatile is _cache, as that is the one that is tested in Connect(Async).

Addresses #bugnumber (in this specific format)
None