### PR TITLE
Add support for int keyed dictionaries to configuration binder.

### DIFF
--- a/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
+++ b/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
@@ -393,7 +393,11 @@ namespace Microsoft.Extensions.Configuration
             var valueType = typeInfo.GenericTypeArguments[1];
             var keyTypeIsEnum = keyType.GetTypeInfo().IsEnum;
 
-            if (keyType != typeof(string) && !keyTypeIsEnum)
+            if (keyType != typeof(string) && !keyTypeIsEnum
+                && keyType != typeof(int)
+                && keyType != typeof(uint)
+                && keyType != typeof(short)
+                && keyType != typeof(ushort))
             {
                 // We only support string and enum keys
                 return;
@@ -417,6 +421,11 @@ namespace Microsoft.Extensions.Configuration
                     else if (keyTypeIsEnum)
                     {
                         var key = Enum.Parse(keyType, child.Key);
+                        setter.SetValue(dictionary, item, new object[] { key });
+                    }
+                    else
+                    {
+                        var key = Convert.ChangeType(child.Key, keyType);
                         setter.SetValue(dictionary, item, new object[] { key });
                     }
                 }

--- a/src/Configuration/Config.Binder/test/ConfigurationCollectionBindingTests.cs
+++ b/src/Configuration/Config.Binder/test/ConfigurationCollectionBindingTests.cs
@@ -194,6 +194,49 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         }
 
         [Fact]
+        public void GetIntDictionary()
+        {
+            GetIntDictionaryT<int>(1, 2, 3);
+        }
+        [Fact]
+        public void GetUIntDictionary()
+        {
+            GetIntDictionaryT<uint>(1, 2, 3);
+        }
+        [Fact]
+        public void GetShortDictionary()
+        {
+            GetIntDictionaryT<short>(1, 2, 3);
+        }
+        [Fact]
+        public void GetUShortDictionary()
+        {
+            GetIntDictionaryT<ushort>(1, 2, 3);
+        }
+        private void GetIntDictionaryT<T>(T k1, T k2, T k3)
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"StringDictionary:1", "val_1"},
+                {"StringDictionary:2", "val_2"},
+                {"StringDictionary:3", "val_3"}
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new Dictionary<T, string>();
+            config.GetSection("StringDictionary").Bind(options);
+
+            Assert.Equal(3, options.Count);
+
+            Assert.Equal("val_1", options[k1]);
+            Assert.Equal("val_2", options[k2]);
+            Assert.Equal("val_3", options[k3]);
+        }
+
+        [Fact]
         public void GetStringList()
         {
             var input = new Dictionary<string, string>


### PR DESCRIPTION
Up to now, only string or enum keys are supported for dictionaries in `ConfigurationBinder`.
This simple proposal adds support for integer keys:

- int
- uint
- short
- ushort

