### PR TITLE
[release/3.1] Memory Leak in Microsoft.Extensions.Caching.Memory when handling exceptions

### DIFF
--- a/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 using (ICacheEntry entry = cache.CreateEntry(key))
                 {
                     result = await factory(entry).ConfigureAwait(false);
-                    entry.SetValue(result);
+                    entry.Value = result;
                 }
             }
 

--- a/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
@@ -43,39 +43,43 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value)
         {
-            var entry = cache.CreateEntry(key);
-            entry.Value = value;
-            entry.Dispose();
+            using (var entry = cache.CreateEntry(key))
+            {
+                entry.Value = value;
+            }
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, DateTimeOffset absoluteExpiration)
         {
-            var entry = cache.CreateEntry(key);
-            entry.AbsoluteExpiration = absoluteExpiration;
-            entry.Value = value;
-            entry.Dispose();
+            using (var entry = cache.CreateEntry(key))
+            {
+                entry.AbsoluteExpiration = absoluteExpiration;
+                entry.Value = value;
+            }
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, TimeSpan absoluteExpirationRelativeToNow)
         {
-            var entry = cache.CreateEntry(key);
-            entry.AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow;
-            entry.Value = value;
-            entry.Dispose();
+            using (var entry = cache.CreateEntry(key))
+            {
+                entry.AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow;
+                entry.Value = value;
+            }
 
             return value;
         }
 
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, IChangeToken expirationToken)
         {
-            var entry = cache.CreateEntry(key);
-            entry.AddExpirationToken(expirationToken);
-            entry.Value = value;
-            entry.Dispose();
+            using (var entry = cache.CreateEntry(key))
+            {
+                entry.AddExpirationToken(expirationToken);
+                entry.Value = value;
+            }
 
             return value;
         }
@@ -99,13 +103,11 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (!cache.TryGetValue(key, out object result))
             {
-                var entry = cache.CreateEntry(key);
-                result = factory(entry);
-                entry.SetValue(result);
-                // need to manually call dispose instead of having a using
-                // in case the factory passed in throws, in which case we
-                // do not want to add the entry to the cache
-                entry.Dispose();
+                using (var entry = cache.CreateEntry(key))
+                {
+                    result = factory(entry);
+                    entry.Value = result;
+                }
             }
 
             return (TItem)result;
@@ -115,13 +117,11 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (!cache.TryGetValue(key, out object result))
             {
-                var entry = cache.CreateEntry(key);
-                result = await factory(entry);
-                entry.SetValue(result);
-                // need to manually call dispose instead of having a using
-                // in case the factory passed in throws, in which case we
-                // do not want to add the entry to the cache
-                entry.Dispose();
+                using (ICacheEntry entry = cache.CreateEntry(key))
+                {
+                    result = await factory(entry).ConfigureAwait(false);
+                    entry.SetValue(result);
+                }
             }
 
             return (TItem)result;

--- a/src/Caching/Memory/src/CacheEntry.cs
+++ b/src/Caching/Memory/src/CacheEntry.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Extensions.Caching.Memory
 {
     internal class CacheEntry : ICacheEntry
     {
-        private bool _added = false;
+        private bool _disposed = false;
         private static readonly Action<object> ExpirationCallback = ExpirationTokensExpired;
         private readonly Action<CacheEntry> _notifyCacheOfExpiration;
-        private readonly Action<CacheEntry> _notifyCacheEntryDisposed;
+        private readonly Action<CacheEntry> _notifyCacheEntryCommit;
         private IList<IDisposable> _expirationTokenRegistrations;
         private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
         private bool _isExpired;
@@ -26,12 +26,13 @@ namespace Microsoft.Extensions.Caching.Memory
         private long? _size;
         private IDisposable _scope;
         private object _value;
+        private bool _valueHasBeenSet;
 
         internal readonly object _lock = new object();
 
         internal CacheEntry(
             object key,
-            Action<CacheEntry> notifyCacheEntryDisposed,
+            Action<CacheEntry> notifyCacheEntryCommit,
             Action<CacheEntry> notifyCacheOfExpiration)
         {
             if (key == null)
@@ -39,9 +40,9 @@ namespace Microsoft.Extensions.Caching.Memory
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (notifyCacheEntryDisposed == null)
+            if (notifyCacheEntryCommit == null)
             {
-                throw new ArgumentNullException(nameof(notifyCacheEntryDisposed));
+                throw new ArgumentNullException(nameof(notifyCacheEntryCommit));
             }
 
             if (notifyCacheOfExpiration == null)
@@ -50,7 +51,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Key = key;
-            _notifyCacheEntryDisposed = notifyCacheEntryDisposed;
+            _notifyCacheEntryCommit = notifyCacheEntryCommit;
             _notifyCacheOfExpiration = notifyCacheOfExpiration;
 
             _scope = CacheEntryHelper.EnterScope(this);
@@ -180,11 +181,9 @@ namespace Microsoft.Extensions.Caching.Memory
             set
             {
                 _value = value;
-                ValueHasBeenSet = true;
+                _valueHasBeenSet = true;
             }
         }
-
-        internal bool ValueHasBeenSet { get; private set; }
 
         internal DateTimeOffset LastAccessed { get; set; }
 
@@ -192,12 +191,19 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public void Dispose()
         {
-            if (!_added)
+            if (!_disposed)
             {
-                _added = true;
+                _disposed = true;
                 _scope.Dispose();
-                _notifyCacheEntryDisposed(this);
-                PropagateOptions(CacheEntryHelper.Current);
+
+                // Don't commit or propagate options if the CacheEntry Value was never set.
+                // We assume an exception occurred causing the caller to not set the Value successfully,
+                // so don't use this entry.
+                if (_valueHasBeenSet)
+                {
+                    _notifyCacheEntryCommit(this);
+                    PropagateOptions(CacheEntryHelper.Current);
+                }
             }
         }
 

--- a/src/Caching/Memory/src/CacheEntry.cs
+++ b/src/Caching/Memory/src/CacheEntry.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.Caching.Memory
         private TimeSpan? _slidingExpiration;
         private long? _size;
         private IDisposable _scope;
+        private object _value;
 
         internal readonly object _lock = new object();
 
@@ -173,7 +174,17 @@ namespace Microsoft.Extensions.Caching.Memory
 
         public object Key { get; private set; }
 
-        public object Value { get; set; }
+        public object Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                ValueHasBeenSet = true;
+            }
+        }
+
+        internal bool ValueHasBeenSet { get; private set; }
 
         internal DateTimeOffset LastAccessed { get; set; }
 

--- a/src/Caching/Memory/src/CacheEntry.cs
+++ b/src/Caching/Memory/src/CacheEntry.cs
@@ -194,7 +194,11 @@ namespace Microsoft.Extensions.Caching.Memory
             if (!_disposed)
             {
                 _disposed = true;
+
+                // Ensure the _scope reference is cleared because it can reference other CacheEntry instances.
+                // This CacheEntry is going to be put into a MemoryCache, and we don't want to root unnecessary objects.
                 _scope.Dispose();
+                _scope = null;
 
                 // Don't commit or propagate options if the CacheEntry Value was never set.
                 // We assume an exception occurred causing the caller to not set the Value successfully,

--- a/src/Caching/Memory/src/MemoryCache.cs
+++ b/src/Caching/Memory/src/MemoryCache.cs
@@ -115,13 +115,6 @@ namespace Microsoft.Extensions.Caching.Memory
                 return;
             }
 
-            if (!entry.ValueHasBeenSet)
-            {
-                // No-op if the CacheEntry Value was never set. We assume an exception occurred and the caller
-                // never set the Value successfully, so don't use this entry.
-                return;
-            }
-
             if (_options.SizeLimit.HasValue && !entry.Size.HasValue)
             {
                 throw new InvalidOperationException($"Cache entry must specify a value for {nameof(entry.Size)} when {nameof(_options.SizeLimit)} is set.");

--- a/src/Caching/Memory/src/MemoryCache.cs
+++ b/src/Caching/Memory/src/MemoryCache.cs
@@ -115,6 +115,13 @@ namespace Microsoft.Extensions.Caching.Memory
                 return;
             }
 
+            if (!entry.ValueHasBeenSet)
+            {
+                // No-op if the CacheEntry Value was never set. We assume an exception occurred and the caller
+                // never set the Value successfully, so don't use this entry.
+                return;
+            }
+
             if (_options.SizeLimit.HasValue && !entry.Size.HasValue)
             {
                 throw new InvalidOperationException($"Cache entry must specify a value for {nameof(entry.Size)} when {nameof(_options.SizeLimit)} is set.");

--- a/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
+++ b/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
@@ -180,6 +180,9 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.False(cache.TryGetValue(key, out int obj));
+
+            // verify that throwing an exception doesn't leak CacheEntry objects
+            Assert.Null(CacheEntryHelper.Current);
         }
 
         [Fact]
@@ -199,6 +202,9 @@ namespace Microsoft.Extensions.Caching.Memory
             }
 
             Assert.False(cache.TryGetValue(key, out int obj));
+
+            // verify that throwing an exception doesn't leak CacheEntry objects
+            Assert.Null(CacheEntryHelper.Current);
         }
 
         [Fact]

--- a/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
+++ b/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -205,6 +206,25 @@ namespace Microsoft.Extensions.Caching.Memory
 
             // verify that throwing an exception doesn't leak CacheEntry objects
             Assert.Null(CacheEntryHelper.Current);
+        }
+
+        [Fact]
+        public void DisposingCacheEntryReleasesScope()
+        {
+            object GetScope(ICacheEntry entry)
+            {
+                return entry.GetType()
+                    .GetField("_scope", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetValue(entry);
+            }
+
+            var cache = CreateCache();
+
+            ICacheEntry entry = cache.CreateEntry("myKey");
+            Assert.NotNull(GetScope(entry));
+
+            entry.Dispose();
+            Assert.Null(GetScope(entry));
         }
 
         [Fact]


### PR DESCRIPTION
Resolves https://github.com/dotnet/extensions/issues/3533

Backport of https://github.com/dotnet/runtime/pull/42355

When an exception is thrown inside MemoryCache.GetOrCreate, we are leaking CacheEntry objects. This is because they are not being Disposed properly, and the async local CacheEntryStack is growing indefinitely.

The fix is to ensure the CacheEntry objects are disposed correctly. In order to do this, I set a flag to indicate whether the CacheEntry.Value has been set. If it hasn't, Disposing the CacheEntry won't add it to the cache.