### PR TITLE
[master] Do not pass `/p:OfficialBuildId=A.Number` into Linux build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,33 +180,16 @@ stages:
         displayName: 'Ubuntu 16.04'
         pool:
           vmImage: ubuntu-16.04
-        variables:
-        # Only enable publishing in official builds.
-        - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: _OfficialBuildArgs
-            value: -p:OfficialBuildId=$(Build.BuildNumber)
-        # else
-        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          - name: _OfficialBuildArgs
-            value: ''
         strategy:
           matrix:
             ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
               Debug:
                 _BuildConfig: Debug
-                _SignType: none
-                _DotNetPublishToBlobFeed : false
             Release:
               _BuildConfig: Release
-              _SignType: none
-              _DotNetPublishToBlobFeed : false
         steps:
         - checkout: self
           clean: true
-        - task: NodeTool@0
-          displayName: Install Node 10.x
-          inputs:
-            versionSpec: 10.x
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
           - task: Bash@3
             displayName: Setup Private Feeds Credentials
@@ -263,12 +246,8 @@ stages:
             ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
               Debug:
                 _BuildConfig: Debug
-                _SignType: none
-                _DotNetPublishToBlobFeed : false
             Release:
               _BuildConfig: Release
-              _SignType: none
-              _DotNetPublishToBlobFeed : false
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
- causes symbol publication to be "real" i.e. not a dry run
- mandatory followup to #3242

nits:
- remove extra `$(_SignType)` and `$(_DotNetPublishtoBlobFeed)` variables
- do not install `nodejs` in Lunix build (no longer needed)