### PR TITLE
Feature/consolelifetime bypass cancel

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <add key="darc-pub-dotnet-core-setup-57d5bbb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-57d5bbb5/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-corefx-8a3ffed" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-8a3ffed5/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-corefx-282d5b9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-corefx-282d5b9f/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -89,17 +89,17 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.20113.5">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.20213.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>15f00efd583eab4372b2e9ca25bd80ace5b119ad</Sha>
+      <Sha>1a55276ab9d16792cec595ba870df39a9d97d5ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.20113.5">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.20213.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>15f00efd583eab4372b2e9ca25bd80ace5b119ad</Sha>
+      <Sha>1a55276ab9d16792cec595ba870df39a9d97d5ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.20113.5">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.20213.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>15f00efd583eab4372b2e9ca25bd80ace5b119ad</Sha>
+      <Sha>1a55276ab9d16792cec595ba870df39a9d97d5ca</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.4.1-beta4-20127-10">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,7 @@
     <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
     <MicrosoftNETCorePlatformsPackageVersion>3.1.1</MicrosoftNETCorePlatformsPackageVersion>
     <!-- Packages from dotnet/arcade -->
-    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.20113.5</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.20213.4</MicrosoftDotNetGenAPIPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetVersion>3.4.1-beta4-20127-10</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -210,7 +210,14 @@ function InstallDotNet {
 
       local runtimeSourceFeedKey=''
       if [[ -n "${7:-}" ]]; then
-        decodedFeedKey=`echo $7 | base64 --decode`
+        # The 'base64' binary on alpine uses '-d' and doesn't support '--decode'
+        # '-d'. To work around this, do a simple detection and switch the parameter
+        # accordingly.
+        decodeArg="--decode"
+        if base64 --help 2>&1 | grep -q "BusyBox"; then
+            decodeArg="-d"
+        fi
+        decodedFeedKey=`echo $7 | base64 $decodeArg`
         runtimeSourceFeedKey="--feed-credential $decodedFeedKey"
       fi
 

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.20113.5",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.20113.5"
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.20213.4",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.20213.4"
   }
 }

--- a/src/Hosting/Hosting/src/ConsoleLifetimeOptions.cs
+++ b/src/Hosting/Hosting/src/ConsoleLifetimeOptions.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -10,5 +12,10 @@ namespace Microsoft.Extensions.Hosting
         /// The default is false.
         /// </summary>
         public bool SuppressStatusMessages { get; set; }
+
+        /// <summary>
+        /// Indicates if host lifetime shouldn't handle the <see cref="Console.CancelKeyPress"/> event.
+        /// </summary>
+        public bool IgnoreCancelKeyPress { get; set; }
     }
 }

--- a/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
@@ -58,7 +58,11 @@ namespace Microsoft.Extensions.Hosting.Internal
             }
 
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
-            Console.CancelKeyPress += OnCancelKeyPress;
+
+            if (!Options.IgnoreCancelKeyPress)
+            {
+                Console.CancelKeyPress += OnCancelKeyPress;
+            }
 
             // Console applications start immediately.
             return Task.CompletedTask;
@@ -79,7 +83,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         private void OnProcessExit(object sender, EventArgs e)
         {
             ApplicationLifetime.StopApplication();
-            if(!_shutdownBlock.WaitOne(HostOptions.ShutdownTimeout))
+            if (!_shutdownBlock.WaitOne(HostOptions.ShutdownTimeout))
             {
                 Logger.LogInformation("Waiting for the host to be disposed. Ensure all 'IHost' instances are wrapped in 'using' blocks.");
             }


### PR DESCRIPTION
When trying to use Generic Host in an Android app, calling `Host.CreateDefaultHost()` to initiate it.

When calling `host.Start()`, calls `ConsoleLifetime.WaitForStartAsync(token)` under the hood, which calls `Console.CancelKeyPress += OnCancelKeyPress;`, that throws a `PlatformNotSupportedException`.

I tried copying the `ConsoleLifetime` file to my project, and removed that line. Then at service config I added it to the service registration:

```c#
servicesBuilder.AddSingleton<IHostLifetime, AppConsoleLifetime>();
```

It worked like a charm.
This PR is a proof of concept. Would be happy to work on it, add tests or whatever required.

Usage:

```c#
this.Host =
  Host
  .CreateDefaultBuilder()
  .UseConsoleLifetime(consoleLifetimeOptions => 
    consoleLifetimeOptions.IgnoreCancelKeyPress = true)
  .ConfigureLogging(...)
  .ConfigureServices(...)
  .Build();

Host.Start();
```

Note: My branch is based on `release/3.1`.