### PR TITLE
[release/3.1] Move SDL validation to ringed release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,6 @@ variables:
     - name: _InternalRuntimeDownloadArgs
       value: ''
 
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-AspNet-SDLValidation-Params
-
 # CI and PR triggers
 trigger:
   batch: true
@@ -354,17 +350,3 @@ stages:
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: true
-        continueOnError: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "Extensions"
-        -TsaCodebaseName "Extensions"
-        -TsaPublish $True'

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,0 +1,9 @@
+-SourceToolsList @("policheck","credscan")
+-TsaInstanceURL https://devdiv.visualstudio.com/
+-TsaProjectName DEVDIV
+-TsaNotificationEmail aspnetcore-build@microsoft.com
+-TsaCodebaseAdmin REDMOND\kevinpi
+-TsaBugAreaPath DevDiv\ASP.NET Core
+-TsaIterationPath DevDiv
+-TsaOnboard $True
+-TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -5,5 +5,7 @@
 -TsaCodebaseAdmin REDMOND\kevinpi
 -TsaBugAreaPath DevDiv\ASP.NET Core
 -TsaIterationPath DevDiv
+-TsaRepositoryName Extensions
+-TsaCodebaseName Extensions
 -TsaOnboard $True
 -TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -3,7 +3,7 @@
 -TsaProjectName DEVDIV
 -TsaNotificationEmail aspnetcore-build@microsoft.com
 -TsaCodebaseAdmin REDMOND\kevinpi
--TsaBugAreaPath DevDiv\ASP.NET Core
+-TsaBugAreaPath "DevDiv\ASP.NET Core"
 -TsaIterationPath DevDiv
 -TsaRepositoryName Extensions
 -TsaCodebaseName Extensions


### PR DESCRIPTION
Moves SDL out of the repo build and into the ringed release pipeline, as per the goal of reducing build time. CC @Pilchie