### PR TITLE
Flow singleton IServiceProvider through to DataAnnotationValidateOptions

### DIFF
--- a/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netcoreapp.cs
+++ b/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netcoreapp.cs
@@ -13,8 +13,9 @@ namespace Microsoft.Extensions.Options
 {
     public partial class DataAnnotationValidateOptions<TOptions> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
     {
-        public DataAnnotationValidateOptions(string name) { }
+        public DataAnnotationValidateOptions(string name, System.IServiceProvider serviceProvider = null) { }
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public System.IServiceProvider ServiceProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
     }
 }

--- a/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netstandard2.0.cs
+++ b/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.netstandard2.0.cs
@@ -13,8 +13,9 @@ namespace Microsoft.Extensions.Options
 {
     public partial class DataAnnotationValidateOptions<TOptions> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
     {
-        public DataAnnotationValidateOptions(string name) { }
+        public DataAnnotationValidateOptions(string name, System.IServiceProvider serviceProvider = null) { }
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public System.IServiceProvider ServiceProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
     }
 }

--- a/src/Options/DataAnnotations/src/DataAnnotationValidateOptions.cs
+++ b/src/Options/DataAnnotations/src/DataAnnotationValidateOptions.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 
 namespace Microsoft.Extensions.Options
 {
@@ -19,15 +18,22 @@ namespace Microsoft.Extensions.Options
         /// Constructor.
         /// </summary>
         /// <param name="name">The name of the option.</param>
-        public DataAnnotationValidateOptions(string name)
+        /// <param name="serviceProvider">The service provider that will be passed to the <see cref="ValidationContext"/>.</param>
+        public DataAnnotationValidateOptions(string name, IServiceProvider serviceProvider = null)
         {
             Name = name;
+            ServiceProvider = serviceProvider;
         }
 
         /// <summary>
         /// The options name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// The service provider passed to the <see cref="ValidationContext"/>.
+        /// </summary>
+        public IServiceProvider ServiceProvider { get; }
 
         /// <summary>
         /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
@@ -42,7 +48,7 @@ namespace Microsoft.Extensions.Options
             {
                 var validationResults = new List<ValidationResult>();
                 if (Validator.TryValidateObject(options,
-                    new ValidationContext(options, serviceProvider: null, items: null),
+                    new ValidationContext(options, serviceProvider: ServiceProvider, items: null),
                     validationResults,
                     validateAllProperties: true))
                 {

--- a/src/Options/DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
+++ b/src/Options/DataAnnotations/src/OptionsBuilderDataAnnotationsExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that additional calls can be chained.</returns>
         public static OptionsBuilder<TOptions> ValidateDataAnnotations<TOptions>(this OptionsBuilder<TOptions> optionsBuilder) where TOptions : class
         {
-            optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>(new DataAnnotationValidateOptions<TOptions>(optionsBuilder.Name));
+            optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>((serviceProvider) => new DataAnnotationValidateOptions<TOptions>(optionsBuilder.Name, serviceProvider));
             return optionsBuilder;
         }
     }


### PR DESCRIPTION
Summary of the changes
 - Passes the `IServiceProvider` used to resolve the `IValidateOptions` singleton service through to the `ValidationContext` that is received by the `ValidationAttribute`s. This lets `ValidationAttribute` implementations call `ValidationContext.GetService` in order to resolve dependencies to help them do their validation at runtime.
 - Does not add any tests because it didn't look like DataAnnotationValidateOptions had any to begin with.
 - Added the new ctor parameter as an optional parameter so that existing custom users of this class didn't break

Addresses #N/A (should I create a bug first?)