### PR TITLE
Switch to MIT license

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
 
 [*.cs]
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 [*.cs]
 indent_size = 4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
     <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://asp.net</PackageProjectUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <LangVersion>8.0</LangVersion>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,201 +1,23 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+The MIT License (MIT)
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) .NET Foundation and Contributors
 
-   1. Definitions.
+All rights reserved.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/eng/LicenseHeader.txt
+++ b/eng/LicenseHeader.txt
@@ -1,3 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 

--- a/eng/tools/BaselineGenerator/Program.cs
+++ b/eng/tools/BaselineGenerator/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Analyzers/Async/src/AsyncAnalysisData.cs
+++ b/src/Analyzers/Async/src/AsyncAnalysisData.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Analyzers/Async/src/Descriptors.cs
+++ b/src/Analyzers/Async/src/Descriptors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 

--- a/src/Analyzers/Async/src/LogFormatAnalyzer.cs
+++ b/src/Analyzers/Async/src/LogFormatAnalyzer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;

--- a/src/Analyzers/Async/test/AsyncAnalyzerTests.cs
+++ b/src/Analyzers/Async/test/AsyncAnalyzerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 using Xunit;

--- a/src/Analyzers/Async/test/AsyncDiagnosticRunner.cs
+++ b/src/Analyzers/Async/test/AsyncDiagnosticRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;

--- a/src/Caching/Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.netcoreapp.cs
+++ b/src/Caching/Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Distributed
 {

--- a/src/Caching/Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.netstandard2.0.cs
+++ b/src/Caching/Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Distributed
 {

--- a/src/Caching/Abstractions/src/CacheEntryExtensions.cs
+++ b/src/Caching/Abstractions/src/CacheEntryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/Caching/Abstractions/src/CacheItemPriority.cs
+++ b/src/Caching/Abstractions/src/CacheItemPriority.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Memory
 {

--- a/src/Caching/Abstractions/src/DistributedCacheEntryExtensions.cs
+++ b/src/Caching/Abstractions/src/DistributedCacheEntryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Abstractions/src/DistributedCacheEntryOptions.cs
+++ b/src/Caching/Abstractions/src/DistributedCacheEntryOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Abstractions/src/DistributedCacheExtensions.cs
+++ b/src/Caching/Abstractions/src/DistributedCacheExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Caching/Abstractions/src/EvictionReason.cs
+++ b/src/Caching/Abstractions/src/EvictionReason.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Memory
 {

--- a/src/Caching/Abstractions/src/ICacheEntry.cs
+++ b/src/Caching/Abstractions/src/ICacheEntry.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Caching/Abstractions/src/IDistributedCache.cs
+++ b/src/Caching/Abstractions/src/IDistributedCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Caching/Abstractions/src/IMemoryCache.cs
+++ b/src/Caching/Abstractions/src/IMemoryCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Abstractions/src/Internal/ISystemClock.cs
+++ b/src/Caching/Abstractions/src/Internal/ISystemClock.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Abstractions/src/Internal/SystemClock.cs
+++ b/src/Caching/Abstractions/src/Internal/SystemClock.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Abstractions/src/MemoryCacheEntryExtensions.cs
+++ b/src/Caching/Abstractions/src/MemoryCacheEntryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/Caching/Abstractions/src/MemoryCacheEntryOptions.cs
+++ b/src/Caching/Abstractions/src/MemoryCacheEntryOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Caching/Abstractions/src/PostEvictionCallbackRegistration.cs
+++ b/src/Caching/Abstractions/src/PostEvictionCallbackRegistration.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Memory
 {

--- a/src/Caching/Abstractions/src/PostEvictionDelegate.cs
+++ b/src/Caching/Abstractions/src/PostEvictionDelegate.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Memory
 {

--- a/src/Caching/Memory/ref/Microsoft.Extensions.Caching.Memory.netcoreapp.cs
+++ b/src/Caching/Memory/ref/Microsoft.Extensions.Caching.Memory.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Distributed
 {

--- a/src/Caching/Memory/ref/Microsoft.Extensions.Caching.Memory.netstandard2.0.cs
+++ b/src/Caching/Memory/ref/Microsoft.Extensions.Caching.Memory.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Distributed
 {

--- a/src/Caching/Memory/src/CacheEntry.cs
+++ b/src/Caching/Memory/src/CacheEntry.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Caching/Memory/src/CacheEntryHelper.cs
+++ b/src/Caching/Memory/src/CacheEntryHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/Memory/src/CacheEntryStack.cs
+++ b/src/Caching/Memory/src/CacheEntryStack.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Memory/src/MemoryCache.cs
+++ b/src/Caching/Memory/src/MemoryCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Caching/Memory/src/MemoryCacheOptions.cs
+++ b/src/Caching/Memory/src/MemoryCacheOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Internal;

--- a/src/Caching/Memory/src/MemoryCacheServiceCollectionExtensions.cs
+++ b/src/Caching/Memory/src/MemoryCacheServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Caching.Distributed;

--- a/src/Caching/Memory/src/MemoryDistributedCache.cs
+++ b/src/Caching/Memory/src/MemoryDistributedCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/Memory/src/MemoryDistributedCacheOptions.cs
+++ b/src/Caching/Memory/src/MemoryDistributedCacheOptions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.Memory
 {

--- a/src/Caching/Memory/test/CacheEntryScopeExpirationTests.cs
+++ b/src/Caching/Memory/test/CacheEntryScopeExpirationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Caching/Memory/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/Memory/test/CacheServiceExtensionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Caching/Memory/test/CapacityTests.cs
+++ b/src/Caching/Memory/test/CapacityTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/Memory/test/CompactTests.cs
+++ b/src/Caching/Memory/test/CompactTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Internal;

--- a/src/Caching/Memory/test/Infrastructure/TestClock.cs
+++ b/src/Caching/Memory/test/Infrastructure/TestClock.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Memory/test/Infrastructure/TestExpirationToken.cs
+++ b/src/Caching/Memory/test/Infrastructure/TestExpirationToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/Caching/Memory/test/Infrastructure/TokenCallbackRegistration.cs
+++ b/src/Caching/Memory/test/Infrastructure/TokenCallbackRegistration.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
+++ b/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/Memory/test/TimeExpirationTests.cs
+++ b/src/Caching/Memory/test/TimeExpirationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/Memory/test/TokenExpirationTests.cs
+++ b/src/Caching/Memory/test/TokenExpirationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/SqlServer/ref/Microsoft.Extensions.Caching.SqlServer.netstandard2.0.cs
+++ b/src/Caching/SqlServer/ref/Microsoft.Extensions.Caching.SqlServer.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.SqlServer
 {

--- a/src/Caching/SqlServer/src/Columns.cs
+++ b/src/Caching/SqlServer/src/Columns.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.SqlServer
 {

--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Data;

--- a/src/Caching/SqlServer/src/IDatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/IDatabaseOperations.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Data;

--- a/src/Caching/SqlServer/src/MonoSqlParameterCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/MonoSqlParameterCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Data;

--- a/src/Caching/SqlServer/src/PlatformHelper.cs
+++ b/src/Caching/SqlServer/src/PlatformHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/SqlServer/src/SqlParameterCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/SqlParameterCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Data;

--- a/src/Caching/SqlServer/src/SqlQueries.cs
+++ b/src/Caching/SqlServer/src/SqlQueries.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Internal;
 

--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Internal;

--- a/src/Caching/SqlServer/src/SqlServerCacheServiceCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Caching.Distributed;

--- a/src/Caching/SqlServer/test/CacheItemInfo.cs
+++ b/src/Caching/SqlServer/test/CacheItemInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/SqlServer/test/SqlServerCacheServicesExtensionsTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheServicesExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.Caching.Distributed;

--- a/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Caching/SqlServer/test/TestClock.cs
+++ b/src/Caching/SqlServer/test/TestClock.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/SqlServer/test/TestOptions.cs
+++ b/src/Caching/SqlServer/test/TestOptions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Caching.SqlServer

--- a/src/Caching/SqlServer/test/TestOptions.cs
+++ b/src/Caching/SqlServer/test/TestOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Caching/StackExchangeRedis/ref/Microsoft.Extensions.Caching.StackExchangeRedis.netstandard2.0.cs
+++ b/src/Caching/StackExchangeRedis/ref/Microsoft.Extensions.Caching.StackExchangeRedis.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Caching.StackExchangeRedis
 {

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;

--- a/src/Caching/StackExchangeRedis/src/RedisExtensions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using StackExchange.Redis;

--- a/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
+++ b/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Caching.Distributed;

--- a/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Caching/StackExchangeRedis/test/Infrastructure/RedisTestConfig.cs
+++ b/src/Caching/StackExchangeRedis/test/Infrastructure/RedisTestConfig.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestExecutor.cs
+++ b/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestExecutor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 //using System;
 //using System.Reflection;
 //using Xunit.Abstractions;

--- a/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestExecutor.cs
+++ b/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestExecutor.cs
@@ -1,6 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //using System;
 //using System.Reflection;
 //using Xunit.Abstractions;

--- a/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestFramework.cs
+++ b/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestFramework.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 //using System.Reflection;
 //using Xunit;
 //using Xunit.Abstractions;

--- a/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestFramework.cs
+++ b/src/Caching/StackExchangeRedis/test/Infrastructure/RedisXunitTestFramework.cs
@@ -1,6 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //using System.Reflection;
 //using Xunit;
 //using Xunit.Abstractions;

--- a/src/Caching/StackExchangeRedis/test/RedisCacheSetAndRemoveTests.cs
+++ b/src/Caching/StackExchangeRedis/test/RedisCacheSetAndRemoveTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/StackExchangeRedis/test/TimeExpirationTests.cs
+++ b/src/Caching/StackExchangeRedis/test/TimeExpirationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Caching/samples/MemoryCacheConcurencySample/Program.cs
+++ b/src/Caching/samples/MemoryCacheConcurencySample/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Caching/samples/MemoryCacheFileWatchSample/Program.cs
+++ b/src/Caching/samples/MemoryCacheFileWatchSample/Program.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Caching/samples/MemoryCacheSample/MemoryCacheWeakReferenceExtensions.cs
+++ b/src/Caching/samples/MemoryCacheSample/MemoryCacheWeakReferenceExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Caching/samples/MemoryCacheSample/Program.cs
+++ b/src/Caching/samples/MemoryCacheSample/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Caching/samples/MemoryCacheSample/WeakToken.cs
+++ b/src/Caching/samples/MemoryCacheSample/WeakToken.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/Caching/samples/ProfilingSample/Program.cs
+++ b/src/Caching/samples/ProfilingSample/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Caching/samples/ProfilingSample/Program.cs
+++ b/src/Caching/samples/ProfilingSample/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Caching/samples/RedisCacheSample/Program.cs
+++ b/src/Caching/samples/RedisCacheSample/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Caching/samples/SqlServerCacheConcurencySample/Program.cs
+++ b/src/Caching/samples/SqlServerCacheConcurencySample/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Caching/samples/SqlServerCacheSample/Program.cs
+++ b/src/Caching/samples/SqlServerCacheSample/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Configuration/Config.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.netcoreapp.cs
+++ b/src/Configuration/Config.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.netstandard2.0.cs
+++ b/src/Configuration/Config.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
+++ b/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Abstractions/src/ConfigurationPath.cs
+++ b/src/Configuration/Config.Abstractions/src/ConfigurationPath.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Abstractions/src/ConfigurationRootExtensions.cs
+++ b/src/Configuration/Config.Abstractions/src/ConfigurationRootExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Configuration/Config.Abstractions/src/IConfiguration.cs
+++ b/src/Configuration/Config.Abstractions/src/IConfiguration.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;

--- a/src/Configuration/Config.Abstractions/src/IConfigurationBuilder.cs
+++ b/src/Configuration/Config.Abstractions/src/IConfigurationBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Configuration/Config.Abstractions/src/IConfigurationProvider.cs
+++ b/src/Configuration/Config.Abstractions/src/IConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;

--- a/src/Configuration/Config.Abstractions/src/IConfigurationRoot.cs
+++ b/src/Configuration/Config.Abstractions/src/IConfigurationRoot.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Configuration/Config.Abstractions/src/IConfigurationSection.cs
+++ b/src/Configuration/Config.Abstractions/src/IConfigurationSection.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Abstractions/src/IConfigurationSource.cs
+++ b/src/Configuration/Config.Abstractions/src/IConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Configuration/Config.AzureKeyVault/ref/Microsoft.Extensions.Configuration.AzureKeyVault.netstandard2.0.cs
+++ b/src/Configuration/Config.AzureKeyVault/ref/Microsoft.Extensions.Configuration.AzureKeyVault.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.AzureKeyVault/samples/EnvironmentSecretManager.cs
+++ b/src/Configuration/Config.AzureKeyVault/samples/EnvironmentSecretManager.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration.AzureKeyVault;

--- a/src/Configuration/Config.AzureKeyVault/samples/EnvironmentSecretManager.cs
+++ b/src/Configuration/Config.AzureKeyVault/samples/EnvironmentSecretManager.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
 

--- a/src/Configuration/Config.AzureKeyVault/samples/Program.cs
+++ b/src/Configuration/Config.AzureKeyVault/samples/Program.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.AzureKeyVault/samples/Program.cs
+++ b/src/Configuration/Config.AzureKeyVault/samples/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationOptions.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationSource.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.AzureKeyVault
 {

--- a/src/Configuration/Config.AzureKeyVault/src/DefaultKeyVaultSecretManager.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/DefaultKeyVaultSecretManager.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;

--- a/src/Configuration/Config.AzureKeyVault/src/IKeyVaultClient.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/IKeyVaultClient.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;

--- a/src/Configuration/Config.AzureKeyVault/src/IKeyVaultSecretManager.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/IKeyVaultSecretManager.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Azure.KeyVault.Models;
 

--- a/src/Configuration/Config.AzureKeyVault/src/KeyVaultClientWrapper.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/KeyVaultClientWrapper.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;

--- a/src/Configuration/Config.AzureKeyVault/src/Properties/AssemblyInfo.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 
 

--- a/src/Configuration/Config.AzureKeyVault/test/AzureKeyVaultConfigurationTest.cs
+++ b/src/Configuration/Config.AzureKeyVault/test/AzureKeyVaultConfigurationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netcoreapp.cs
+++ b/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netstandard2.0.cs
+++ b/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Binder/src/BinderOptions.cs
+++ b/src/Configuration/Config.Binder/src/BinderOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
+++ b/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Binder/test/ConfigurationBinderTests.cs
+++ b/src/Configuration/Config.Binder/test/ConfigurationBinderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Configuration/Config.Binder/test/ConfigurationBinderTests.cs
+++ b/src/Configuration/Config.Binder/test/ConfigurationBinderTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Binder/test/ConfigurationCollectionBindingTests.cs
+++ b/src/Configuration/Config.Binder/test/ConfigurationCollectionBindingTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.netcoreapp.cs
+++ b/src/Configuration/Config.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.netstandard2.0.cs
+++ b/src/Configuration/Config.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.CommandLine/src/CommandLineConfigurationExtensions.cs
+++ b/src/Configuration/Config.CommandLine/src/CommandLineConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/Configuration/Config.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.CommandLine/src/CommandLineConfigurationSource.cs
+++ b/src/Configuration/Config.CommandLine/src/CommandLineConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Configuration/Config.CommandLine/test/CommandLineTest.cs
+++ b/src/Configuration/Config.CommandLine/test/CommandLineTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.CommandLine/test/ConfigurationProviderCommandLineTest.cs
+++ b/src/Configuration/Config.CommandLine/test/ConfigurationProviderCommandLineTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.netcoreapp.cs
+++ b/src/Configuration/Config.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.netstandard2.0.cs
+++ b/src/Configuration/Config.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
+++ b/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.EnvironmentVariables
 {

--- a/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesExtensions.cs
+++ b/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;

--- a/src/Configuration/Config.EnvironmentVariables/test/ConfigurationProviderEnvironmentVariablesTest.cs
+++ b/src/Configuration/Config.EnvironmentVariables/test/ConfigurationProviderEnvironmentVariablesTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
+++ b/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Configuration/Config.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.netcoreapp.cs
+++ b/src/Configuration/Config.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.netstandard2.0.cs
+++ b/src/Configuration/Config.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.FileExtensions/src/FileConfigurationExtensions.cs
+++ b/src/Configuration/Config.FileExtensions/src/FileConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileProviders;

--- a/src/Configuration/Config.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/Configuration/Config.FileExtensions/src/FileConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.FileExtensions/src/FileConfigurationSource.cs
+++ b/src/Configuration/Config.FileExtensions/src/FileConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.FileExtensions/src/FileLoadExceptionContext.cs
+++ b/src/Configuration/Config.FileExtensions/src/FileLoadExceptionContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Configuration/Config.FileExtensions/test/FileConfigurationBuilderExtensionsTest.cs
+++ b/src/Configuration/Config.FileExtensions/test/FileConfigurationBuilderExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.FileExtensions/test/FileConfigurationProviderTest.cs
+++ b/src/Configuration/Config.FileExtensions/test/FileConfigurationProviderTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Ini/ref/Microsoft.Extensions.Configuration.Ini.netcoreapp.cs
+++ b/src/Configuration/Config.Ini/ref/Microsoft.Extensions.Configuration.Ini.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Ini/ref/Microsoft.Extensions.Configuration.Ini.netstandard2.0.cs
+++ b/src/Configuration/Config.Ini/ref/Microsoft.Extensions.Configuration.Ini.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Ini/src/IniConfigurationExtensions.cs
+++ b/src/Configuration/Config.Ini/src/IniConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Ini/src/IniConfigurationProvider.cs
+++ b/src/Configuration/Config.Ini/src/IniConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Configuration/Config.Ini/src/IniConfigurationSource.cs
+++ b/src/Configuration/Config.Ini/src/IniConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.Ini
 {

--- a/src/Configuration/Config.Ini/src/IniStreamConfigurationProvider.cs
+++ b/src/Configuration/Config.Ini/src/IniStreamConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Ini/src/IniStreamConfigurationSource.cs
+++ b/src/Configuration/Config.Ini/src/IniStreamConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.Ini
 {

--- a/src/Configuration/Config.Ini/test/ConfigurationProviderIniTest.cs
+++ b/src/Configuration/Config.Ini/test/ConfigurationProviderIniTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Configuration/Config.Ini/test/IniConfigurationExtensionsTest.cs
+++ b/src/Configuration/Config.Ini/test/IniConfigurationExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Ini/test/IniConfigurationTest.cs
+++ b/src/Configuration/Config.Ini/test/IniConfigurationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.netcoreapp.cs
+++ b/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.netstandard2.0.cs
+++ b/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Json/src/JsonConfigurationExtensions.cs
+++ b/src/Configuration/Config.Json/src/JsonConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs
+++ b/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Json/src/JsonConfigurationProvider.cs
+++ b/src/Configuration/Config.Json/src/JsonConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Json/src/JsonConfigurationSource.cs
+++ b/src/Configuration/Config.Json/src/JsonConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Configuration/Config.Json/src/JsonStreamConfigurationProvider.cs
+++ b/src/Configuration/Config.Json/src/JsonStreamConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Configuration/Config.Json/src/JsonStreamConfigurationSource.cs
+++ b/src/Configuration/Config.Json/src/JsonStreamConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.Json
 {

--- a/src/Configuration/Config.Json/test/ArrayTest.cs
+++ b/src/Configuration/Config.Json/test/ArrayTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.Configuration.Test;

--- a/src/Configuration/Config.Json/test/ConfigurationProviderJsonTest.cs
+++ b/src/Configuration/Config.Json/test/ConfigurationProviderJsonTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Configuration/Config.Json/test/JsonConfigurationExtensionsTest.cs
+++ b/src/Configuration/Config.Json/test/JsonConfigurationExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Json/test/JsonConfigurationTest.cs
+++ b/src/Configuration/Config.Json/test/JsonConfigurationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Configuration/Config.NewtonsoftJson/ref/Microsoft.Extensions.Configuration.NewtonsoftJson.netstandard2.0.cs
+++ b/src/Configuration/Config.NewtonsoftJson/ref/Microsoft.Extensions.Configuration.NewtonsoftJson.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationExtensions.cs
+++ b/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationFileParser.cs
+++ b/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationFileParser.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationProvider.cs
+++ b/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationSource.cs
+++ b/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonStreamConfigurationProvider.cs
+++ b/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonStreamConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonStreamConfigurationSource.cs
+++ b/src/Configuration/Config.NewtonsoftJson/src/NewtonsoftJsonStreamConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.NewtonsoftJson
 {

--- a/src/Configuration/Config.NewtonsoftJson/test/ArrayTest.cs
+++ b/src/Configuration/Config.NewtonsoftJson/test/ArrayTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.Configuration.Test;

--- a/src/Configuration/Config.NewtonsoftJson/test/NewtonsoftConfigurationProviderJsonTest.cs
+++ b/src/Configuration/Config.NewtonsoftJson/test/NewtonsoftConfigurationProviderJsonTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Configuration/Config.NewtonsoftJson/test/NewtonsoftJsonConfigurationExtensionsTest.cs
+++ b/src/Configuration/Config.NewtonsoftJson/test/NewtonsoftJsonConfigurationExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.NewtonsoftJson/test/NewtonsoftJsonConfigurationTest.cs
+++ b/src/Configuration/Config.NewtonsoftJson/test/NewtonsoftJsonConfigurationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration.Test;
 using System;

--- a/src/Configuration/Config.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.netcoreapp.cs
+++ b/src/Configuration/Config.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.netstandard2.0.cs
+++ b/src/Configuration/Config.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.UserSecrets/src/PathHelper.cs
+++ b/src/Configuration/Config.UserSecrets/src/PathHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.UserSecrets/src/UserSecretsConfigurationExtensions.cs
+++ b/src/Configuration/Config.UserSecrets/src/UserSecretsConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.UserSecrets/src/UserSecretsIdAttribute.cs
+++ b/src/Configuration/Config.UserSecrets/src/UserSecretsIdAttribute.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Configuration/Config.UserSecrets/test/ConfigurationExtensionTest.cs
+++ b/src/Configuration/Config.UserSecrets/test/ConfigurationExtensionTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.UserSecrets/test/MsBuildTargetTest.cs
+++ b/src/Configuration/Config.UserSecrets/test/MsBuildTargetTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Configuration/Config.UserSecrets/test/PathHelperTest.cs
+++ b/src/Configuration/Config.UserSecrets/test/PathHelperTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Xml/ref/Microsoft.Extensions.Configuration.Xml.netcoreapp.cs
+++ b/src/Configuration/Config.Xml/ref/Microsoft.Extensions.Configuration.Xml.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Xml/ref/Microsoft.Extensions.Configuration.Xml.netstandard2.0.cs
+++ b/src/Configuration/Config.Xml/ref/Microsoft.Extensions.Configuration.Xml.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config.Xml/src/XmlConfigurationExtensions.cs
+++ b/src/Configuration/Config.Xml/src/XmlConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Xml/src/XmlConfigurationProvider.cs
+++ b/src/Configuration/Config.Xml/src/XmlConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Configuration/Config.Xml/src/XmlConfigurationSource.cs
+++ b/src/Configuration/Config.Xml/src/XmlConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.Xml
 {

--- a/src/Configuration/Config.Xml/src/XmlDocumentDecryptor.cs
+++ b/src/Configuration/Config.Xml/src/XmlDocumentDecryptor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/Configuration/Config.Xml/src/XmlStreamConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config.Xml/src/XmlStreamConfigurationSource.cs
+++ b/src/Configuration/Config.Xml/src/XmlStreamConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration.Xml
 {

--- a/src/Configuration/Config.Xml/test/ConfigurationProviderXmlTest.cs
+++ b/src/Configuration/Config.Xml/test/ConfigurationProviderXmlTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Configuration/Config.Xml/test/XmlConfigurationExtensionsTest.cs
+++ b/src/Configuration/Config.Xml/test/XmlConfigurationExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config.Xml/test/XmlConfigurationTest.cs
+++ b/src/Configuration/Config.Xml/test/XmlConfigurationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netcoreapp.cs
+++ b/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netstandard2.0.cs
+++ b/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config/src/ChainedBuilderExtensions.cs
+++ b/src/Configuration/Config/src/ChainedBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/ChainedConfigurationProvider.cs
+++ b/src/Configuration/Config/src/ChainedConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/ChainedConfigurationSource.cs
+++ b/src/Configuration/Config/src/ChainedConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Configuration/Config/src/ConfigurationBuilder.cs
+++ b/src/Configuration/Config/src/ConfigurationBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/ConfigurationKeyComparer.cs
+++ b/src/Configuration/Config/src/ConfigurationKeyComparer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/ConfigurationProvider.cs
+++ b/src/Configuration/Config/src/ConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/ConfigurationReloadToken.cs
+++ b/src/Configuration/Config/src/ConfigurationReloadToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Configuration/Config/src/ConfigurationRoot.cs
+++ b/src/Configuration/Config/src/ConfigurationRoot.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/ConfigurationSection.cs
+++ b/src/Configuration/Config/src/ConfigurationSection.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/InternalConfigurationRootExtensions.cs
+++ b/src/Configuration/Config/src/InternalConfigurationRootExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Configuration/Config/src/InternalConfigurationRootExtensions.cs
+++ b/src/Configuration/Config/src/InternalConfigurationRootExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/MemoryConfigurationBuilderExtensions.cs
+++ b/src/Configuration/Config/src/MemoryConfigurationBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/src/MemoryConfigurationProvider.cs
+++ b/src/Configuration/Config/src/MemoryConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Configuration/Config/src/MemoryConfigurationSource.cs
+++ b/src/Configuration/Config/src/MemoryConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Configuration/Config/src/StreamConfigurationProvider.cs
+++ b/src/Configuration/Config/src/StreamConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/Config/src/StreamConfigurationSource.cs
+++ b/src/Configuration/Config/src/StreamConfigurationSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Configuration/Config/test/ConfigurationPathComparerTest.cs
+++ b/src/Configuration/Config/test/ConfigurationPathComparerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/Configuration/Config/test/ConfigurationPathTest.cs
+++ b/src/Configuration/Config/test/ConfigurationPathTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/Configuration/Config/test/ConfigurationProviderMemoryTest.cs
+++ b/src/Configuration/Config/test/ConfigurationProviderMemoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Configuration/Config/test/ConfigurationProviderTestBase.cs
+++ b/src/Configuration/Config/test/ConfigurationProviderTestBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/test/ConfigurationRootTest.cs
+++ b/src/Configuration/Config/test/ConfigurationRootTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/Config/test/ConfigurationTest.cs
+++ b/src/Configuration/Config/test/ConfigurationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/test/Config.FunctionalTests/ArrayTests.cs
+++ b/src/Configuration/test/Config.FunctionalTests/ArrayTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Configuration/test/Config.FunctionalTests/ConfigurationTests.cs
+++ b/src/Configuration/test/Config.FunctionalTests/ConfigurationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Configuration/test/Config.FunctionalTests/DisposableFileSystem.cs
+++ b/src/Configuration/test/Config.FunctionalTests/DisposableFileSystem.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Configuration/testassets/Test.Common/ConfigurationProviderExtensions.cs
+++ b/src/Configuration/testassets/Test.Common/ConfigurationProviderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Configuration/testassets/Test.Common/TestStreamHelpers.cs
+++ b/src/Configuration/testassets/Test.Common/TestStreamHelpers.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/DependencyInjection/DI.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.netstandard2.0.cs
+++ b/src/DependencyInjection/DI.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI.Abstractions/src/IServiceCollection.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/IServiceCollection.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/DependencyInjection/DI.Abstractions/src/IServiceProviderFactory.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/IServiceProviderFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Abstractions/src/IServiceProviderFactory.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/IServiceProviderFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI.Abstractions/src/IServiceScope.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/IServiceScope.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Abstractions/src/IServiceScopeFactory.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/IServiceScopeFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI.Abstractions/src/ISupportRequiredService.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ISupportRequiredService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Abstractions/src/ServiceCollectionServiceExtensions.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceCollectionServiceExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Abstractions/src/ServiceDescriptor.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceDescriptor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/DependencyInjection/DI.Abstractions/src/ServiceLifetime.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI.External.Tests/test/Autofac.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Autofac.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Autofac;

--- a/src/DependencyInjection/DI.External.Tests/test/Autofac.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Autofac.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using DryIoc;

--- a/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/Grace.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Grace.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/Grace.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Grace.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Grace.DependencyInjection;

--- a/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Autofac;

--- a/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/SkippableDependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/SkippableDependencyInjectionSpecificationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/DependencyInjection/DI.External.Tests/test/SkippableDependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/SkippableDependencyInjectionSpecificationTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Diagnostics;
 using System.Linq;

--- a/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using StructureMap;

--- a/src/DependencyInjection/DI.External.Tests/test/Unity.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Unity.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.External.Tests/test/Unity.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Unity.cs
@@ -1,4 +1,4 @@
-    // Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/DependencyInjection/DI.Specification.Tests/src/ActivatorUtilitiesTests.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/ActivatorUtilitiesTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/AnotherClass.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/AnotherClass.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/AnotherClassAcceptingData.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/AnotherClassAcceptingData.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithAmbiguousCtors.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithAmbiguousCtors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithAmbiguousCtorsAndAttribute.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithAmbiguousCtorsAndAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithInternalConstructor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithInternalConstructor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithMultipleMarkedCtors.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithMultipleMarkedCtors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithNestedReferencesToProvider.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithNestedReferencesToProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithOptionalArgsCtor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithOptionalArgsCtor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithPrivateCtor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithPrivateCtor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithProtectedConstructor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithProtectedConstructor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithServiceProvider.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithServiceProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithServiceProvider.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithServiceProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithStaticCtor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithStaticCtor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithThrowingCtor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithThrowingCtor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithThrowingEmptyCtor.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ClassWithThrowingEmptyCtor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/CreationCountFakeService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/CreationCountFakeService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackInnerService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackInnerService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackOuterService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackOuterService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposeCallback.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposeCallback.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeOneMultipleService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeOneMultipleService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeOpenGenericService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeOpenGenericService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeOuterService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeOuterService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeTwoMultipleService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeTwoMultipleService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFactoryService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFactoryService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeEveryService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeEveryService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeMultipleService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeMultipleService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeOpenGenericService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeOpenGenericService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeOuterService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeOuterService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeScopedService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeScopedService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeServiceInstance.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeServiceInstance.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeSingletonService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/IFakeSingletonService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/INonexistentService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/INonexistentService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/PocoClass.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/PocoClass.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ScopedFactoryService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ScopedFactoryService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ServiceAcceptingFactoryService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/ServiceAcceptingFactoryService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/TransientFactoryService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/TransientFactoryService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/TypeWithSupersetConstructors.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/TypeWithSupersetConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
 {

--- a/src/DependencyInjection/DI.Specification.Tests/src/ServiceCollection.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/ServiceCollection.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/DependencyInjection/DI/perf/ActivatorUtilitiesBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/ActivatorUtilitiesBenchmark.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using BenchmarkDotNet.Attributes;

--- a/src/DependencyInjection/DI/perf/AssemblyInfo.cs
+++ b/src/DependencyInjection/DI/perf/AssemblyInfo.cs
@@ -1,1 +1,4 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/DependencyInjection/DI/perf/AssemblyInfo.cs
+++ b/src/DependencyInjection/DI/perf/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/DependencyInjection/DI/perf/GetServiceBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/GetServiceBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/perf/IEnumerableGetServiceBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/IEnumerableGetServiceBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/perf/ScopeValidationBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/ScopeValidationBenchmark.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/perf/ServiceProviderEngineBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/ServiceProviderEngineBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/perf/TimeToFirstServiceBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/TimeToFirstServiceBenchmark.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.netcoreapp.cs
+++ b/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.netstandard2.0.cs
+++ b/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.netstandard2.1.cs
+++ b/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.netstandard2.1.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI/src/CallSiteJsonFormatter.cs
+++ b/src/DependencyInjection/DI/src/CallSiteJsonFormatter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Text;

--- a/src/DependencyInjection/DI/src/DefaultServiceProviderFactory.cs
+++ b/src/DependencyInjection/DI/src/DefaultServiceProviderFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/DefaultServiceProviderFactory.cs
+++ b/src/DependencyInjection/DI/src/DefaultServiceProviderFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI/src/DependencyInjectionEventSource.cs
+++ b/src/DependencyInjection/DI/src/DependencyInjectionEventSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics.Tracing;

--- a/src/DependencyInjection/DI/src/ServiceCollection.cs
+++ b/src/DependencyInjection/DI/src/ServiceCollection.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceCollectionContainerBuilderExtensions.cs
+++ b/src/DependencyInjection/DI/src/ServiceCollectionContainerBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteChain.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteChain.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteKind.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteKind.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal enum CallSiteKind

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteKind.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteKind.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteResultCacheLocation.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteResultCacheLocation.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Reflection;
 using System.Runtime.ExceptionServices;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteValidator.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteVisitor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteVisitor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ConstantCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ConstructorCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ConstructorCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/DependencyInjection/DI/src/ServiceLookup/CreateInstanceCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CreateInstanceCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.ExceptionServices;

--- a/src/DependencyInjection/DI/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/FactoryCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/FactoryCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/IEnumerableCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/IEnumerableCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitCallSiteAnalysisResult.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitCallSiteAnalysisResult.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilderContext.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilderContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/IServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/IServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/IServiceProviderEngineCallback.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/IServiceProviderEngineCallback.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ResultCache.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ResultCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/DependencyInjection/DI/src/ServiceLookup/RuntimeServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/RuntimeServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceCacheKey.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceCacheKey.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngine.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceScopeFactoryCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceScopeFactoryCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/SingletonCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/SingletonCallSite.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/src/ServiceLookup/StackGuard.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/StackGuard.cs
@@ -1,6 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/src/ServiceLookup/StackGuard.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/StackGuard.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ThrowHelper.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ThrowHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/DependencyInjection/DI/src/ServiceProvider.cs
+++ b/src/DependencyInjection/DI/src/ServiceProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/src/ServiceProviderMode.cs
+++ b/src/DependencyInjection/DI/src/ServiceProviderMode.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/DependencyInjection/DI/src/ServiceProviderOptions.cs
+++ b/src/DependencyInjection/DI/src/ServiceProviderOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/test/CallSiteTests.cs
+++ b/src/DependencyInjection/DI/test/CallSiteTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/DependencyInjection/DI/test/CircularDependencyTests.cs
+++ b/src/DependencyInjection/DI/test/CircularDependencyTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/test/DependencyInjectionEventSourceTests.cs
+++ b/src/DependencyInjection/DI/test/DependencyInjectionEventSourceTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DependencyInjection/DI/test/Fakes/AbstractClass.cs
+++ b/src/DependencyInjection/DI/test/Fakes/AbstractClass.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/DependencyOnCircularDependency.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/DependencyOnCircularDependency.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/DirectCircularDependencyA.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/DirectCircularDependencyA.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/DirectCircularDependencyB.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/DirectCircularDependencyB.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/ISelfCircularDependencyWithInterface.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/ISelfCircularDependencyWithInterface.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/IndirectCircularDependencyA.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/IndirectCircularDependencyA.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/IndirectCircularDependencyB.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/IndirectCircularDependencyB.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/IndirectCircularDependencyC.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/IndirectCircularDependencyC.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/NoCircularDependencySameTypeMultipleTimesA.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/NoCircularDependencySameTypeMultipleTimesA.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/NoCircularDependencySameTypeMultipleTimesB.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/NoCircularDependencySameTypeMultipleTimesB.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/NoCircularDependencySameTypeMultipleTimesC.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/NoCircularDependencySameTypeMultipleTimesC.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/SelfCircularDependency.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/SelfCircularDependency.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/SelfCircularDependencyGeneric.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/SelfCircularDependencyGeneric.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/CircularReferences/SelfCircularDependencyWithInterface.cs
+++ b/src/DependencyInjection/DI/test/Fakes/CircularReferences/SelfCircularDependencyWithInterface.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/ClassDependsOnPrivateConstructorClass.cs
+++ b/src/DependencyInjection/DI/test/Fakes/ClassDependsOnPrivateConstructorClass.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/Fakes/ClassWithNestedReferencesToProvider.cs
+++ b/src/DependencyInjection/DI/test/Fakes/ClassWithNestedReferencesToProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/test/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
+++ b/src/DependencyInjection/DI/test/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;

--- a/src/DependencyInjection/DI/test/Fakes/DependOnNonexistentService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/DependOnNonexistentService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/Fakes/StructFakeMultipleService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/StructFakeMultipleService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/Fakes/StructFakeMultipleService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/StructFakeMultipleService.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 
 namespace Microsoft.Extensions.DependencyInjection.Fakes
 {

--- a/src/DependencyInjection/DI/test/Fakes/StructFakeService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/StructFakeService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;

--- a/src/DependencyInjection/DI/test/Fakes/StructFakeService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/StructFakeService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 
 namespace Microsoft.Extensions.DependencyInjection.Fakes

--- a/src/DependencyInjection/DI/test/Fakes/StructService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/StructService.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.DependencyInjection.Fakes
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.DependencyInjection.Fakes
 {
     public struct StructService
     {

--- a/src/DependencyInjection/DI/test/Fakes/StructService.cs
+++ b/src/DependencyInjection/DI/test/Fakes/StructService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Fakes
 {

--- a/src/DependencyInjection/DI/test/ServiceCollectionDescriptorExtensionsTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceCollectionDescriptorExtensionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/DependencyInjection/DI/test/ServiceCollectionServiceExtensionsTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceCollectionServiceExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.AspNetCore.Testing;

--- a/src/DependencyInjection/DI/test/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/CallSiteFactoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithDefaultConstructorParameters.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithDefaultConstructorParameters.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithEnumerableConstructors.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithEnumerableConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithGenericServices.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithGenericServices.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithMultipleParameterizedConstructors.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithMultipleParameterizedConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithNoConstructors.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithNoConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithNoPublicConstructors.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithNoPublicConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithNonOverlappedConstructors.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithNonOverlappedConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterizedAndNullaryConstructor.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterizedAndNullaryConstructor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterizedConstructor.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterizedConstructor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterlessConstructor.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterlessConstructor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterlessPublicConstructor.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithParameterlessPublicConstructor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {

--- a/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithUnresolvableEnumerableConstructors.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/Types/TypeWithUnresolvableEnumerableConstructors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;

--- a/src/DependencyInjection/DI/test/ServiceProviderCompilationTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderCompilationTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/DependencyInjection/DI/test/ServiceProviderCompilationTestData.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderCompilationTestData.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
 {

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/test/ServiceProviderDefaultContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderDefaultContainerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/test/ServiceProviderDynamicContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderDynamicContainerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/test/ServiceProviderEngineScopeTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderEngineScopeTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;

--- a/src/DependencyInjection/DI/test/ServiceProviderExpressionsContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderExpressionsContainerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/test/ServiceProviderILEmitContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderILEmitContainerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DependencyInjection/DI/test/ServiceProviderServiceExtensionsTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderServiceExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/test/ServiceProviderValidationTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderValidationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;

--- a/src/DependencyInjection/DI/test/ServiceTableTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceTableTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DependencyInjection/DI/test/Utils/MultiServiceHelpers.cs
+++ b/src/DependencyInjection/DI/test/Utils/MultiServiceHelpers.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/DiagnosticAdapter/ref/Microsoft.Extensions.DiagnosticAdapter.netcoreapp.cs
+++ b/src/DiagnosticAdapter/ref/Microsoft.Extensions.DiagnosticAdapter.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DiagnosticAdapter
 {

--- a/src/DiagnosticAdapter/ref/Microsoft.Extensions.DiagnosticAdapter.netstandard2.0.cs
+++ b/src/DiagnosticAdapter/ref/Microsoft.Extensions.DiagnosticAdapter.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DiagnosticAdapter
 {

--- a/src/DiagnosticAdapter/src/DiagnosticListenerExtensions.cs
+++ b/src/DiagnosticAdapter/src/DiagnosticListenerExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DiagnosticAdapter;
 

--- a/src/DiagnosticAdapter/src/DiagnosticNameAttribute.cs
+++ b/src/DiagnosticAdapter/src/DiagnosticNameAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DiagnosticAdapter/src/DiagnosticSourceAdapter.cs
+++ b/src/DiagnosticAdapter/src/DiagnosticSourceAdapter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DiagnosticAdapter/src/IDiagnosticSourceMethodAdapter.cs
+++ b/src/DiagnosticAdapter/src/IDiagnosticSourceMethodAdapter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/DiagnosticAdapter/src/Infrastructure/IProxy.cs
+++ b/src/DiagnosticAdapter/src/Infrastructure/IProxy.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DiagnosticAdapter.Infrastructure
 {

--- a/src/DiagnosticAdapter/src/Infrastructure/IProxyFactory.cs
+++ b/src/DiagnosticAdapter/src/Infrastructure/IProxyFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DiagnosticAdapter.Infrastructure
 {

--- a/src/DiagnosticAdapter/src/Internal/InvalidProxyOperationException.cs
+++ b/src/DiagnosticAdapter/src/Internal/InvalidProxyOperationException.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DiagnosticAdapter/src/Internal/ProxyAssembly.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyAssembly.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if NETCOREAPP2_0 || NET461
 using System;

--- a/src/DiagnosticAdapter/src/Internal/ProxyBase.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DiagnosticAdapter.Infrastructure;

--- a/src/DiagnosticAdapter/src/Internal/ProxyBaseOfT.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyBaseOfT.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/DiagnosticAdapter/src/Internal/ProxyEnumerable.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyEnumerable.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/DiagnosticAdapter/src/Internal/ProxyFactory.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/DiagnosticAdapter/src/Internal/ProxyList.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyList.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/DiagnosticAdapter/src/Internal/ProxyMethodEmitter.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyMethodEmitter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if NETCOREAPP2_0 || NET461
 using System;

--- a/src/DiagnosticAdapter/src/Internal/ProxyTypeCache.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyTypeCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/DiagnosticAdapter/src/Internal/ProxyTypeCacheResult.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyTypeCacheResult.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/DiagnosticAdapter/src/Internal/ProxyTypeEmitter.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyTypeEmitter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if NETCOREAPP2_0 || NET461
 using System;

--- a/src/DiagnosticAdapter/src/ProxyDiagnosticSourceMethodAdapter.cs
+++ b/src/DiagnosticAdapter/src/ProxyDiagnosticSourceMethodAdapter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/DiagnosticAdapter/test/DiagnosticSourceAdapterTest.cs
+++ b/src/DiagnosticAdapter/test/DiagnosticSourceAdapterTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/DiagnosticAdapter/test/Internal/ProxyFactoryTest.cs
+++ b/src/DiagnosticAdapter/test/Internal/ProxyFactoryTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DiagnosticAdapter.Infrastructure;
 using Xunit;

--- a/src/DiagnosticAdapter/test/Internal/ProxyTypeEmitterTest.cs
+++ b/src/DiagnosticAdapter/test/Internal/ProxyTypeEmitterTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/DiagnosticAdapter/test/ProxyDiagnosticSourceMethodAdapterTest.cs
+++ b/src/DiagnosticAdapter/test/ProxyDiagnosticSourceMethodAdapterTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq.Expressions;

--- a/src/FileProviders/Abstractions/ref/Microsoft.Extensions.FileProviders.Abstractions.netcoreapp.cs
+++ b/src/FileProviders/Abstractions/ref/Microsoft.Extensions.FileProviders.Abstractions.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileProviders
 {

--- a/src/FileProviders/Abstractions/ref/Microsoft.Extensions.FileProviders.Abstractions.netstandard2.0.cs
+++ b/src/FileProviders/Abstractions/ref/Microsoft.Extensions.FileProviders.Abstractions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileProviders
 {

--- a/src/FileProviders/Abstractions/src/IDirectoryContents.cs
+++ b/src/FileProviders/Abstractions/src/IDirectoryContents.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/FileProviders/Abstractions/src/IFileInfo.cs
+++ b/src/FileProviders/Abstractions/src/IFileInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Abstractions/src/IFileProvider.cs
+++ b/src/FileProviders/Abstractions/src/IFileProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Primitives;
 

--- a/src/FileProviders/Abstractions/src/NotFoundDirectoryContents.cs
+++ b/src/FileProviders/Abstractions/src/NotFoundDirectoryContents.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/FileProviders/Abstractions/src/NotFoundFileInfo.cs
+++ b/src/FileProviders/Abstractions/src/NotFoundFileInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Abstractions/src/NullChangeToken.cs
+++ b/src/FileProviders/Abstractions/src/NullChangeToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/FileProviders/Abstractions/src/NullFileProvider.cs
+++ b/src/FileProviders/Abstractions/src/NullFileProvider.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Primitives;
 

--- a/src/FileProviders/Composite/ref/Microsoft.Extensions.FileProviders.Composite.netcoreapp.cs
+++ b/src/FileProviders/Composite/ref/Microsoft.Extensions.FileProviders.Composite.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileProviders
 {

--- a/src/FileProviders/Composite/ref/Microsoft.Extensions.FileProviders.Composite.netstandard2.0.cs
+++ b/src/FileProviders/Composite/ref/Microsoft.Extensions.FileProviders.Composite.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileProviders
 {

--- a/src/FileProviders/Composite/src/CompositeDirectoryContents.cs
+++ b/src/FileProviders/Composite/src/CompositeDirectoryContents.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/FileProviders/Composite/src/CompositeFileProvider.cs
+++ b/src/FileProviders/Composite/src/CompositeFileProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileProviders/Composite/test/CompositeFileProviderTests.cs
+++ b/src/FileProviders/Composite/test/CompositeFileProviderTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileProviders/Composite/test/MockChangeToken.cs
+++ b/src/FileProviders/Composite/test/MockChangeToken.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Primitives;
 using System;

--- a/src/FileProviders/Composite/test/MockDisposable.cs
+++ b/src/FileProviders/Composite/test/MockDisposable.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileProviders/Composite/test/MockFileInfo.cs
+++ b/src/FileProviders/Composite/test/MockFileInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Composite/test/MockFileProvider.cs
+++ b/src/FileProviders/Composite/test/MockFileProvider.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileProviders/Physical/ref/Microsoft.Extensions.FileProviders.Physical.netcoreapp.cs
+++ b/src/FileProviders/Physical/ref/Microsoft.Extensions.FileProviders.Physical.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileProviders
 {

--- a/src/FileProviders/Physical/ref/Microsoft.Extensions.FileProviders.Physical.netstandard2.0.cs
+++ b/src/FileProviders/Physical/ref/Microsoft.Extensions.FileProviders.Physical.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileProviders
 {

--- a/src/FileProviders/Physical/src/ExclusionFilters.cs
+++ b/src/FileProviders/Physical/src/ExclusionFilters.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Physical/src/IPollingChangeToken.cs
+++ b/src/FileProviders/Physical/src/IPollingChangeToken.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using Microsoft.Extensions.Primitives;

--- a/src/FileProviders/Physical/src/Internal/Clock.cs
+++ b/src/FileProviders/Physical/src/Internal/Clock.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileProviders/Physical/src/Internal/FileSystemInfoHelper.cs
+++ b/src/FileProviders/Physical/src/Internal/FileSystemInfoHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Physical/src/Internal/IClock.cs
+++ b/src/FileProviders/Physical/src/Internal/IClock.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileProviders/Physical/src/Internal/PathUtils.cs
+++ b/src/FileProviders/Physical/src/Internal/PathUtils.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Linq;

--- a/src/FileProviders/Physical/src/Internal/PhysicalDirectoryContents.cs
+++ b/src/FileProviders/Physical/src/Internal/PhysicalDirectoryContents.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/FileProviders/Physical/src/PhysicalDirectoryInfo.cs
+++ b/src/FileProviders/Physical/src/PhysicalDirectoryInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Physical/src/PhysicalFileInfo.cs
+++ b/src/FileProviders/Physical/src/PhysicalFileInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Physical/src/PhysicalFileProvider.cs
+++ b/src/FileProviders/Physical/src/PhysicalFileProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/FileProviders/Physical/src/PhysicalFilesWatcher.cs
+++ b/src/FileProviders/Physical/src/PhysicalFilesWatcher.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/FileProviders/Physical/src/PollingFileChangeToken.cs
+++ b/src/FileProviders/Physical/src/PollingFileChangeToken.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/FileProviders/Physical/src/PollingWildCardChangeToken.cs
+++ b/src/FileProviders/Physical/src/PollingWildCardChangeToken.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/FileProviders/Physical/test/DisposableFileSystem.cs
+++ b/src/FileProviders/Physical/test/DisposableFileSystem.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Physical/test/ExclusionFilterTests.cs
+++ b/src/FileProviders/Physical/test/ExclusionFilterTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileProviders/Physical/test/MockFileSystemWatcher.cs
+++ b/src/FileProviders/Physical/test/MockFileSystemWatcher.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
+++ b/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileProviders/Physical/test/PhysicalFilesWatcherTests.cs
+++ b/src/FileProviders/Physical/test/PhysicalFilesWatcherTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/FileProviders/Physical/test/PollingWildCardChangeTokenTest.cs
+++ b/src/FileProviders/Physical/test/PollingWildCardChangeTokenTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileProviders/Physical/test/TestClock.cs
+++ b/src/FileProviders/Physical/test/TestClock.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.netstandard2.0.cs
+++ b/src/FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileSystemGlobbing
 {

--- a/src/FileSystemGlobbing/src/Abstractions/DirectoryInfoBase.cs
+++ b/src/FileSystemGlobbing/src/Abstractions/DirectoryInfoBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Abstractions/FileInfoBase.cs
+++ b/src/FileSystemGlobbing/src/Abstractions/FileInfoBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
 {

--- a/src/FileSystemGlobbing/src/Abstractions/FileInfoWrapper.cs
+++ b/src/FileSystemGlobbing/src/Abstractions/FileInfoWrapper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/FileSystemGlobbing/src/Abstractions/FileSystemInfoBase.cs
+++ b/src/FileSystemGlobbing/src/Abstractions/FileSystemInfoBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
 {

--- a/src/FileSystemGlobbing/src/FilePatternMatch.cs
+++ b/src/FileSystemGlobbing/src/FilePatternMatch.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Internal;

--- a/src/FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Internal/ILinearPattern.cs
+++ b/src/FileSystemGlobbing/src/Internal/ILinearPattern.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/FileSystemGlobbing/src/Internal/IPathSegment.cs
+++ b/src/FileSystemGlobbing/src/Internal/IPathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Internal
 {

--- a/src/FileSystemGlobbing/src/Internal/IPattern.cs
+++ b/src/FileSystemGlobbing/src/Internal/IPattern.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Internal
 {

--- a/src/FileSystemGlobbing/src/Internal/IPatternContext.cs
+++ b/src/FileSystemGlobbing/src/Internal/IPatternContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;

--- a/src/FileSystemGlobbing/src/Internal/IRaggedPattern.cs
+++ b/src/FileSystemGlobbing/src/Internal/IRaggedPattern.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/FileSystemGlobbing/src/Internal/InMemoryFileInfo.cs
+++ b/src/FileSystemGlobbing/src/Internal/InMemoryFileInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;

--- a/src/FileSystemGlobbing/src/Internal/MatcherContext.cs
+++ b/src/FileSystemGlobbing/src/Internal/MatcherContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Internal/PathSegments/CurrentPathSegment.cs
+++ b/src/FileSystemGlobbing/src/Internal/PathSegments/CurrentPathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileSystemGlobbing/src/Internal/PathSegments/LiteralPathSegment.cs
+++ b/src/FileSystemGlobbing/src/Internal/PathSegments/LiteralPathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Util;

--- a/src/FileSystemGlobbing/src/Internal/PathSegments/ParentPathSegment.cs
+++ b/src/FileSystemGlobbing/src/Internal/PathSegments/ParentPathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileSystemGlobbing/src/Internal/PathSegments/RecursiveWildcardSegment.cs
+++ b/src/FileSystemGlobbing/src/Internal/PathSegments/RecursiveWildcardSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileSystemGlobbing/src/Internal/PathSegments/WildcardPathSegment.cs
+++ b/src/FileSystemGlobbing/src/Internal/PathSegments/WildcardPathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContext.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinear.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinear.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinearExclude.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinearExclude.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinearInclude.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinearInclude.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRagged.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRagged.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRaggedExclude.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRaggedExclude.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRaggedInclude.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRaggedInclude.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;

--- a/src/FileSystemGlobbing/src/Internal/PatternTestResult.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternTestResult.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Internal
 {

--- a/src/FileSystemGlobbing/src/Internal/Patterns/PatternBuilder.cs
+++ b/src/FileSystemGlobbing/src/Internal/Patterns/PatternBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/Matcher.cs
+++ b/src/FileSystemGlobbing/src/Matcher.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/MatcherExtensions.cs
+++ b/src/FileSystemGlobbing/src/MatcherExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/src/PatternMatchingResult.cs
+++ b/src/FileSystemGlobbing/src/PatternMatchingResult.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/FileSystemGlobbing/src/Util/StringComparisonHelper.cs
+++ b/src/FileSystemGlobbing/src/Util/StringComparisonHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/FileSystemGlobbing/test/FileAbstractionsTests.cs
+++ b/src/FileSystemGlobbing/test/FileAbstractionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Linq;

--- a/src/FileSystemGlobbing/test/FunctionalTests.cs
+++ b/src/FileSystemGlobbing/test/FunctionalTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/test/PatternContexts/PatternContextLinearTests.cs
+++ b/src/FileSystemGlobbing/test/PatternContexts/PatternContextLinearTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/test/PatternContexts/PatternContextRaggedTests.cs
+++ b/src/FileSystemGlobbing/test/PatternContexts/PatternContextRaggedTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Internal;

--- a/src/FileSystemGlobbing/test/PatternMatchingTests.cs
+++ b/src/FileSystemGlobbing/test/PatternMatchingTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility;

--- a/src/FileSystemGlobbing/test/PatternSegments/CurrentPathSegmentTests.cs
+++ b/src/FileSystemGlobbing/test/PatternSegments/CurrentPathSegmentTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments;
 using Xunit;

--- a/src/FileSystemGlobbing/test/PatternSegments/LiteralPathSegmentTests.cs
+++ b/src/FileSystemGlobbing/test/PatternSegments/LiteralPathSegmentTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments;

--- a/src/FileSystemGlobbing/test/PatternSegments/ParentPathSegmentTests.cs
+++ b/src/FileSystemGlobbing/test/PatternSegments/ParentPathSegmentTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments;
 using Xunit;

--- a/src/FileSystemGlobbing/test/PatternSegments/RecursiveWildcardSegmentTests.cs
+++ b/src/FileSystemGlobbing/test/PatternSegments/RecursiveWildcardSegmentTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments;
 using Xunit;

--- a/src/FileSystemGlobbing/test/PatternSegments/WildcardPathSegmentTests.cs
+++ b/src/FileSystemGlobbing/test/PatternSegments/WildcardPathSegmentTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/test/Patterns/PatternTests.cs
+++ b/src/FileSystemGlobbing/test/Patterns/PatternTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Internal;

--- a/src/FileSystemGlobbing/test/TestUtility/DisposableFileSystem.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/DisposableFileSystem.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/FileSystemGlobbing/test/TestUtility/FileSystemGlobbingTestContext.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/FileSystemGlobbingTestContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Xunit;

--- a/src/FileSystemGlobbing/test/TestUtility/FileSystemOperationRecorder.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/FileSystemOperationRecorder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/FileSystemGlobbing/test/TestUtility/MockDirectoryInfo.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/MockDirectoryInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/test/TestUtility/MockFileInfoStub.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/MockFileInfoStub.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 

--- a/src/FileSystemGlobbing/test/TestUtility/MockLinearPatternBuilder.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/MockLinearPatternBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/test/TestUtility/MockNonRecursivePathSegment.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/MockNonRecursivePathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Internal;

--- a/src/FileSystemGlobbing/test/TestUtility/MockRaggedPatternBuilder.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/MockRaggedPatternBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/FileSystemGlobbing/test/TestUtility/MockRecursivePathSegment.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/MockRecursivePathSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileSystemGlobbing.Internal;

--- a/src/FileSystemGlobbing/test/TestUtility/PatternContextHelper.cs
+++ b/src/FileSystemGlobbing/test/TestUtility/PatternContextHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileSystemGlobbing.Internal;
 

--- a/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netcoreapp.cs
+++ b/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netstandard2.0.cs
+++ b/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Hosting/Abstractions/src/BackgroundService.cs
+++ b/src/Hosting/Abstractions/src/BackgroundService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Abstractions/src/EnvironmentName.cs
+++ b/src/Hosting/Abstractions/src/EnvironmentName.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Abstractions/src/Environments.cs
+++ b/src/Hosting/Abstractions/src/Environments.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Abstractions/src/HostBuilderContext.cs
+++ b/src/Hosting/Abstractions/src/HostBuilderContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;

--- a/src/Hosting/Abstractions/src/HostDefaults.cs
+++ b/src/Hosting/Abstractions/src/HostDefaults.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Abstractions/src/HostEnvironmentEnvExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostEnvironmentEnvExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Hosting/Abstractions/src/HostingAbstractionsHostBuilderExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Abstractions/src/HostingEnvironmentExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingEnvironmentExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Hosting/Abstractions/src/IApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IApplicationLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Abstractions/src/IHost.cs
+++ b/src/Hosting/Abstractions/src/IHost.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 

--- a/src/Hosting/Abstractions/src/IHostBuilder.cs
+++ b/src/Hosting/Abstractions/src/IHostBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/Abstractions/src/IHostEnvironment.cs
+++ b/src/Hosting/Abstractions/src/IHostEnvironment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileProviders;

--- a/src/Hosting/Abstractions/src/IHostLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/Abstractions/src/IHostedService.cs
+++ b/src/Hosting/Abstractions/src/IHostedService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/Abstractions/src/IHostingEnvironment.cs
+++ b/src/Hosting/Abstractions/src/IHostingEnvironment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.FileProviders;

--- a/src/Hosting/Abstractions/src/ServiceCollectionHostedServiceExtensions.cs
+++ b/src/Hosting/Abstractions/src/ServiceCollectionHostedServiceExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netcoreapp.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netstandard2.0.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netstandard2.1.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netstandard2.1.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Hosting/src/ConsoleLifetimeOptions.cs
+++ b/src/Hosting/Hosting/src/ConsoleLifetimeOptions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Hosting/src/Host.cs
+++ b/src/Hosting/Hosting/src/Host.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Reflection;

--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/Hosting/src/HostOptions.cs
+++ b/src/Hosting/Hosting/src/HostOptions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Hosting/Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/HostingHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Hosting/src/Internal/ConfigureContainerAdapter.cs
+++ b/src/Hosting/Hosting/src/Internal/ConfigureContainerAdapter.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Hosting/src/Internal/Host.cs
+++ b/src/Hosting/Hosting/src/Internal/Host.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.FileProviders;
 

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Hosting/Hosting/src/Internal/IConfigureContainerAdapter.cs
+++ b/src/Hosting/Hosting/src/Internal/IConfigureContainerAdapter.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Internal
 {

--- a/src/Hosting/Hosting/src/Internal/IServiceFactoryAdapter.cs
+++ b/src/Hosting/Hosting/src/Internal/IServiceFactoryAdapter.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/src/Internal/LoggerEventIds.cs
+++ b/src/Hosting/Hosting/src/Internal/LoggerEventIds.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Hosting/Hosting/src/Internal/ServiceFactoryAdapter.cs
+++ b/src/Hosting/Hosting/src/Internal/ServiceFactoryAdapter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
+++ b/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
+++ b/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/Hosting/test/Fakes/FakeHostLifetime.cs
+++ b/src/Hosting/Hosting/test/Fakes/FakeHostLifetime.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Hosting/test/Fakes/FakeHostedService.cs
+++ b/src/Hosting/Hosting/test/Fakes/FakeHostedService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Hosting/test/Fakes/FakeOptions.cs
+++ b/src/Hosting/Hosting/test/Fakes/FakeOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Fakes
 {

--- a/src/Hosting/Hosting/test/Fakes/FakeService.cs
+++ b/src/Hosting/Hosting/test/Fakes/FakeService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Hosting/Hosting/test/Fakes/FakeServiceCollection.cs
+++ b/src/Hosting/Hosting/test/Fakes/FakeServiceCollection.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/test/Fakes/FakeServiceProviderFactory.cs
+++ b/src/Hosting/Hosting/test/Fakes/FakeServiceProviderFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/test/Fakes/IFakeEveryService.cs
+++ b/src/Hosting/Hosting/test/Fakes/IFakeEveryService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Fakes
 {

--- a/src/Hosting/Hosting/test/Fakes/IFakeScopedService.cs
+++ b/src/Hosting/Hosting/test/Fakes/IFakeScopedService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Fakes
 {

--- a/src/Hosting/Hosting/test/Fakes/IFakeService.cs
+++ b/src/Hosting/Hosting/test/Fakes/IFakeService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Fakes
 {

--- a/src/Hosting/Hosting/test/Fakes/IFakeServiceInstance.cs
+++ b/src/Hosting/Hosting/test/Fakes/IFakeServiceInstance.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Fakes
 {

--- a/src/Hosting/Hosting/test/Fakes/IFakeSingletonService.cs
+++ b/src/Hosting/Hosting/test/Fakes/IFakeSingletonService.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Fakes
 {

--- a/src/Hosting/Hosting/test/HostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/HostBuilderTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/Hosting/test/HostTests.cs
+++ b/src/Hosting/Hosting/test/HostTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Hosting/Hosting/test/Internal/HostTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/IntegrationTesting/src/ApplicationPublisher.cs
+++ b/src/Hosting/IntegrationTesting/src/ApplicationPublisher.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Hosting/IntegrationTesting/src/Common/ApplicationType.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/ApplicationType.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.IntegrationTesting
 {

--- a/src/Hosting/IntegrationTesting/src/Common/DeploymentParameters.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/DeploymentParameters.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/IntegrationTesting/src/Common/DeploymentResult.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/DeploymentResult.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/Hosting/IntegrationTesting/src/Common/DotNetCommands.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/DotNetCommands.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Hosting/IntegrationTesting/src/Common/LoggingHandler.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/LoggingHandler.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/Hosting/IntegrationTesting/src/Common/ProcessLoggingExtensions.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/ProcessLoggingExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 

--- a/src/Hosting/IntegrationTesting/src/Common/RetryHelper.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/RetryHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Hosting/IntegrationTesting/src/Common/RuntimeArchitecture.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/RuntimeArchitecture.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.IntegrationTesting
 {

--- a/src/Hosting/IntegrationTesting/src/Common/RuntimeFlavor.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/RuntimeFlavor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.IntegrationTesting
 {

--- a/src/Hosting/IntegrationTesting/src/Common/Tfm.cs
+++ b/src/Hosting/IntegrationTesting/src/Common/Tfm.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Hosting/IntegrationTesting/src/Deployers/ApplicationDeployer.cs
+++ b/src/Hosting/IntegrationTesting/src/Deployers/ApplicationDeployer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/IntegrationTesting/src/Deployers/ApplicationDeployerFactory.cs
+++ b/src/Hosting/IntegrationTesting/src/Deployers/ApplicationDeployerFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/Hosting/IntegrationTesting/src/Deployers/SelfHostDeployer.cs
+++ b/src/Hosting/IntegrationTesting/src/Deployers/SelfHostDeployer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Hosting/IntegrationTesting/src/ProcessExtensions.cs
+++ b/src/Hosting/IntegrationTesting/src/ProcessExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Hosting/IntegrationTesting/src/ProcessHelpers.cs
+++ b/src/Hosting/IntegrationTesting/src/ProcessHelpers.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Hosting/IntegrationTesting/src/PublishedApplication.cs
+++ b/src/Hosting/IntegrationTesting/src/PublishedApplication.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Hosting/IntegrationTesting/src/TestMatrix.cs
+++ b/src/Hosting/IntegrationTesting/src/TestMatrix.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Hosting/IntegrationTesting/src/TestVariant.cs
+++ b/src/Hosting/IntegrationTesting/src/TestVariant.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit.Abstractions;
 

--- a/src/Hosting/IntegrationTesting/src/xunit/SkipIfEnvironmentVariableNotEnabled.cs
+++ b/src/Hosting/IntegrationTesting/src/xunit/SkipIfEnvironmentVariableNotEnabled.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.AspNetCore.Testing;

--- a/src/Hosting/IntegrationTesting/src/xunit/SkipOn32BitOSAttribute.cs
+++ b/src/Hosting/IntegrationTesting/src/xunit/SkipOn32BitOSAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Hosting/Systemd/ref/Microsoft.Extensions.Hosting.Systemd.netstandard2.1.cs
+++ b/src/Hosting/Systemd/ref/Microsoft.Extensions.Hosting.Systemd.netstandard2.1.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/Systemd/src/ISystemdNotifier.cs
+++ b/src/Hosting/Systemd/src/ISystemdNotifier.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting.Systemd
 {

--- a/src/Hosting/Systemd/src/ServiceState.cs
+++ b/src/Hosting/Systemd/src/ServiceState.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Hosting/Systemd/src/SystemdHelpers.cs
+++ b/src/Hosting/Systemd/src/SystemdHelpers.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Hosting/Systemd/src/SystemdHostBuilderExtensions.cs
+++ b/src/Hosting/Systemd/src/SystemdHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Systemd;

--- a/src/Hosting/Systemd/src/SystemdLifetime.cs
+++ b/src/Hosting/Systemd/src/SystemdLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/Systemd/src/SystemdNotifier.cs
+++ b/src/Hosting/Systemd/src/SystemdNotifier.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Hosting/Systemd/test/UseSystemdTests.cs
+++ b/src/Hosting/Systemd/test/UseSystemdTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;

--- a/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs
+++ b/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.1.cs
+++ b/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.1.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/Hosting/WindowsServices/src/Internal/Win32.cs
+++ b/src/Hosting/WindowsServices/src/Internal/Win32.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Hosting/WindowsServices/src/WindowsServiceHelpers.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceHelpers.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Hosting/WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceLifetime.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ServiceProcess;

--- a/src/Hosting/WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Hosting/WindowsServices/src/WindowsServiceLifetimeOptions.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceLifetimeOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Hosting;
 

--- a/src/Hosting/WindowsServices/test/UseWindowsServiceTests.cs
+++ b/src/Hosting/WindowsServices/test/UseWindowsServiceTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;

--- a/src/Hosting/samples/GenericHostSample/MyContainer.cs
+++ b/src/Hosting/samples/GenericHostSample/MyContainer.cs
@@ -1,4 +1,7 @@
-﻿namespace GenericHostSample
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace GenericHostSample
 {
     internal class MyContainer
     {

--- a/src/Hosting/samples/GenericHostSample/MyContainer.cs
+++ b/src/Hosting/samples/GenericHostSample/MyContainer.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace GenericHostSample
 {

--- a/src/Hosting/samples/GenericHostSample/MyContainerFactory.cs
+++ b/src/Hosting/samples/GenericHostSample/MyContainerFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/samples/GenericHostSample/MyContainerFactory.cs
+++ b/src/Hosting/samples/GenericHostSample/MyContainerFactory.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GenericHostSample

--- a/src/Hosting/samples/GenericHostSample/MyServiceA.cs
+++ b/src/Hosting/samples/GenericHostSample/MyServiceA.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/samples/GenericHostSample/MyServiceA.cs
+++ b/src/Hosting/samples/GenericHostSample/MyServiceA.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/samples/GenericHostSample/MyServiceB.cs
+++ b/src/Hosting/samples/GenericHostSample/MyServiceB.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/samples/GenericHostSample/MyServiceB.cs
+++ b/src/Hosting/samples/GenericHostSample/MyServiceB.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/samples/GenericHostSample/ProgramExternallyControlled.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramExternallyControlled.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Hosting/samples/GenericHostSample/ProgramExternallyControlled.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramExternallyControlled.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/samples/GenericHostSample/ProgramFullControl.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramFullControl.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Hosting/samples/GenericHostSample/ProgramFullControl.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramFullControl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;

--- a/src/Hosting/samples/GenericHostSample/ProgramHelloWorld.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramHelloWorld.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/samples/GenericHostSample/ProgramHelloWorld.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramHelloWorld.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Hosting/samples/GenericHostSample/ProgramNoDisposeHangs.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramNoDisposeHangs.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/samples/GenericHostSample/ProgramNoDisposeHangs.cs
+++ b/src/Hosting/samples/GenericHostSample/ProgramNoDisposeHangs.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/samples/GenericHostSample/WindowsServiceControlled.cs
+++ b/src/Hosting/samples/GenericHostSample/WindowsServiceControlled.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/samples/GenericHostSample/WindowsServiceControlled.cs
+++ b/src/Hosting/samples/GenericHostSample/WindowsServiceControlled.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Hosting/samples/SampleMsmqHost/MsmqConnection.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqConnection.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Hosting/samples/SampleMsmqHost/MsmqConnection.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqConnection.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Messaging;
 using System.Text;

--- a/src/Hosting/samples/SampleMsmqHost/MsmqOptions.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqOptions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Messaging;
 

--- a/src/Hosting/samples/SampleMsmqHost/MsmqOptions.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Messaging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Messaging;
 
 namespace SampleMsmqHost
 {

--- a/src/Hosting/samples/SampleMsmqHost/MsmqProcessor.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqProcessor.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Hosting/samples/SampleMsmqHost/MsmqProcessor.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqProcessor.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Messaging;
 using System.Text;

--- a/src/Hosting/samples/SampleMsmqHost/MsmqService.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqService.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Hosting/samples/SampleMsmqHost/MsmqService.cs
+++ b/src/Hosting/samples/SampleMsmqHost/MsmqService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;

--- a/src/Hosting/samples/SampleMsmqHost/Program.cs
+++ b/src/Hosting/samples/SampleMsmqHost/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Messaging;
 using System.Threading;

--- a/src/Hosting/samples/SampleMsmqHost/Program.cs
+++ b/src/Hosting/samples/SampleMsmqHost/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Messaging;

--- a/src/Hosting/test/FunctionalTests/Properties/AssemblyInfo.cs
+++ b/src/Hosting/test/FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Hosting/test/testassets/Microsoft.Extensions.Hosting.TestApp/Program.cs
+++ b/src/Hosting/test/testassets/Microsoft.Extensions.Hosting.TestApp/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Hosting;

--- a/src/HttpClientFactory/Http/perf/CreationOverheadBenchmark.cs
+++ b/src/HttpClientFactory/Http/perf/CreationOverheadBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/perf/FakeClientHandler.cs
+++ b/src/HttpClientFactory/Http/perf/FakeClientHandler.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/HttpClientFactory/Http/perf/FakeLoggerProvider.cs
+++ b/src/HttpClientFactory/Http/perf/FakeLoggerProvider.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/HttpClientFactory/Http/perf/LoggingOverheadBenchmark.cs
+++ b/src/HttpClientFactory/Http/perf/LoggingOverheadBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/perf/Properties/AssemblyInfo.cs
+++ b/src/HttpClientFactory/Http/perf/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
 

--- a/src/HttpClientFactory/Http/ref/Microsoft.Extensions.Http.netcoreapp.cs
+++ b/src/HttpClientFactory/Http/ref/Microsoft.Extensions.Http.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/HttpClientFactory/Http/ref/Microsoft.Extensions.Http.netstandard2.0.cs
+++ b/src/HttpClientFactory/Http/ref/Microsoft.Extensions.Http.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/HttpClientFactory/Http/src/ActiveHandlerTrackingEntry.cs
+++ b/src/HttpClientFactory/Http/src/ActiveHandlerTrackingEntry.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/HttpClientFactory/Http/src/DefaultHttpClientFactory.cs
+++ b/src/HttpClientFactory/Http/src/DefaultHttpClientFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/HttpClientFactory/Http/src/DefaultHttpMessageHandlerBuilder.cs
+++ b/src/HttpClientFactory/Http/src/DefaultHttpMessageHandlerBuilder.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/src/DefaultTypedHttpClientFactory.cs
+++ b/src/HttpClientFactory/Http/src/DefaultTypedHttpClientFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/src/DependencyInjection/DefaultHttpClientBuilder.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/DefaultHttpClientBuilder.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientMappingRegistry.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientMappingRegistry.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/src/DependencyInjection/IHttpClientBuilder.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/IHttpClientBuilder.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Net.Http;
 

--- a/src/HttpClientFactory/Http/src/ExpiredHandlerTrackingEntry.cs
+++ b/src/HttpClientFactory/Http/src/ExpiredHandlerTrackingEntry.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/src/HttpClientFactoryExtensions.cs
+++ b/src/HttpClientFactory/Http/src/HttpClientFactoryExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/HttpClientFactory/Http/src/HttpClientFactoryOptions.cs
+++ b/src/HttpClientFactory/Http/src/HttpClientFactoryOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/src/HttpMessageHandlerBuilder.cs
+++ b/src/HttpClientFactory/Http/src/HttpMessageHandlerBuilder.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/src/HttpMessageHandlerFactoryExtensions.cs
+++ b/src/HttpClientFactory/Http/src/HttpMessageHandlerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/HttpClientFactory/Http/src/IHttpClientFactory.cs
+++ b/src/HttpClientFactory/Http/src/IHttpClientFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/HttpClientFactory/Http/src/IHttpMessageHandlerBuilderFilter.cs
+++ b/src/HttpClientFactory/Http/src/IHttpMessageHandlerBuilderFilter.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/HttpClientFactory/Http/src/IHttpMessageHandlerFactory.cs
+++ b/src/HttpClientFactory/Http/src/IHttpMessageHandlerFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/HttpClientFactory/Http/src/ITypedHttpClientFactory.cs
+++ b/src/HttpClientFactory/Http/src/ITypedHttpClientFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/src/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/LifetimeTrackingHttpMessageHandler.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Net.Http;
 

--- a/src/HttpClientFactory/Http/src/Logging/HttpHeadersLogValue.cs
+++ b/src/HttpClientFactory/Http/src/Logging/HttpHeadersLogValue.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandlerBuilderFilter.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandlerBuilderFilter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Http.Logging;

--- a/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/test/DefaultHttpClientFactoryTest.cs
+++ b/src/HttpClientFactory/Http/test/DefaultHttpClientFactoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/test/DefaultHttpMessageHandlerBuilderTest.cs
+++ b/src/HttpClientFactory/Http/test/DefaultHttpMessageHandlerBuilderTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/HttpClientFactory/Http/test/DependencyInjection/OtherTestOptions.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/OtherTestOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/HttpClientFactory/Http/test/HttpMessageHandlerBuilderTest.cs
+++ b/src/HttpClientFactory/Http/test/HttpMessageHandlerBuilderTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/test/ITestTypedClient.cs
+++ b/src/HttpClientFactory/Http/test/ITestTypedClient.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Net.Http;
 

--- a/src/HttpClientFactory/Http/test/Logging/HttpHeadersLogValueTest.cs
+++ b/src/HttpClientFactory/Http/test/Logging/HttpHeadersLogValueTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Http/test/Logging/RedactedLogValueIntegrationTest.cs
+++ b/src/HttpClientFactory/Http/test/Logging/RedactedLogValueIntegrationTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using System.Net.Http;

--- a/src/HttpClientFactory/Http/test/TestTypedClient.cs
+++ b/src/HttpClientFactory/Http/test/TestTypedClient.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Net.Http;
 

--- a/src/HttpClientFactory/Polly/ref/Microsoft.Extensions.Http.Polly.netstandard2.0.cs
+++ b/src/HttpClientFactory/Polly/ref/Microsoft.Extensions.Http.Polly.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/HttpClientFactory/Polly/src/DependencyInjection/PollyHttpClientBuilderExtensions.cs
+++ b/src/HttpClientFactory/Polly/src/DependencyInjection/PollyHttpClientBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Polly.Registry;

--- a/src/HttpClientFactory/Polly/src/HttpRequestMessageExtensions.cs
+++ b/src/HttpClientFactory/Polly/src/HttpRequestMessageExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Http;
 using System;

--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Polly/src/Properties/AssemblyInfo.cs
+++ b/src/HttpClientFactory/Polly/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 
 

--- a/src/HttpClientFactory/Polly/test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
+++ b/src/HttpClientFactory/Polly/test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/HttpClientFactory/Polly/test/HttpRequestMessageExtensionsTest.cs
+++ b/src/HttpClientFactory/Polly/test/HttpRequestMessageExtensionsTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/Polly/test/PolicyHttpMessageHandlerTest.cs
+++ b/src/HttpClientFactory/Polly/test/PolicyHttpMessageHandlerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/HttpClientFactory/samples/HttpClientFactorySample/Program.cs
+++ b/src/HttpClientFactory/samples/HttpClientFactorySample/Program.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net.Http;

--- a/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
+++ b/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Abstractions/src/EventId.cs
+++ b/src/Logging/Logging.Abstractions/src/EventId.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Abstractions/src/FormattedLogValues.cs
+++ b/src/Logging/Logging.Abstractions/src/FormattedLogValues.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Logging/Logging.Abstractions/src/IExternalScopeProvider.cs
+++ b/src/Logging/Logging.Abstractions/src/IExternalScopeProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Abstractions/src/ILogger.cs
+++ b/src/Logging/Logging.Abstractions/src/ILogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Abstractions/src/ILoggerFactory.cs
+++ b/src/Logging/Logging.Abstractions/src/ILoggerFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Abstractions/src/ILoggerProvider.cs
+++ b/src/Logging/Logging.Abstractions/src/ILoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Abstractions/src/ILoggerT.cs
+++ b/src/Logging/Logging.Abstractions/src/ILoggerT.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Abstractions/src/ISupportExternalScope.cs
+++ b/src/Logging/Logging.Abstractions/src/ISupportExternalScope.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Abstractions/src/LogLevel.cs
+++ b/src/Logging/Logging.Abstractions/src/LogLevel.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/Logging/Logging.Abstractions/src/LogValuesFormatter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Logging/Logging.Abstractions/src/LoggerExtensions.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Abstractions/src/LoggerExternalScopeProvider.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerExternalScopeProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Logging/Logging.Abstractions/src/LoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Internal;

--- a/src/Logging/Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerMessage.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Logging/Logging.Abstractions/src/LoggerT.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerT.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Internal;

--- a/src/Logging/Logging.Abstractions/src/NullLogger.cs
+++ b/src/Logging/Logging.Abstractions/src/NullLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Abstractions/src/NullLoggerFactory.cs
+++ b/src/Logging/Logging.Abstractions/src/NullLoggerFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Abstractions
 {

--- a/src/Logging/Logging.Abstractions/src/NullLoggerProvider.cs
+++ b/src/Logging/Logging.Abstractions/src/NullLoggerProvider.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Abstractions
 {

--- a/src/Logging/Logging.Abstractions/src/NullLoggerT.cs
+++ b/src/Logging/Logging.Abstractions/src/NullLoggerT.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Analyzers/src/Descriptors.cs
+++ b/src/Logging/Logging.Analyzers/src/Descriptors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 

--- a/src/Logging/Logging.Analyzers/src/LogFormatAnalyzer.cs
+++ b/src/Logging/Logging.Analyzers/src/LogFormatAnalyzer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/Logging/Logging.Analyzers/test/LogFormatAnalyzerTests.cs
+++ b/src/Logging/Logging.Analyzers/test/LogFormatAnalyzerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Logging/Logging.Analyzers/test/LoggingDiagnosticRunner.cs
+++ b/src/Logging/Logging.Analyzers/test/LoggingDiagnosticRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;

--- a/src/Logging/Logging.AzureAppServices/ref/Microsoft.Extensions.Logging.AzureAppServices.netstandard2.0.cs
+++ b/src/Logging/Logging.AzureAppServices/ref/Microsoft.Extensions.Logging.AzureAppServices.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.AzureAppServices/src/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/AzureAppServicesLoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging.AzureAppServices/src/AzureBlobLoggerOptions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/AzureBlobLoggerOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.AzureAppServices/src/AzureFileLoggerOptions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/AzureFileLoggerOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.AzureAppServices/src/BatchLoggerConfigureOptions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BatchLoggerConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Logging/Logging.AzureAppServices/src/BatchingLogger.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BatchingLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Logging/Logging.AzureAppServices/src/BatchingLoggerOptions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BatchingLoggerOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.AzureAppServices/src/BatchingLoggerProvider.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BatchingLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Logging/Logging.AzureAppServices/src/BlobAppendReferenceWrapper.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BlobAppendReferenceWrapper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Logging/Logging.AzureAppServices/src/BlobLoggerConfigureOptions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BlobLoggerConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/Logging/Logging.AzureAppServices/src/BlobLoggerProvider.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BlobLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.AzureAppServices/src/ConfigurationBasedLevelSwitcher.cs
+++ b/src/Logging/Logging.AzureAppServices/src/ConfigurationBasedLevelSwitcher.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.AzureAppServices/src/FileLoggerConfigureOptions.cs
+++ b/src/Logging/Logging.AzureAppServices/src/FileLoggerConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.AzureAppServices/src/FileLoggerProvider.cs
+++ b/src/Logging/Logging.AzureAppServices/src/FileLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Logging/Logging.AzureAppServices/src/ICloudAppendBlob.cs
+++ b/src/Logging/Logging.AzureAppServices/src/ICloudAppendBlob.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Logging/Logging.AzureAppServices/src/IWebAppContext.cs
+++ b/src/Logging/Logging.AzureAppServices/src/IWebAppContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.AzureAppServices
 {

--- a/src/Logging/Logging.AzureAppServices/src/LogMessage.cs
+++ b/src/Logging/Logging.AzureAppServices/src/LogMessage.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.AzureAppServices/src/Properties/AssemblyInfo.cs
+++ b/src/Logging/Logging.AzureAppServices/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 
 

--- a/src/Logging/Logging.AzureAppServices/src/SiteConfigurationProvider.cs
+++ b/src/Logging/Logging.AzureAppServices/src/SiteConfigurationProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.AzureAppServices/src/WebAppContext.cs
+++ b/src/Logging/Logging.AzureAppServices/src/WebAppContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.AzureAppServices/test/AzureAppendBlobTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/AzureAppendBlobTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Logging/Logging.AzureAppServices/test/AzureBlobSinkTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/AzureBlobSinkTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.AzureAppServices/test/AzureDiagnosticsConfigurationProviderTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/AzureDiagnosticsConfigurationProviderTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Logging/Logging.AzureAppServices/test/BatchingLoggerProviderTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/BatchingLoggerProviderTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.AzureAppServices/test/ConfigureOptionsTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/ConfigureOptionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.AzureAppServices/test/FileLoggerTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/FileLoggerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Logging/Logging.AzureAppServices/test/LoggerBuilderExtensionsTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/LoggerBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.AzureAppServices/test/ManualIntervalControl.cs
+++ b/src/Logging/Logging.AzureAppServices/test/ManualIntervalControl.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 

--- a/src/Logging/Logging.AzureAppServices/test/OptionsWrapperMonitor.cs
+++ b/src/Logging/Logging.AzureAppServices/test/OptionsWrapperMonitor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Options;

--- a/src/Logging/Logging.AzureAppServices/test/TestBlobSink.cs
+++ b/src/Logging/Logging.AzureAppServices/test/TestBlobSink.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Logging/Logging.AzureAppServices/test/TestBlobSink.cs
+++ b/src/Logging/Logging.AzureAppServices/test/TestBlobSink.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Logging/Logging.AzureAppServices/test/TestFileLoggerProvider.cs
+++ b/src/Logging/Logging.AzureAppServices/test/TestFileLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Logging/Logging.AzureAppServices/test/WebConfigurationLevelSwitchTests.cs
+++ b/src/Logging/Logging.AzureAppServices/test/WebConfigurationLevelSwitchTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.Configuration/ref/Microsoft.Extensions.Logging.Configuration.netcoreapp.cs
+++ b/src/Logging/Logging.Configuration/ref/Microsoft.Extensions.Logging.Configuration.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Configuration/ref/Microsoft.Extensions.Logging.Configuration.netstandard2.0.cs
+++ b/src/Logging/Logging.Configuration/ref/Microsoft.Extensions.Logging.Configuration.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Configuration/src/ILoggerProviderConfiguration.cs
+++ b/src/Logging/Logging.Configuration/src/ILoggerProviderConfiguration.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Logging/Logging.Configuration/src/ILoggerProviderConfigurationFactory.cs
+++ b/src/Logging/Logging.Configuration/src/ILoggerProviderConfigurationFactory.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.Configuration/src/LoggerFilterConfigureOptions.cs
+++ b/src/Logging/Logging.Configuration/src/LoggerFilterConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/Logging.Configuration/src/LoggerProviderConfiguration.cs
+++ b/src/Logging/Logging.Configuration/src/LoggerProviderConfiguration.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Logging/Logging.Configuration/src/LoggerProviderConfigurationExtensions.cs
+++ b/src/Logging/Logging.Configuration/src/LoggerProviderConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Logging/Logging.Configuration/src/LoggerProviderConfigurationFactory.cs
+++ b/src/Logging/Logging.Configuration/src/LoggerProviderConfigurationFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.Configuration/src/LoggerProviderConfigureOptions.cs
+++ b/src/Logging/Logging.Configuration/src/LoggerProviderConfigureOptions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Logging/Logging.Configuration/src/LoggerProviderOptionsChangeTokenSource.cs
+++ b/src/Logging/Logging.Configuration/src/LoggerProviderOptionsChangeTokenSource.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Logging/Logging.Configuration/src/LoggingBuilderConfigurationExtensions.cs
+++ b/src/Logging/Logging.Configuration/src/LoggingBuilderConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src/Logging/Logging.Configuration/src/LoggingBuilderExtensions.cs
+++ b/src/Logging/Logging.Configuration/src/LoggingBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging.Configuration/src/LoggingConfiguration.cs
+++ b/src/Logging/Logging.Configuration/src/LoggingConfiguration.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Logging/Logging.Console/ref/Microsoft.Extensions.Logging.Console.netcoreapp.cs
+++ b/src/Logging/Logging.Console/ref/Microsoft.Extensions.Logging.Console.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Console/ref/Microsoft.Extensions.Logging.Console.netstandard2.0.cs
+++ b/src/Logging/Logging.Console/ref/Microsoft.Extensions.Logging.Console.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Console/src/AnsiLogConsole.cs
+++ b/src/Logging/Logging.Console/src/AnsiLogConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Logging/Logging.Console/src/AnsiSystemConsole.cs
+++ b/src/Logging/Logging.Console/src/AnsiSystemConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.IO;
 

--- a/src/Logging/Logging.Console/src/ConsoleLogger.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerFormat.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Console
 {

--- a/src/Logging/Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerFormat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.Extensions.Logging.Console

--- a/src/Logging/Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Logging/Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Logging/Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Logging/Logging.Console/src/IAnsiSystemConsole.cs
+++ b/src/Logging/Logging.Console/src/IAnsiSystemConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Console
 {

--- a/src/Logging/Logging.Console/src/IConsole.cs
+++ b/src/Logging/Logging.Console/src/IConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Console/src/LogMessageEntry.cs
+++ b/src/Logging/Logging.Console/src/LogMessageEntry.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Console/src/WindowsLogConsole.cs
+++ b/src/Logging/Logging.Console/src/WindowsLogConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Logging/Logging.Debug/ref/Microsoft.Extensions.Logging.Debug.netcoreapp.cs
+++ b/src/Logging/Logging.Debug/ref/Microsoft.Extensions.Logging.Debug.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Debug/ref/Microsoft.Extensions.Logging.Debug.netstandard2.0.cs
+++ b/src/Logging/Logging.Debug/ref/Microsoft.Extensions.Logging.Debug.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.Debug/src/DebugLogger.cs
+++ b/src/Logging/Logging.Debug/src/DebugLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.Debug/src/DebugLogger.debug.cs
+++ b/src/Logging/Logging.Debug/src/DebugLogger.debug.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 // We need to define the DEBUG symbol because we want the logger
 // to work even when this package is compiled on release. Otherwise,
 // the call to Debug.WriteLine will not be in the release binary

--- a/src/Logging/Logging.Debug/src/DebugLogger.debug.cs
+++ b/src/Logging/Logging.Debug/src/DebugLogger.debug.cs
@@ -1,6 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // We need to define the DEBUG symbol because we want the logger
 // to work even when this package is compiled on release. Otherwise,
 // the call to Debug.WriteLine will not be in the release binary

--- a/src/Logging/Logging.Debug/src/DebugLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.Debug/src/DebugLoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Logging/Logging.Debug/src/DebugLoggerProvider.cs
+++ b/src/Logging/Logging.Debug/src/DebugLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Debug
 {

--- a/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.netcoreapp.cs
+++ b/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.netstandard2.0.cs
+++ b/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.EventLog/src/EventLogLogger.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.EventLog/src/EventLogLoggerProvider.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Options;

--- a/src/Logging/Logging.EventLog/src/EventLogSettings.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogSettings.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.EventLog/src/EventLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.EventLog/src/EventLoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging.EventLog/src/IEventLog.cs
+++ b/src/Logging/Logging.EventLog/src/IEventLog.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 

--- a/src/Logging/Logging.EventLog/src/WindowsEventLog.cs
+++ b/src/Logging/Logging.EventLog/src/WindowsEventLog.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.netcoreapp.cs
+++ b/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.netstandard2.0.cs
+++ b/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.EventSource/src/EventLogFiltersConfigureOptions.cs
+++ b/src/Logging/Logging.EventSource/src/EventLogFiltersConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging.EventSource;
 using Microsoft.Extensions.Options;

--- a/src/Logging/Logging.EventSource/src/EventLogFiltersConfigureOptionsChangeSource.cs
+++ b/src/Logging/Logging.EventSource/src/EventLogFiltersConfigureOptionsChangeSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging.EventSource;
 using Microsoft.Extensions.Options;

--- a/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers;

--- a/src/Logging/Logging.EventSource/src/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging.EventSource/src/EventSourceLoggerProvider.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Logging/Logging.EventSource/src/ExceptionInfo.cs
+++ b/src/Logging/Logging.EventSource/src/ExceptionInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.EventSource/test/AssemblyInfo.cs
+++ b/src/Logging/Logging.EventSource/test/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Logging/Logging.EventSource/test/AzureAppServicesLoggerFactoryExtensionsTests.cs
+++ b/src/Logging/Logging.EventSource/test/AzureAppServicesLoggerFactoryExtensionsTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/src/Logging/Logging.EventSource/test/AzureAppServicesLoggerFactoryExtensionsTests.cs
+++ b/src/Logging/Logging.EventSource/test/AzureAppServicesLoggerFactoryExtensionsTests.cs
@@ -1,5 +1,5 @@
-﻿// // Copyright (c) .NET Foundation. All rights reserved.
-// // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
+++ b/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.Testing/src/AssemblyTestLog.cs
+++ b/src/Logging/Logging.Testing/src/AssemblyTestLog.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.Testing/src/BeginScopeContext.cs
+++ b/src/Logging/Logging.Testing/src/BeginScopeContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Testing
 {

--- a/src/Logging/Logging.Testing/src/CollectDumpAttribute.cs
+++ b/src/Logging/Logging.Testing/src/CollectDumpAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Logging/Logging.Testing/src/CollectDumpAttribute.cs
+++ b/src/Logging/Logging.Testing/src/CollectDumpAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.Testing/src/DumpCollector/DumpCollector.Windows.cs
+++ b/src/Logging/Logging.Testing/src/DumpCollector/DumpCollector.Windows.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.Testing/src/DumpCollector/DumpCollector.cs
+++ b/src/Logging/Logging.Testing/src/DumpCollector/DumpCollector.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/Logging/Logging.Testing/src/ITestSink.cs
+++ b/src/Logging/Logging.Testing/src/ITestSink.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Logging/Logging.Testing/src/ITestSink.cs
+++ b/src/Logging/Logging.Testing/src/ITestSink.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Concurrent;
 
 namespace Microsoft.Extensions.Logging.Testing

--- a/src/Logging/Logging.Testing/src/LogLevelAttribute.cs
+++ b/src/Logging/Logging.Testing/src/LogLevelAttribute.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Testing/src/LogValuesAssert.cs
+++ b/src/Logging/Logging.Testing/src/LogValuesAssert.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Logging/Logging.Testing/src/LogValuesAssert.cs
+++ b/src/Logging/Logging.Testing/src/LogValuesAssert.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging.Testing/src/LoggedTest/ILoggedTest.cs
+++ b/src/Logging/Logging.Testing/src/LoggedTest/ILoggedTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/Logging/Logging.Testing/src/LoggedTest/LoggedTest.cs
+++ b/src/Logging/Logging.Testing/src/LoggedTest/LoggedTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Reflection;
 using Microsoft.AspNetCore.Testing;

--- a/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
+++ b/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Logging/Logging.Testing/src/TestFrameworkFileLoggerAttribute.cs
+++ b/src/Logging/Logging.Testing/src/TestFrameworkFileLoggerAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.AspNetCore.Testing;

--- a/src/Logging/Logging.Testing/src/TestLogger.cs
+++ b/src/Logging/Logging.Testing/src/TestLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Testing/src/TestLoggerFactory.cs
+++ b/src/Logging/Logging.Testing/src/TestLoggerFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Testing
 {

--- a/src/Logging/Logging.Testing/src/TestLoggerProvider.cs
+++ b/src/Logging/Logging.Testing/src/TestLoggerProvider.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging.Testing
 {

--- a/src/Logging/Logging.Testing/src/TestLoggerT.cs
+++ b/src/Logging/Logging.Testing/src/TestLoggerT.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Testing/src/TestSink.cs
+++ b/src/Logging/Logging.Testing/src/TestSink.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Logging/Logging.Testing/src/WriteContext.cs
+++ b/src/Logging/Logging.Testing/src/WriteContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging.Testing/src/XunitLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.Testing/src/XunitLoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging.Testing/src/XunitLoggerProvider.cs
+++ b/src/Logging/Logging.Testing/src/XunitLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Logging/Logging.Testing/test/AssemblyTestLogTests.cs
+++ b/src/Logging/Logging.Testing/test/AssemblyTestLogTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Logging/Logging.Testing/test/LogValuesAssertTest.cs
+++ b/src/Logging/Logging.Testing/test/LogValuesAssertTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Logging/Logging.Testing/test/LogValuesAssertTest.cs
+++ b/src/Logging/Logging.Testing/test/LogValuesAssertTest.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/Logging/Logging.Testing/test/LoggedTestXunitTests.cs
+++ b/src/Logging/Logging.Testing/test/LoggedTestXunitTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using System.Reflection;

--- a/src/Logging/Logging.Testing/test/Properties/AssemblyInfo.cs
+++ b/src/Logging/Logging.Testing/test/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 

--- a/src/Logging/Logging.Testing/test/Properties/AssemblyInfo.cs
+++ b/src/Logging/Logging.Testing/test/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;

--- a/src/Logging/Logging.Testing/test/TestTestOutputHelper.cs
+++ b/src/Logging/Logging.Testing/test/TestTestOutputHelper.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Logging/Logging.Testing/test/XunitLoggerProviderTest.cs
+++ b/src/Logging/Logging.Testing/test/XunitLoggerProviderTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text.RegularExpressions;

--- a/src/Logging/Logging.TraceSource/ref/Microsoft.Extensions.Logging.TraceSource.netcoreapp.cs
+++ b/src/Logging/Logging.TraceSource/ref/Microsoft.Extensions.Logging.TraceSource.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.TraceSource/ref/Microsoft.Extensions.Logging.TraceSource.netstandard2.0.cs
+++ b/src/Logging/Logging.TraceSource/ref/Microsoft.Extensions.Logging.TraceSource.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Logging/Logging.TraceSource/src/TraceSourceFactoryExtensions.cs
+++ b/src/Logging/Logging.TraceSource/src/TraceSourceFactoryExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.TraceSource/src/TraceSourceLogger.cs
+++ b/src/Logging/Logging.TraceSource/src/TraceSourceLogger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging.TraceSource/src/TraceSourceLoggerProvider.cs
+++ b/src/Logging/Logging.TraceSource/src/TraceSourceLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Logging/Logging.TraceSource/src/TraceSourceScope.cs
+++ b/src/Logging/Logging.TraceSource/src/TraceSourceScope.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Logging/Logging/perf/EventSourceBenchmark.cs
+++ b/src/Logging/Logging/perf/EventSourceBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/Logging/Logging/perf/LogValuesBenchmarks.cs
+++ b/src/Logging/Logging/perf/LogValuesBenchmarks.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using BenchmarkDotNet.Attributes;

--- a/src/Logging/Logging/perf/LoggingBenchmarkBase.cs
+++ b/src/Logging/Logging/perf/LoggingBenchmarkBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Logging/Logging/perf/LoggingOverheadBenchmark.cs
+++ b/src/Logging/Logging/perf/LoggingOverheadBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using BenchmarkDotNet.Attributes;

--- a/src/Logging/Logging/perf/ScopesOverheadBenchmark.cs
+++ b/src/Logging/Logging/perf/ScopesOverheadBenchmark.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netcoreapp.cs
+++ b/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netstandard2.0.cs
+++ b/src/Logging/Logging/ref/Microsoft.Extensions.Logging.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Logging/Logging/src/DefaultLoggerLevelConfigureOptions.cs
+++ b/src/Logging/Logging/src/DefaultLoggerLevelConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Logging/Logging/src/FilterLoggingBuilderExtensions.cs
+++ b/src/Logging/Logging/src/FilterLoggingBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/Logging/src/ILoggingBuilder.cs
+++ b/src/Logging/Logging/src/ILoggingBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Logging/Logging/src/Logger.cs
+++ b/src/Logging/Logging/src/Logger.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging/src/LoggerFactory.cs
+++ b/src/Logging/Logging/src/LoggerFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/Logging/src/LoggerFilterOptions.cs
+++ b/src/Logging/Logging/src/LoggerFilterOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Logging/Logging/src/LoggerFilterRule.cs
+++ b/src/Logging/Logging/src/LoggerFilterRule.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging/src/LoggerInformation.cs
+++ b/src/Logging/Logging/src/LoggerInformation.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging/src/LoggerRuleSelector.cs
+++ b/src/Logging/Logging/src/LoggerRuleSelector.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging/src/LoggingBuilder.cs
+++ b/src/Logging/Logging/src/LoggingBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Logging/Logging/src/LoggingBuilderExtensions.cs
+++ b/src/Logging/Logging/src/LoggingBuilderExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Logging/Logging/src/LoggingServiceCollectionExtensions.cs
+++ b/src/Logging/Logging/src/LoggingServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/Logging/Logging/src/ProviderAliasAttribute.cs
+++ b/src/Logging/Logging/src/ProviderAliasAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/Logging/src/StaticFilterOptionsMonitor.cs
+++ b/src/Logging/Logging/src/StaticFilterOptionsMonitor.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Options;

--- a/src/Logging/samples/SampleApp/LoggerExtensions.cs
+++ b/src/Logging/samples/SampleApp/LoggerExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/Logging/samples/SampleApp/Program.cs
+++ b/src/Logging/samples/SampleApp/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Logging/shared/NullExternalScopeProvider.cs
+++ b/src/Logging/shared/NullExternalScopeProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/shared/NullScope.cs
+++ b/src/Logging/shared/NullScope.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/test/AnsiLogConsoleTest.cs
+++ b/src/Logging/test/AnsiLogConsoleTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging.Console;

--- a/src/Logging/test/Console/ConsoleContext.cs
+++ b/src/Logging/test/Console/ConsoleContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/test/Console/ConsoleSink.cs
+++ b/src/Logging/test/Console/ConsoleSink.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Logging/test/Console/TestConsole.cs
+++ b/src/Logging/test/Console/TestConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging.Console;

--- a/src/Logging/test/ConsoleLoggerTest.cs
+++ b/src/Logging/test/ConsoleLoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/DebugLoggerTest.cs
+++ b/src/Logging/test/DebugLoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging.Test;
 using Xunit;

--- a/src/Logging/test/EventIdTest.cs
+++ b/src/Logging/test/EventIdTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Xunit;

--- a/src/Logging/test/EventIdTest.cs
+++ b/src/Logging/test/EventIdTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Logging/test/EventLogLoggerTest.cs
+++ b/src/Logging/test/EventLogLoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/FormattedLogValuesTest.cs
+++ b/src/Logging/test/FormattedLogValuesTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Logging/test/LogLevelEnumTest.cs
+++ b/src/Logging/test/LogLevelEnumTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/LoggerBuilderExtensionsTests.cs
+++ b/src/Logging/test/LoggerBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/test/LoggerExtensionsTest.cs
+++ b/src/Logging/test/LoggerExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Logging/test/LoggerFactoryExtensionsTest.cs
+++ b/src/Logging/test/LoggerFactoryExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging.Testing;
 using Moq;

--- a/src/Logging/test/LoggerFactoryTest.cs
+++ b/src/Logging/test/LoggerFactoryTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Logging/test/LoggerFactoryTest.cs
+++ b/src/Logging/test/LoggerFactoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/LoggerFilterTest.cs
+++ b/src/Logging/test/LoggerFilterTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/LoggerMessageTest.cs
+++ b/src/Logging/test/LoggerMessageTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/LoggerProviderConfigurationFactoryTest.cs
+++ b/src/Logging/test/LoggerProviderConfigurationFactoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/test/LoggerProviderConfigurationTests.cs
+++ b/src/Logging/test/LoggerProviderConfigurationTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;

--- a/src/Logging/test/LoggerTest.cs
+++ b/src/Logging/test/LoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/LoggingServiceCollectionExtensionsTest.cs
+++ b/src/Logging/test/LoggingServiceCollectionExtensionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/test/NullLoggerFactoryTest.cs
+++ b/src/Logging/test/NullLoggerFactoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Logging/test/NullLoggerTest.cs
+++ b/src/Logging/test/NullLoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Logging/test/ProviderAliasAttribute.cs
+++ b/src/Logging/test/ProviderAliasAttribute.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/test/TestConfiguration.cs
+++ b/src/Logging/test/TestConfiguration.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Logging/test/TestLoggerBuilder.cs
+++ b/src/Logging/test/TestLoggerBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Logging/test/TestLoggerExtensions.cs
+++ b/src/Logging/test/TestLoggerExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Logging/test/TestLoggerProvider.cs
+++ b/src/Logging/test/TestLoggerProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Logging.Testing;

--- a/src/Logging/test/TraceSourceLoggerProviderTest.cs
+++ b/src/Logging/test/TraceSourceLoggerProviderTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if NET472
 using System;

--- a/src/Logging/test/TraceSourceLoggerProviderTest.cs
+++ b/src/Logging/test/TraceSourceLoggerProviderTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if NET472

--- a/src/Logging/test/TraceSourceLoggerTest.cs
+++ b/src/Logging/test/TraceSourceLoggerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using Xunit;

--- a/src/Logging/test/TraceSourceScopeTest.cs
+++ b/src/Logging/test/TraceSourceScopeTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 using Xunit;

--- a/src/Options/ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.netcoreapp.cs
+++ b/src/Options/ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Options/ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.netstandard2.0.cs
+++ b/src/Options/ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Options/ConfigurationExtensions/src/ConfigurationChangeTokenSource.cs
+++ b/src/Options/ConfigurationExtensions/src/ConfigurationChangeTokenSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Options/ConfigurationExtensions/src/ConfigureFromConfigurationOptions.cs
+++ b/src/Options/ConfigurationExtensions/src/ConfigureFromConfigurationOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Options/ConfigurationExtensions/src/NamedConfigureFromConfigurationOptions.cs
+++ b/src/Options/ConfigurationExtensions/src/NamedConfigureFromConfigurationOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Options/ConfigurationExtensions/src/OptionsBuilderConfigurationExtensions.cs
+++ b/src/Options/ConfigurationExtensions/src/OptionsBuilderConfigurationExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Options/ConfigurationExtensions/src/OptionsConfigurationServiceCollectionExtensions.cs
+++ b/src/Options/ConfigurationExtensions/src/OptionsConfigurationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Configuration;

--- a/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netcoreapp.cs
+++ b/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netstandard2.0.cs
+++ b/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Options/DataAnnotations/src/DataAnnotationValidateOptions.cs
+++ b/src/Options/DataAnnotations/src/DataAnnotationValidateOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
+++ b/src/Options/DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Options;
 

--- a/src/Options/Options/ref/Microsoft.Extensions.Options.netcoreapp.cs
+++ b/src/Options/Options/ref/Microsoft.Extensions.Options.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
+++ b/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Options/Options/src/ConfigureNamedOptions.cs
+++ b/src/Options/Options/src/ConfigureNamedOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/ConfigureOptions.cs
+++ b/src/Options/Options/src/ConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/IConfigureNamedOptions.cs
+++ b/src/Options/Options/src/IConfigureNamedOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/IConfigureOptions.cs
+++ b/src/Options/Options/src/IConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/IOptions.cs
+++ b/src/Options/Options/src/IOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/IOptionsChangeTokenSource.cs
+++ b/src/Options/Options/src/IOptionsChangeTokenSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Primitives;
 

--- a/src/Options/Options/src/IOptionsFactory.cs
+++ b/src/Options/Options/src/IOptionsFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/IOptionsMonitor.cs
+++ b/src/Options/Options/src/IOptionsMonitor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/IOptionsMonitorCache.cs
+++ b/src/Options/Options/src/IOptionsMonitorCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/IOptionsSnapshot.cs
+++ b/src/Options/Options/src/IOptionsSnapshot.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/IPostConfigureOptions.cs
+++ b/src/Options/Options/src/IPostConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/IValidateOptions.cs
+++ b/src/Options/Options/src/IValidateOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/Options.cs
+++ b/src/Options/Options/src/Options.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/OptionsBuilder.cs
+++ b/src/Options/Options/src/OptionsBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Options/Options/src/OptionsCache.cs
+++ b/src/Options/Options/src/OptionsCache.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Options/Options/src/OptionsFactory.cs
+++ b/src/Options/Options/src/OptionsFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/Options/src/OptionsManager.cs
+++ b/src/Options/Options/src/OptionsManager.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options
 {

--- a/src/Options/Options/src/OptionsMonitor.cs
+++ b/src/Options/Options/src/OptionsMonitor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/Options/src/OptionsMonitorExtensions.cs
+++ b/src/Options/Options/src/OptionsMonitorExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/OptionsServiceCollectionExtensions.cs
+++ b/src/Options/Options/src/OptionsServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/Options/src/OptionsValidationException.cs
+++ b/src/Options/Options/src/OptionsValidationException.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/Options/src/OptionsWrapper.cs
+++ b/src/Options/Options/src/OptionsWrapper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/OptionsWrapper.cs
+++ b/src/Options/Options/src/OptionsWrapper.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace Microsoft.Extensions.Options

--- a/src/Options/Options/src/PostConfigureOptions.cs
+++ b/src/Options/Options/src/PostConfigureOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/ValidateOptions.cs
+++ b/src/Options/Options/src/ValidateOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/Options/src/ValidateOptionsResult.cs
+++ b/src/Options/Options/src/ValidateOptionsResult.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/test/ComplexOptions.cs
+++ b/src/Options/test/ComplexOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Options/test/FakeChangeToken.cs
+++ b/src/Options/test/FakeChangeToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/Options/test/FakeOptions.cs
+++ b/src/Options/test/FakeOptions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options.Tests
 {

--- a/src/Options/test/FakeOptionsFactory.cs
+++ b/src/Options/test/FakeOptionsFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Options.Tests
 {

--- a/src/Options/test/OptionsBuilderTest.cs
+++ b/src/Options/test/OptionsBuilderTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/test/OptionsFactoryTests.cs
+++ b/src/Options/test/OptionsFactoryTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Options/test/OptionsMonitorTest.cs
+++ b/src/Options/test/OptionsMonitorTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/test/OptionsSnapshotTest.cs
+++ b/src/Options/test/OptionsSnapshotTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Options/test/OptionsTest.cs
+++ b/src/Options/test/OptionsTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Options/test/OptionsValidationTests.cs
+++ b/src/Options/test/OptionsValidationTests.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Primitives/perf/Properties/AssemblyInfo.cs
+++ b/src/Primitives/perf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 [assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/Primitives/perf/StringSegmentBenchmark.cs
+++ b/src/Primitives/perf/StringSegmentBenchmark.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 

--- a/src/Primitives/perf/StringSegmentBenchmark.cs
+++ b/src/Primitives/perf/StringSegmentBenchmark.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using BenchmarkDotNet.Attributes;

--- a/src/Primitives/perf/StringValuesBenchmark.cs
+++ b/src/Primitives/perf/StringValuesBenchmark.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/Primitives/perf/StringValuesBenchmark.cs
+++ b/src/Primitives/perf/StringValuesBenchmark.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;

--- a/src/Primitives/ref/Microsoft.Extensions.Primitives.netcoreapp.cs
+++ b/src/Primitives/ref/Microsoft.Extensions.Primitives.netcoreapp.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Primitives
 {

--- a/src/Primitives/ref/Microsoft.Extensions.Primitives.netstandard2.0.cs
+++ b/src/Primitives/ref/Microsoft.Extensions.Primitives.netstandard2.0.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Extensions.Primitives
 {

--- a/src/Primitives/src/CancellationChangeToken.cs
+++ b/src/Primitives/src/CancellationChangeToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Primitives/src/ChangeToken.cs
+++ b/src/Primitives/src/ChangeToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Primitives/src/CompositeChangeToken.cs
+++ b/src/Primitives/src/CompositeChangeToken.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Primitives/src/Extensions.cs
+++ b/src/Primitives/src/Extensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Text;
 

--- a/src/Primitives/src/IChangeToken.cs
+++ b/src/Primitives/src/IChangeToken.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Primitives/src/InplaceStringBuilder.cs
+++ b/src/Primitives/src/InplaceStringBuilder.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Primitives/src/StringSegment.cs
+++ b/src/Primitives/src/StringSegment.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/Primitives/src/StringSegmentComparer.cs
+++ b/src/Primitives/src/StringSegmentComparer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Primitives/src/StringTokenizer.cs
+++ b/src/Primitives/src/StringTokenizer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Primitives/src/ThrowHelper.cs
+++ b/src/Primitives/src/ThrowHelper.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Primitives/test/ChangeTokenTest.cs
+++ b/src/Primitives/test/ChangeTokenTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Primitives/test/CompositeChangeTokenTest.cs
+++ b/src/Primitives/test/CompositeChangeTokenTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Primitives/test/InplaceStringBuilderTest.cs
+++ b/src/Primitives/test/InplaceStringBuilderTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.Extensions.Primitives;

--- a/src/Primitives/test/StringSegmentTest.cs
+++ b/src/Primitives/test/StringSegmentTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/Primitives/test/StringTokenizerTest.cs
+++ b/src/Primitives/test/StringTokenizerTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Xunit;

--- a/src/Primitives/test/StringValuesTests.cs
+++ b/src/Primitives/test/StringValuesTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Shared/src/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/Shared/src/ActivatorUtilities/ActivatorUtilities.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Shared/src/ActivatorUtilities/ActivatorUtilitiesConstructorAttribute.cs
+++ b/src/Shared/src/ActivatorUtilities/ActivatorUtilitiesConstructorAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/src/ActivatorUtilities/ObjectFactory.cs
+++ b/src/Shared/src/ActivatorUtilities/ObjectFactory.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/src/BenchmarkRunner/AspNetCoreBenchmarkAttribute.cs
+++ b/src/Shared/src/BenchmarkRunner/AspNetCoreBenchmarkAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Shared/src/BenchmarkRunner/DefaultCoreConfig.cs
+++ b/src/Shared/src/BenchmarkRunner/DefaultCoreConfig.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;

--- a/src/Shared/src/BenchmarkRunner/DefaultCoreDebugConfig.cs
+++ b/src/Shared/src/BenchmarkRunner/DefaultCoreDebugConfig.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;

--- a/src/Shared/src/BenchmarkRunner/DefaultCorePerfLabConfig.cs
+++ b/src/Shared/src/BenchmarkRunner/DefaultCorePerfLabConfig.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;

--- a/src/Shared/src/BenchmarkRunner/DefaultCoreProfileConfig.cs
+++ b/src/Shared/src/BenchmarkRunner/DefaultCoreProfileConfig.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;

--- a/src/Shared/src/BenchmarkRunner/DefaultCoreValidationConfig.cs
+++ b/src/Shared/src/BenchmarkRunner/DefaultCoreValidationConfig.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;

--- a/src/Shared/src/BenchmarkRunner/ParameterizedJobConfigAttribute.cs
+++ b/src/Shared/src/BenchmarkRunner/ParameterizedJobConfigAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/src/BenchmarkRunner/ParamsDisplayInfoColumn.cs
+++ b/src/Shared/src/BenchmarkRunner/ParamsDisplayInfoColumn.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Reports;

--- a/src/Shared/src/BenchmarkRunner/Program.cs
+++ b/src/Shared/src/BenchmarkRunner/Program.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Shared/src/CommandLineUtils/CommandLine/AnsiConsole.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/AnsiConsole.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandArgument.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandArgument.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandOption.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandOption.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandOptionType.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandOptionType.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 namespace Microsoft.Extensions.CommandLineUtils

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandParsingException.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandParsingException.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/src/CommandLineUtils/Utilities/ArgumentEscaper.cs
+++ b/src/Shared/src/CommandLineUtils/Utilities/ArgumentEscaper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Shared/src/CommandLineUtils/Utilities/DotNetMuxer.cs
+++ b/src/Shared/src/CommandLineUtils/Utilities/DotNetMuxer.cs
@@ -1,6 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // System.AppContext.GetData is not available in these frameworks
 #if !NET451 && !NET452 && !NET46 && !NET461
 

--- a/src/Shared/src/CommandLineUtils/Utilities/DotNetMuxer.cs
+++ b/src/Shared/src/CommandLineUtils/Utilities/DotNetMuxer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 // System.AppContext.GetData is not available in these frameworks
 #if !NET451 && !NET452 && !NET46 && !NET461
 

--- a/src/Shared/src/EmptyDisposable.cs
+++ b/src/Shared/src/EmptyDisposable.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/src/HashCodeCombiner/HashCodeCombiner.cs
+++ b/src/Shared/src/HashCodeCombiner/HashCodeCombiner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Shared/src/HostFactoryResolver/HostFactoryResolver.cs
+++ b/src/Shared/src/HostFactoryResolver/HostFactoryResolver.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/Shared/src/NonCapturingTimer/NonCapturingTimer.cs
+++ b/src/Shared/src/NonCapturingTimer/NonCapturingTimer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Shared/src/ParameterDefaultValue/ParameterDefaultValue.cs
+++ b/src/Shared/src/ParameterDefaultValue/ParameterDefaultValue.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/Shared/src/ProviderAliasUtilities/ProviderAliasUtilities.cs
+++ b/src/Shared/src/ProviderAliasUtilities/ProviderAliasUtilities.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/Shared/src/ReferenceAssemblyInfo.cs
+++ b/src/Shared/src/ReferenceAssemblyInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // Reference assemblies should have the ReferenceAssemblyAttribute. 
 [assembly:System.Runtime.CompilerServices.ReferenceAssembly]

--- a/src/Shared/src/TypeNameHelper/TypeNameHelper.cs
+++ b/src/Shared/src/TypeNameHelper/TypeNameHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Shared/src/ValueStopwatch/ValueStopwatch.cs
+++ b/src/Shared/src/ValueStopwatch/ValueStopwatch.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Shared/test/ArgumentEscaperTests.cs
+++ b/src/Shared/test/ArgumentEscaperTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Shared/test/CommandLineApplicationTests.cs
+++ b/src/Shared/test/CommandLineApplicationTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Shared/test/DotNetMuxerTests.cs
+++ b/src/Shared/test/DotNetMuxerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if NETCOREAPP
 using System.IO;

--- a/src/Shared/test/HashCodeCombinerTest.cs
+++ b/src/Shared/test/HashCodeCombinerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/Shared/test/HostFactoryResolverTests.cs
+++ b/src/Shared/test/HostFactoryResolverTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 using System;

--- a/src/Shared/test/NonCapturingTimerTest.cs
+++ b/src/Shared/test/NonCapturingTimerTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Shared/test/SingleThreadedSynchronizationContext.cs
+++ b/src/Shared/test/SingleThreadedSynchronizationContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Shared/test/TypeNameHelperTest.cs
+++ b/src/Shared/test/TypeNameHelperTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Shared/test/ValueStopwatchTest.cs
+++ b/src/Shared/test/ValueStopwatchTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Shared/testassets/BuildWebHostInvalidSignature/Program.cs
+++ b/src/Shared/testassets/BuildWebHostInvalidSignature/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 

--- a/src/Shared/testassets/BuildWebHostPatternTestSite/Program.cs
+++ b/src/Shared/testassets/BuildWebHostPatternTestSite/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 

--- a/src/Shared/testassets/CreateHostBuilderInvalidSignature/Program.cs
+++ b/src/Shared/testassets/CreateHostBuilderInvalidSignature/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 

--- a/src/Shared/testassets/CreateHostBuilderPatternTestSite/Program.cs
+++ b/src/Shared/testassets/CreateHostBuilderPatternTestSite/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 

--- a/src/Shared/testassets/CreateWebHostBuilderInvalidSignature/Program.cs
+++ b/src/Shared/testassets/CreateWebHostBuilderInvalidSignature/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 

--- a/src/Shared/testassets/CreateWebHostBuilderPatternTestSite/Program.cs
+++ b/src/Shared/testassets/CreateWebHostBuilderPatternTestSite/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using MockHostTypes;
 

--- a/src/Shared/testassets/MockHostTypes/Host.cs
+++ b/src/Shared/testassets/MockHostTypes/Host.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/testassets/MockHostTypes/HostBuilder.cs
+++ b/src/Shared/testassets/MockHostTypes/HostBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace MockHostTypes
 {

--- a/src/Shared/testassets/MockHostTypes/IHost.cs
+++ b/src/Shared/testassets/MockHostTypes/IHost.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/testassets/MockHostTypes/IHostBuilder.cs
+++ b/src/Shared/testassets/MockHostTypes/IHostBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace MockHostTypes
 {

--- a/src/Shared/testassets/MockHostTypes/IWebHost.cs
+++ b/src/Shared/testassets/MockHostTypes/IWebHost.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/testassets/MockHostTypes/IWebHostBuilder.cs
+++ b/src/Shared/testassets/MockHostTypes/IWebHostBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace MockHostTypes
 {

--- a/src/Shared/testassets/MockHostTypes/ServiceProvider.cs
+++ b/src/Shared/testassets/MockHostTypes/ServiceProvider.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/testassets/MockHostTypes/WebHost.cs
+++ b/src/Shared/testassets/MockHostTypes/WebHost.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Shared/testassets/MockHostTypes/WebHostBuilder.cs
+++ b/src/Shared/testassets/MockHostTypes/WebHostBuilder.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace MockHostTypes
 {

--- a/src/TestingUtils/Internal.AspNetCore.Analyzers/src/PubternalityAnalyzer.cs
+++ b/src/TestingUtils/Internal.AspNetCore.Analyzers/src/PubternalityAnalyzer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;

--- a/src/TestingUtils/Internal.AspNetCore.Analyzers/src/PubturnalityDescriptors.cs
+++ b/src/TestingUtils/Internal.AspNetCore.Analyzers/src/PubturnalityDescriptors.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 

--- a/src/TestingUtils/Internal.AspNetCore.Analyzers/test/PubternabilityAnalyzerTests.cs
+++ b/src/TestingUtils/Internal.AspNetCore.Analyzers/test/PubternabilityAnalyzerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/Assert.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/Assert.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
 using Xunit.Sdk;

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/CodeFixRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/CodeFixRunner.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticAnalyzerRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticAnalyzerRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticLocation.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticLocation.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticVerifier.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticVerifier.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/TestSource.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/TestSource.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/CultureReplacer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/CultureReplacer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ExceptionAssertions.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ExceptionAssertions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/FlakyOn.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/FlakyOn.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/FlakyOn.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/FlakyOn.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.AspNetCore.Testing
 {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Testing
 {
     public static class HelixQueues

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ITestMethodLifecycle.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ITestMethodLifecycle.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/RepeatAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/RepeatAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/RepeatContext.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/RepeatContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ReplaceCulture.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ReplaceCulture.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ShortClassNameAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ShortClassNameAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright(c) .NET Foundation.All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ShortClassNameAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/ShortClassNameAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TaskExtensions.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TaskExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestContext.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Reflection;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestFileOutputContext.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestFileOutputContext.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestOutputDirectoryAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestOutputDirectoryAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestPathUtilities.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestPathUtilities.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestPlatformHelper.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/TestPlatformHelper.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/CollectingEventListener.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/CollectingEventListener.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/CollectingEventListener.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/CollectingEventListener.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventAssert.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventAssert.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventAssert.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventAssert.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventSourceTestBase.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventSourceTestBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventSourceTestBase.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/EventSourceTestBase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/contentFiles/cs/netstandard2.0/EventSourceTestCollection.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/contentFiles/cs/netstandard2.0/EventSourceTestCollection.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 namespace Microsoft.AspNetCore.Testing.Tracing
 {
     // This file comes from Microsoft.AspNetCore.Testing and has to be defined in the test assembly.

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/contentFiles/cs/netstandard2.0/EventSourceTestCollection.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/contentFiles/cs/netstandard2.0/EventSourceTestCollection.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.AspNetCore.Testing.Tracing
 {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestAssemblyRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestAssemblyRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestCaseRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestCaseRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestClassRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestClassRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestCollectionRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestCollectionRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestFramework.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestFramework.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Reflection;
 using Xunit.Abstractions;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestFrameworkExecutor.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestFrameworkExecutor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestInvoker.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestInvoker.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestMethodRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestMethodRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTestRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTheoryTestCaseRunner.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AspNetTheoryTestCaseRunner.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AssemblyFixtureAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/AssemblyFixtureAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalFactAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalFactAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalFactDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalFactDiscoverer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit.Abstractions;
 using Xunit.Sdk;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalTheoryAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalTheoryAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalTheoryDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ConditionalTheoryDiscoverer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/DockerOnlyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/DockerOnlyAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/EnvironmentVariableSkipConditionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/EnvironmentVariableSkipConditionAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Xunit.Sdk;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTraitDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTraitDiscoverer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTraitDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTraitDiscoverer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Xunit.Abstractions;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FrameworkSkipConditionAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/IEnvironmentVariable.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/IEnvironmentVariable.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.AspNetCore.Testing
 {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ITestCondition.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/ITestCondition.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.AspNetCore.Testing
 {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MaximumOSVersionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MaximumOSVersionAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MinimumOsVersionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MinimumOsVersionAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/OSSkipConditionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/OSSkipConditionAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/OperatingSystems.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/OperatingSystems.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/RuntimeFrameworks.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/RuntimeFrameworks.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/SkipOnCIAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/SkipOnCIAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/SkipOnHelixAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/SkipOnHelixAttribute.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/SkippedTestCase.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/SkippedTestCase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/TestMethodExtensions.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/TestMethodExtensions.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Linq;
 using Xunit.Abstractions;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WORKAROUND_SkippedDataRowTestCase.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WORKAROUND_SkippedDataRowTestCase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.ComponentModel;
 using Xunit.Abstractions;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WORKAROUND_SkippedDataRowTestCase.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WORKAROUND_SkippedDataRowTestCase.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.ComponentModel;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WindowsVersions.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WindowsVersions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/AlphabeticalOrderer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/AlphabeticalOrderer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/AssemblyFixtureTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/AssemblyFixtureTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/CollectingEventListenerTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/CollectingEventListenerTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing.Tracing;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/CollectingEventListenerTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/CollectingEventListenerTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ConditionalFactTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ConditionalFactTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ConditionalTheoryTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ConditionalTheoryTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/DockerTests.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/DockerTests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/EnvironmentVariableSkipConditionTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/EnvironmentVariableSkipConditionTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ExceptionAssertTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ExceptionAssertTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/HttpClientSlimTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/HttpClientSlimTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionAttributeTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MinimumOSVersionAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MinimumOSVersionAttributeTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MinimumOSVersionTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MinimumOSVersionTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionAttributeTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/Properties/AssemblyInfo.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Testing;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/Properties/AssemblyInfo.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/RepeatTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/RepeatTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Xunit;
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ReplaceCultureAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/ReplaceCultureAttributeTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Globalization;
 using Xunit;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/SkipOnCITests.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/SkipOnCITests.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Microsoft.AspNetCore.Testing;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TaskExtensionsTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TaskExtensionsTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestAssemblyFixture.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestAssemblyFixture.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.AspNetCore.Testing
 {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestCollectionFixture.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestCollectionFixture.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.AspNetCore.Testing
 {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestContextTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestContextTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestPathUtilitiesTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestPathUtilitiesTest.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestPlatformHelperTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/TestPlatformHelperTest.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Testing;
 using Xunit;


### PR DESCRIPTION
Closes #2965 

Reviewing commit-by-commit is recommended.

* The first commit "fixes" the headers for the repository so we are in a known good state to move forward with the change
* All changes to "normal" source files were made by a Fix All in Solution using an upcoming Roslyn feature for file headers
* All changes to generated reference assembly sources were made by running `dotnet msbuild /t:GenerateReferenceSource`
* The change to **src/Shared/src/ReferenceAssemblyInfo.cs** was applied manually (it's not part of any solution, and also not generated by `/t:GenerateReferenceSource`)