### PR TITLE
Remove dependency on netstandard.library

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -74,10 +74,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c39af4fc45c05e862815c34239b33de3b0259705</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0-preview.3.20160.8">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>73268c790b7ff31c98a292efbc583e25562074d7</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,6 @@
     <MicrosoftNETCoreAppRefPackageVersion>5.0.0-preview.3.20174.7</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-preview.3.20174.7</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-preview.3.20174.7</MicrosoftNETCoreAppInternalPackageVersion>
-    <NETStandardLibraryRefPackageVersion>2.1.0-preview.3.20160.8</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->
     <MicrosoftBclAsyncInterfacesPackageVersion>1.0.0</MicrosoftBclAsyncInterfacesPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.3.20174.7</MicrosoftWin32RegistryPackageVersion>

--- a/eng/Workarounds.AfterArcade.targets
+++ b/eng/Workarounds.AfterArcade.targets
@@ -17,16 +17,6 @@
       />
   </ItemGroup>
 
-  <ItemGroup>
-    <KnownFrameworkReference Update="NETStandard.Library">
-      <!-- Workaround for netstandard2.1 projects until we can get a preview 8 SDK containing https://github.com/dotnet/sdk/pull/3463 fix. -->
-      <RuntimeFrameworkName>NETStandard.Library</RuntimeFrameworkName>
-
-      <!-- Only update the targeting pack version for preview builds. -->
-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1' and '$(IsServicingBuild)' != 'true'">$(NETStandardLibraryRefPackageVersion)</TargetingPackVersion>
-    </KnownFrameworkReference>
-  </ItemGroup>
-
   <!-- Workaround for implicit references added by Arcade based on project name. Non-test projects should not reference these projects. -->
   <ItemGroup Condition="'$(IsUnitTestProject)' == 'false'">
     <PackageReference Remove="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
This package isn't being produced out of dotnet/runtime anymore - we should just use the default version that is bundled with the SDK rather than listing a dependency on it.

CC @dagood @Pilchie @ericstj

Branch created by following the instructions in https://github.com/dotnet/aspnetcore-internal/blob/master/docs/engineering/servicing-and-preview-fixes.md