### PR TITLE
Clarify doc-comments in IHostApplicationLifetime

### DIFF
--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Extensions.Hosting
         CancellationToken ApplicationStarted { get; }
 
         /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
-        /// Shutdown will block until this event completes.
+        /// Triggered when the application host is beginning a graceful shutdown.
+        /// Shutdown will block until any callbacks registered on this token have returned.
         /// </summary>
         CancellationToken ApplicationStopping { get; }
 
         /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
-        /// Shutdown will block until this event completes.
+        /// Triggered when the application host has completed a graceful shutdown.
+        /// The application will not exit until any callbacks registered on this token have returned.
         /// </summary>
         CancellationToken ApplicationStopped { get; }
 

--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Hosting
 
         /// <summary>
         /// Triggered when the application host has completed a graceful shutdown.
-        /// The application will not exit until any callbacks registered on this token have returned.
+        /// The application will not exit until all callbacks registered on this token have completed.
         /// </summary>
         CancellationToken ApplicationStopped { get; }
 

--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Hosting
         CancellationToken ApplicationStarted { get; }
 
         /// <summary>
-        /// Triggered when the application host is beginning a graceful shutdown.
+        /// Triggered when the application host is starting a graceful shutdown.
         /// Shutdown will block until any callbacks registered on this token have returned.
         /// </summary>
         CancellationToken ApplicationStopping { get; }

--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Hosting
 
         /// <summary>
         /// Triggered when the application host is starting a graceful shutdown.
-        /// Shutdown will block until any callbacks registered on this token have returned.
+        /// Shutdown will block until all callbacks registered on this token have completed.
         /// </summary>
         CancellationToken ApplicationStopping { get; }
 


### PR DESCRIPTION
 - Correct/clarify comments on ApplicationStopping and ApplicationStopped

I was a little doubtful about "any callbacks" vs "all callbacks", which might be stronger/clearer?

Addresses #2962 
