### PR TITLE
Add new Polly DI extension method for HttpClientFactory

### DIFF
--- a/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -61,5 +61,42 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return registry;
         }
+
+        /// <summary>
+        /// Registers an empty <see cref="PolicyRegistry"/> in the service collection with service types
+        /// <see cref="IPolicyRegistry{String}"/>, and <see cref="IReadOnlyPolicyRegistry{String}"/> and
+        /// uses the specified delegate to configure it.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureRegistry">A delegate that is used to configure an <see cref="IPolicyRegistry{String}"/>.</param>
+        /// <returns>The provided <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddPolicyRegistry(this IServiceCollection services, Action<IServiceProvider, IPolicyRegistry<string>> configureRegistry)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureRegistry == null)
+            {
+                throw new ArgumentNullException(nameof(configureRegistry));
+            }
+
+            // Create an empty registry, configure it and register it as an instance.
+            // This is the best way to get a single instance registered using both interfaces.
+            services.AddSingleton(serviceProvider =>
+            {
+                var registry = new PolicyRegistry();
+
+                configureRegistry(serviceProvider, registry);
+
+                return registry;
+            });
+
+            services.AddSingleton<IPolicyRegistry<string>>(serviceProvider => serviceProvider.GetRequiredService<PolicyRegistry>());
+            services.AddSingleton<IReadOnlyPolicyRegistry<string>>(serviceProvider => serviceProvider.GetRequiredService<PolicyRegistry>());
+
+            return services;
+        }
     }
 }

--- a/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -8,8 +8,8 @@ using Polly.Registry;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-   /// Provides convenience extension methods to register <see cref="IPolicyRegistry{String}"/> and 
-   /// <see cref="IReadOnlyPolicyRegistry{String}"/> in the service collection.
+    /// Provides convenience extension methods to register <see cref="IPolicyRegistry{String}"/> and 
+    /// <see cref="IReadOnlyPolicyRegistry{String}"/> in the service collection.
     /// </summary>
     public static class PollyServiceCollectionExtensions
     {
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// the newly created registry.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
-        /// <returns>The newly created <see cref="PolicyRegistry"/>.</returns>
+        /// <returns>The newly created <see cref="IPolicyRegistry{String}"/>.</returns>
         public static IPolicyRegistry<string> AddPolicyRegistry(this IServiceCollection services)
         {
             if (services == null)

--- a/src/HttpClientFactory/Polly/test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
+++ b/src/HttpClientFactory/Polly/test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public async Task AddTransientHttpErrorPolicy_AddsPolicyHandler_HandlesStatusCode(HttpStatusCode statusCode)
         {
             // Arrange
-            var handler = new SequenceMessageHandler()
+            using var handler = new SequenceMessageHandler()
             {
                 Responses =
                 {
@@ -303,7 +303,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public async Task AddTransientHttpErrorPolicy_AddsPolicyHandler_HandlesHttpRequestException()
         {
             // Arrange
-            var handler = new SequenceMessageHandler()
+            using var handler = new SequenceMessageHandler()
             {
                 Responses =
                 {

--- a/src/HttpClientFactory/Polly/test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
+++ b/src/HttpClientFactory/Polly/test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
@@ -415,6 +415,59 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.True(registry.ContainsKey("host2"));
         }
 
+        [Fact]
+        public async Task AddPolicyHandlerFromRegistry_WithConfigureDelegate_AddsPolicyHandler()
+        {
+            var options = new PollyPolicyOptions()
+            {
+                PolicyName = "retrypolicy"
+            };
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSingleton(options);
+
+            serviceCollection.AddPolicyRegistry((serviceProvider, registry) =>
+            {
+                string policyName = serviceProvider.GetRequiredService<PollyPolicyOptions>().PolicyName;
+
+                registry.Add<IAsyncPolicy<HttpResponseMessage>>(policyName, RetryPolicy);
+            });
+
+            HttpMessageHandlerBuilder builder = null;
+
+            // Act1
+            serviceCollection.AddHttpClient("example.com", c => c.BaseAddress = new Uri("http://example.com"))
+                .AddPolicyHandlerFromRegistry(options.PolicyName)
+                .ConfigureHttpMessageHandlerBuilder(b =>
+                {
+                    b.PrimaryHandler = PrimaryHandler;
+
+                    builder = b;
+                });
+
+            var services = serviceCollection.BuildServiceProvider();
+            var factory = services.GetRequiredService<IHttpClientFactory>();
+
+            // Act2
+            var client = factory.CreateClient("example.com");
+
+            // Assert
+            Assert.NotNull(client);
+
+            Assert.Collection(
+                builder.AdditionalHandlers,
+                h => Assert.IsType<LoggingScopeHttpMessageHandler>(h),
+                h => Assert.IsType<PolicyHttpMessageHandler>(h),
+                h => Assert.IsType<LoggingHttpMessageHandler>(h));
+
+            // Act 3
+            var response = await client.SendAsync(new HttpRequestMessage());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        }
+
         // Throws an exception or fails on even numbered requests, otherwise succeeds.
         private class FaultyMessageHandler : DelegatingHandler
         {
@@ -446,6 +499,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 var func = Responses[CallCount++ % Responses.Count];
                 return Task.FromResult(func(request));
             }
+        }
+
+        private class PollyPolicyOptions
+        {
+            public string PolicyName { get; set; }
         }
     }
 }


### PR DESCRIPTION
This pull request adds the following new overload to the Polly extensions for HttpClientFactory:

```csharp
public static IServiceCollection AddPolicyRegistry(
    this IServiceCollection services,
    Action<IServiceProvider, IPolicyRegistry<string>> configureRegistry)
```

The existing two registrations allow a policy registry to be registered and then configured directly, but there isn't an overload that takes a delegate and provides the `IServiceProvider` to allow the policies to be configured based on other registered services, such as settings loaded from `IConfiguration`.

I've added a unit test that demonstrates the use case of using another service to configure the policies at the point the policy registry dependency is first resolved.

I've also tidied up a few minor trivial things I found while making the change, which I can split into a separate PR if necessary.