### PR TITLE
Revert SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.3.20168.3"
+    "version": "5.0.100-preview.1.20106.1"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.3.20168.3",
+    "dotnet": "5.0.100-preview.1.20106.1",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppInternalPackageVersion)"


### PR DESCRIPTION
Newer SDK brings in the net5.0 TFM. AspNetCore isn't ready for that yet. Trying to downgrade SDK so Extensions produces netcoreapp5.0 again.

