### PR TITLE
Fix LoggingEventSource to handle null strings

### DIFF
--- a/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
@@ -125,6 +125,10 @@ namespace Microsoft.Extensions.Logging.EventSource
         {
             if (IsEnabled())
             {
+                LoggerName ??= "";
+                EventName ??= "";
+                FormattedMessage ??= "";
+
                 fixed (char* loggerName = LoggerName)
                 fixed (char* eventName = EventName)
                 fixed (char* formattedMessage = FormattedMessage)
@@ -174,6 +178,8 @@ namespace Microsoft.Extensions.Logging.EventSource
         {
             if (IsEnabled())
             {
+                LoggerName ??= "";
+
                 fixed (char* loggerName = LoggerName)
                 {
                     const int eventDataCount = 3;
@@ -193,6 +199,11 @@ namespace Microsoft.Extensions.Logging.EventSource
         {
             if (IsEnabled())
             {
+                LoggerName ??= "";
+                EventName ??= "";
+                ExceptionJson ??= "";
+                ArgumentsJson ??= "";
+
                 fixed (char* loggerName = LoggerName)
                 fixed (char* eventName = EventName)
                 fixed (char* exceptionJson = ExceptionJson)
@@ -219,6 +230,9 @@ namespace Microsoft.Extensions.Logging.EventSource
         {
             if (IsEnabled())
             {
+                LoggerName ??= "";
+                ArgumentsJson ??= "";
+
                 fixed (char* loggerName = LoggerName)
                 fixed (char* argumentsJson = ArgumentsJson)
                 {
@@ -240,6 +254,8 @@ namespace Microsoft.Extensions.Logging.EventSource
         {
             if (IsEnabled())
             {
+                LoggerName ??= "";
+
                 fixed (char* loggerName = LoggerName)
                 {
                     const int eventDataCount = 3;
@@ -457,16 +473,9 @@ namespace Microsoft.Extensions.Logging.EventSource
                 }
 #endif
 
-                if (pinnedString != null)
-                {
-                    eventData.DataPointer = (IntPtr)pinnedString;
-                    eventData.Size = checked((str.Length + 1) * sizeof(char)); // size is specified in bytes, including null wide char
-                }
-                else
-                {
-                    eventData.DataPointer = IntPtr.Zero;
-                    eventData.Size = 0;
-                }
+                eventData.DataPointer = (IntPtr)pinnedString;
+                eventData.Size = checked((str.Length + 1) * sizeof(char)); // size is specified in bytes, including null wide char
+
             }
             else
             {

--- a/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
@@ -22,4 +22,8 @@
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Extensions.Logging.EventSource.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
+++ b/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
@@ -427,6 +427,35 @@ namespace Microsoft.Extensions.Logging.Test
             }
         }
 
+        [Fact]
+        public void Logs_AsExpected_FormattedMessage_WithNullString()
+        {
+            using (var testListener = new TestEventListener())
+            {
+                var factory = CreateLoggerFactory();
+
+                var listenerSettings = new TestEventListener.ListenerSettings();
+                listenerSettings.Keywords = LoggingEventSource.Keywords.FormattedMessage;
+                listenerSettings.FilterSpec = null;
+                listenerSettings.Level = EventLevel.Verbose;
+                testListener.EnableEvents(listenerSettings);
+
+                LogStuff(factory);
+
+                var containsNullEventName = false;
+
+                foreach (var eventJson in testListener.Events)
+                {
+                    if (eventJson.Contains(@"""__EVENT_NAME"":""FormattedMessage""") && eventJson.Contains(@"""EventName"":"""","))
+                    {
+                        containsNullEventName = true;
+                    }
+                }
+
+                Assert.True(containsNullEventName, "EventName is supposed to be null but it isn't.");
+            }
+        }
+
         private void LogStuff(ILoggerFactory factory)
         {
             var logger1 = factory.CreateLogger("Logger1");

--- a/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
+++ b/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
@@ -456,6 +456,66 @@ namespace Microsoft.Extensions.Logging.Test
             }
         }
 
+        [Fact]
+        public void Logs_AsExpected_MessageJson_WithNullString()
+        {
+            using (var testListener = new TestEventListener())
+            {
+                var listenerSettings = new TestEventListener.ListenerSettings();
+                listenerSettings.Keywords = LoggingEventSource.Keywords.JsonMessage;
+                listenerSettings.FilterSpec = null;
+                listenerSettings.Level = EventLevel.Verbose;
+                testListener.EnableEvents(listenerSettings);
+
+                // Write some MessageJson events with null string.
+                for (var i = 0; i < 100; i++)
+                {
+                    LoggingEventSource.Instance.MessageJson(LogLevel.Trace, 1, "MyLogger", 5, null, null, "testJson");
+                }
+
+                bool containsNullEventName = false;
+                foreach (var eventJson in testListener.Events)
+                {
+                    if (eventJson.Contains(@"""__EVENT_NAME"":""MessageJson""") && eventJson.Contains(@"""EventName"":"""","))
+                    {
+                        containsNullEventName = true;
+                    }
+                }
+
+                Assert.True(containsNullEventName, "EventName and ExceptionJson is supposed to be null but it isn't.");
+            }
+        }
+
+        [Fact]
+        public void Logs_AsExpected_ActivityJson_WithNullString()
+        {
+            using (var testListener = new TestEventListener())
+            {
+                var listenerSettings = new TestEventListener.ListenerSettings();
+                listenerSettings.Keywords = LoggingEventSource.Keywords.JsonMessage;
+                listenerSettings.FilterSpec = null;
+                listenerSettings.Level = EventLevel.Verbose;
+                testListener.EnableEvents(listenerSettings);
+
+                // Write some MessageJson events with null string.
+                for (var i = 0; i < 100; i++)
+                {
+                    LoggingEventSource.Instance.ActivityJsonStart(6, 1, null, "someJson");
+                }
+
+                bool containsNullLoggerName = false;
+                foreach (var eventJson in testListener.Events)
+                {
+                    if (eventJson.Contains(@"""__EVENT_NAME"":""ActivityJsonStart""") && eventJson.Contains(@"""LoggerName"":"""","))
+                    {
+                        containsNullLoggerName = true;
+                    }
+                }
+
+                Assert.True(containsNullLoggerName, "LoggerName is supposed to be null but it isn't.");
+            }
+        }
+
         private void LogStuff(ILoggerFactory factory)
         {
             var logger1 = factory.CreateLogger("Logger1");


### PR DESCRIPTION
Fix issue initially reported in this issue: https://github.com/microsoft/perfview/issues/1092.

`EventSource.WriteEventCore` does not play nicely with null strings passed directly.

This fixes https://github.com/dotnet/extensions/issues/2958. 

cc @davidfowl @josalem   