### PR TITLE
Use legacy MyGet feeds

### DIFF
--- a/eng/Sources.props
+++ b/eng/Sources.props
@@ -5,9 +5,8 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' ">
       $(RestoreSources);
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
+      https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://api.nuget.org/v3/index.json;
     </RestoreSources>


### PR DESCRIPTION
As part of [moving to Azure Artifacts from MyGet](https://github.com/dotnet/arcade/blob/master/Documentation/MigrationPlan/MyGetFeeds.md), point all MyGet feed sources to new Azure Artifacts feed.

@dougbu FYI, from email.