### PR TITLE
Fixed variable name typo

### DIFF
--- a/src/Shared/src/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/Shared/src/ActivatorUtilities/ActivatorUtilities.cs
@@ -111,10 +111,10 @@ namespace Microsoft.Extensions.Internal
             var argumentArray = Expression.Parameter(typeof(object[]), "argumentArray");
             var factoryExpressionBody = BuildFactoryExpression(constructor, parameterMap, provider, argumentArray);
 
-            var factoryLamda = Expression.Lambda<Func<IServiceProvider, object[], object>>(
+            var factoryLambda = Expression.Lambda<Func<IServiceProvider, object[], object>>(
                 factoryExpressionBody, provider, argumentArray);
 
-            var result = factoryLamda.Compile();
+            var result = factoryLambda.Compile();
             return result.Invoke;
         }
 


### PR DESCRIPTION
The variable was named `factoryLamda`, which is a bit wrong because the only definition I've found for "lamda" is "_London Academy of Music and Dramatic Art_". I'm pretty sure this has nothing to do with music and art, so I just replaced it with `factoryLambda` 😄 
