### PR TITLE
[release/3.1] Add npm package to BAR artifacts

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,17 @@
+<Project>
+    <PropertyGroup>
+        <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
+        <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
+
+        <PublishDependsOnTargets>$(PublishDependsOnTargets);_AddNpmPackagesToManifest</PublishDependsOnTargets>
+    </PropertyGroup>
+    <Target Name="_AddNpmPackagesToManifest">
+        <ItemGroup>
+            <ItemsToPushToBlobFeed Include="$(ArtifactsDir)\packages\**\*.tgz">
+                <IsShipping>true</IsShipping>
+                <PublishFlatContainer>true</PublishFlatContainer>
+                <RelativeBlobPath>npm/%(Filename)%(Extension)</RelativeBlobPath>
+            </ItemsToPushToBlobFeed>
+        </ItemGroup>
+    </Target>
+</Project>


### PR DESCRIPTION
This (attempts) to add the JS Interop NPM package to the shipping artifacts in BAR. The ones generated by dotnet/aspnetcore are and it makes our release process much more complicated that I have to go and find the right artifacts from AzDO instead of the files just being present in the drop share.

I say 'attempts' above because I've been hitting my head against a wall trying to "test" this. I *think* it does the right thing but can't figure out the MSBuild incantations necessary to actually generate an asset manifest to **see** if it works. Perhaps @wtgodbe or someone else from @dotnet/aspnet-build can help?

We'll know it's working if the `tgz` files appear in [barviz for dotnet-extensions](https://maestro-prod.westus2.cloudapp.azure.com/129/https:%2F%2Fgithub.com%2Fdotnet%2Fextensions/latest/graph), like the `jar`, `pom` and `tgz` files [already do for dotnet-aspnetcore](https://maestro-prod.westus2.cloudapp.azure.com/129/https:%2F%2Fgithub.com%2Fdotnet%2Faspnetcore/latest/graph)