### PR TITLE
Update branding to 2.1.23

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <ExtensionsBaselineVersion>2.1.21</ExtensionsBaselineVersion>
+    <ExtensionsBaselineVersion>2.1.22</ExtensionsBaselineVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.Caching.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Caching.Abstractions' ">

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -1,4 +1,4 @@
-﻿<Baseline Version="2.1.21">
+﻿<Baseline Version="2.1.22">
   <Package Id="Microsoft.Extensions.Caching.Abstractions" Version="2.1.2" />
   <Package Id="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
   <Package Id="Microsoft.Extensions.Caching.Redis" Version="2.1.2" />

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -11,7 +11,7 @@
       Microsoft.Extensions.Configuration.Binder;
     </PackagesInPatch>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.22' ">
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.23' ">
     <PackagesInPatch>
     </PackagesInPatch>
   </PropertyGroup>

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>22</PatchVersion>
+    <PatchVersion>23</PatchVersion>
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PreReleaseBrandingLabel></PreReleaseBrandingLabel>
     <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>


### PR DESCRIPTION
- dotnet/aspnetcore-internal#3676
- do actual branding and prepare for 2.1.23 patches, if any
- update package baselines from 2.1.22
  - remove Microsoft.Extensions.Logging.Testing from the baselines, not released