### PR TITLE
Allow injection of ConnectionMultiplexer

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         /// The configuration used to connect to Redis.
         /// </summary>
         public string Configuration { get; set; }
-        
+
         /// <summary>
         /// The configuration used to connect to Redis.
         /// This is preferred over Configuration.
@@ -31,9 +31,9 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         public string InstanceName { get; set; }
 
         /// <summary>
-        /// The redis connection factory.
+        /// Redis connection multiplexer.
         /// </summary>
-        public Func<Task<IConnectionMultiplexer>> ConnectionFactory;
+        public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
 
         RedisCacheOptions IOptions<RedisCacheOptions>.Value
         {

--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         public string InstanceName { get; set; }
 
         /// <summary>
-        /// Redis connection multiplexer.
+        /// Redis connection multiplexer that is used to connect to Redis.
+        /// This is preferred over ConfigurationOptions and Configuration.
         /// </summary>
         public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
 

--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
@@ -27,6 +29,11 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         /// The Redis instance name.
         /// </summary>
         public string InstanceName { get; set; }
+
+        /// <summary>
+        /// The redis connection factory.
+        /// </summary>
+        public Func<Task<IConnectionMultiplexer>> ConnectionFactory;
 
         RedisCacheOptions IOptions<RedisCacheOptions>.Value
         {

--- a/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Microsoft.Extensions.Caching.StackExchangeRedis
@@ -22,7 +23,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
             var services = new ServiceCollection();
 
             // Act
-            services.AddStackExchangeRedisCache(options => { });
+            services.AddStackExchangeRedisCache(options => { options.ConnectionMultiplexer = new Mock<IConnectionMultiplexer>().Object; });
 
             // Assert
             var distributedCache = services.FirstOrDefault(desc => desc.ServiceType == typeof(IDistributedCache));
@@ -39,7 +40,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
             services.AddScoped(typeof(IDistributedCache), sp => Mock.Of<IDistributedCache>());
 
             // Act
-            services.AddStackExchangeRedisCache(options => { });
+            services.AddStackExchangeRedisCache(options => { options.ConnectionMultiplexer = new Mock<IConnectionMultiplexer>().Object; });
 
             // Assert
             var serviceProvider = services.BuildServiceProvider();
@@ -56,7 +57,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         {
             var services = new ServiceCollection();
 
-            Assert.Same(services, services.AddStackExchangeRedisCache(_ => { }));
+            Assert.Same(services, services.AddStackExchangeRedisCache(options => { options.ConnectionMultiplexer = new Mock<IConnectionMultiplexer>().Object; }));
         }
     }
 }

--- a/src/Caching/StackExchangeRedis/test/RedisCacheTests.cs
+++ b/src/Caching/StackExchangeRedis/test/RedisCacheTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Microsoft.Extensions.Caching.StackExchangeRedis
+{
+    public class RedisCacheTests
+    {
+        [Fact]
+        public void Remove_OptionHasConnectionFactory_CallsConnectionFactoryToCreateConnection()
+        {
+            // Arrange
+            var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+            var databaseMock = new Mock<IDatabase>();
+            connectionMultiplexerMock.Setup(c => c.GetDatabase(-1, null)).Returns(databaseMock.Object);
+
+            var options = new RedisCacheOptions {
+                ConnectionFactory = () => Task.FromResult(connectionMultiplexerMock.Object)
+            };
+            var redisCache = new RedisCache(options);
+            var key = "key";
+
+            // Act
+            redisCache.Remove(key);
+
+            // Assert
+            databaseMock.Verify((d) => d.KeyDelete(key, CommandFlags.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task RemoveAsync_OptionHasConnectionFactory_CallsConnectionFactoryToCreateConnection()
+        {
+            // Arrange
+            var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+            var databaseMock = new Mock<IDatabase>();
+            connectionMultiplexerMock.Setup(c => c.GetDatabase(-1, null)).Returns(databaseMock.Object);
+
+            var options = new RedisCacheOptions {
+                ConnectionFactory = () => Task.FromResult(connectionMultiplexerMock.Object)
+            };
+            var redisCache = new RedisCache(options);
+            var key = "key";
+
+            // Act
+            await redisCache.RemoveAsync(key);
+
+            // Assert
+            databaseMock.Verify((d) => d.KeyDeleteAsync(key, CommandFlags.None), Times.Once);
+        }
+    }
+}

--- a/src/Caching/StackExchangeRedis/test/RedisCacheTests.cs
+++ b/src/Caching/StackExchangeRedis/test/RedisCacheTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Moq;
 using StackExchange.Redis;
 using Xunit;
@@ -11,7 +10,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
     public class RedisCacheTests
     {
         [Fact]
-        public void Remove_OptionHasConnectionFactory_CallsConnectionFactoryToCreateConnection()
+        public void Remove_OptionHasConnectionMultiplexer_CallsConnectionMultiplexerGetDatabase()
         {
             // Arrange
             var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
@@ -19,7 +18,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
             connectionMultiplexerMock.Setup(c => c.GetDatabase(-1, null)).Returns(databaseMock.Object);
 
             var options = new RedisCacheOptions {
-                ConnectionFactory = () => Task.FromResult(connectionMultiplexerMock.Object)
+                ConnectionMultiplexer = connectionMultiplexerMock.Object
             };
             var redisCache = new RedisCache(options);
             var key = "key";
@@ -29,27 +28,6 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             // Assert
             databaseMock.Verify((d) => d.KeyDelete(key, CommandFlags.None), Times.Once);
-        }
-
-        [Fact]
-        public async Task RemoveAsync_OptionHasConnectionFactory_CallsConnectionFactoryToCreateConnection()
-        {
-            // Arrange
-            var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
-            var databaseMock = new Mock<IDatabase>();
-            connectionMultiplexerMock.Setup(c => c.GetDatabase(-1, null)).Returns(databaseMock.Object);
-
-            var options = new RedisCacheOptions {
-                ConnectionFactory = () => Task.FromResult(connectionMultiplexerMock.Object)
-            };
-            var redisCache = new RedisCache(options);
-            var key = "key";
-
-            // Act
-            await redisCache.RemoveAsync(key);
-
-            // Assert
-            databaseMock.Verify((d) => d.KeyDeleteAsync(key, CommandFlags.None), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Summary of the changes
 - Add ConnectionFactory property in RedisCacheOptions
 - RedisCache class uses ConnectionFactory to create connection objects when it is set

Addresses #718
