### PR TITLE
Package references updates

### DIFF
--- a/docs/ReferenceChanges.md
+++ b/docs/ReferenceChanges.md
@@ -1,0 +1,50 @@
+Package: Microsoft.Extensions.Configuration.Binder
+  TFM: .NETStandard2.0
+    Removed:
+      Microsoft.Extensions.Configuration
+Package: Microsoft.Extensions.Configuration.Json
+  TFM: .NETStandard2.0
+    Removed:
+      System.Threading.Tasks.Extensions
+Package: Microsoft.Extensions.DependencyInjection
+  TFM: .NETFramework4.6.1
+    Added:
+      System.Threading.Tasks.Extensions
+  TFM: .NETStandard2.0
+    Added:
+      System.Threading.Tasks.Extensions
+Package: Microsoft.Extensions.Hosting.Abstractions
+  TFM: .NETCoreApp5.0
+    Removed:
+      Microsoft.Extensions.Logging.Abstractions
+  TFM: .NETStandard2.0
+    Removed:
+      Microsoft.Extensions.Logging.Abstractions
+    Added:
+      System.Threading.Tasks.Extensions
+Package: Microsoft.Extensions.Logging
+  TFM: .NETCoreApp5.0
+    Removed:
+      Microsoft.Extensions.Configuration.Binder
+  TFM: .NETStandard2.0
+    Removed:
+      Microsoft.Extensions.Configuration.Binder
+Package: Microsoft.Extensions.Logging.Console
+  TFM: .NETCoreApp5.0
+    Removed:
+      Microsoft.Extensions.Configuration.Abstractions
+  TFM: .NETStandard2.0
+    Removed:
+      Microsoft.Extensions.Configuration.Abstractions
+Package: Microsoft.Extensions.Logging.EventLog
+  TFM: .NETFramework4.6.1
+    Removed:
+      System.Diagnostics.EventLog
+Package: Microsoft.Extensions.Logging.EventSource
+  TFM: .NETStandard2.0
+    Removed:
+      System.Threading.Tasks.Extensions
+Package: Microsoft.Extensions.Options
+  TFM: .NETStandard2.0
+    Removed:
+      System.ComponentModel.Annotations

--- a/docs/ReferenceChanges.md
+++ b/docs/ReferenceChanges.md
@@ -6,13 +6,6 @@ Package: Microsoft.Extensions.Configuration.Json
   TFM: .NETStandard2.0
     Removed:
       System.Threading.Tasks.Extensions
-Package: Microsoft.Extensions.DependencyInjection
-  TFM: .NETFramework4.6.1
-    Added:
-      System.Threading.Tasks.Extensions
-  TFM: .NETStandard2.0
-    Added:
-      System.Threading.Tasks.Extensions
 Package: Microsoft.Extensions.Hosting.Abstractions
   TFM: .NETCoreApp5.0
     Removed:
@@ -20,8 +13,6 @@ Package: Microsoft.Extensions.Hosting.Abstractions
   TFM: .NETStandard2.0
     Removed:
       Microsoft.Extensions.Logging.Abstractions
-    Added:
-      System.Threading.Tasks.Extensions
 Package: Microsoft.Extensions.Logging
   TFM: .NETCoreApp5.0
     Removed:


### PR DESCRIPTION
Addresses item in https://github.com/dotnet/aspnetcore/issues/19254

As we discussed previously, we wanted to understand the changes in out package graph and make appropriate announcements. I made a quick analyzer that found the following.

I've noticed that dotnet/runtime does a few things differently:
1. If no code from a package dependency is actually used, it is not included as a dependency in the package produced. This can lead to breaking changes.
2. If code from a transitive dependency is used, it will be included as a direct dependency. Though this results in a different set of dependencies listed in the package, I believe it does not cause a breaking change, especially given that we service all of those dependencies.

I've opened this as a PR so we can review each change if necessary. However, I don't plan to check this in.