### PR TITLE
Typo in comment: who's => whose

### DIFF
--- a/src/Logging/Logging.Abstractions/src/ILoggerT.cs
+++ b/src/Logging/Logging.Abstractions/src/ILoggerT.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging
     /// <typeparamref name="TCategoryName"/> type name.
     /// Generally used to enable activation of a named <see cref="ILogger"/> from dependency injection.
     /// </summary>
-    /// <typeparam name="TCategoryName">The type who's name is used for the logger category name.</typeparam>
+    /// <typeparam name="TCategoryName">The type whose name is used for the logger category name.</typeparam>
     public interface ILogger<out TCategoryName> : ILogger
     {
         


### PR DESCRIPTION
I found a small grammar typo in a comment ("who's" instead of "whose"), which I fixed.
This PR includes no changes to the code.