### PR TITLE
Prepare for strict coherency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,51 +10,51 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.ComponentModel.Annotations" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.IO.Pipelines" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Reflection.Metadata" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Text.Json" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>
@@ -224,7 +224,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>71b580038fb704df63e03c6b7ae7d2c6a4fdd71d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.7.20321.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.7.20321.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1f4d0db2339c37d75723d063827fd2a4c6e2ecef</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,7 +26,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d908270add914db0e9fb3ce72e93c410e8f0f95a</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="5.0.0-preview.7.20321.2">
+    <Dependency Name="System.IO.Pipelines" Version="5.0.0-preview.8.20323.9">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d908270add914db0e9fb3ce72e93c410e8f0f95a</Sha>
     </Dependency>


### PR DESCRIPTION
Strict coherency means that if your repo declares a dependency with a CPD attribute, the CPD parent must have a direct dependency on that dependency.
This means for extensions that it should remove the CPD attributes altogether because they do not do anything and of course runtime can't have a dependency on binaries produced in the same build.

Reasons for this approach over the current approach:
- This eliminates some ambiguous tie-breaking scenarios that are very problematic and dangerous in servicing
- Those tie breaking scenarios require the use of BAR to break the ties. If the DB data were to be lost then the tie-breaking would do unexpected things.