### PR TITLE
merging rc2 and update brandint to rtm

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -344,6 +344,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
+      publishingInfraVersion: 3
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+   <PropertyGroup>
+      <PublishingVersion>3</PublishingVersion>
+   </PropertyGroup>
+</Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,201 +10,201 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.ComponentModel.Annotations" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.IO.Pipelines" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Reflection.Metadata" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="System.Text.Json" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration.Xml" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Primitives" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Primitives" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Hosting" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Hosting" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Http" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.Debug" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging.TraceSource" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Options" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.Extensions.Options" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.
     -->
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -212,21 +212,21 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20431.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20467.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
+      <Sha>b63ea25b8dc50bb3dfcef128d415254bd5ca4dc8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20431.1">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20467.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
+      <Sha>b63ea25b8dc50bb3dfcef128d415254bd5ca4dc8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20431.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20467.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
+      <Sha>b63ea25b8dc50bb3dfcef128d415254bd5ca4dc8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-rc.1.20452.14">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-rc.2.20474.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d2e8221c4d18df2f01010eb3867f989fe9cfc7b3</Sha>
+      <Sha>e9ac240eaa36fa0b324ff4432e45d1fbc1e5b290</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-3.20416.3">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,8 +10,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <ExperimentalVersionPrefix>0.1.$(PatchVersion)</ExperimentalVersionPrefix>
     <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <ExperimentalVersionPrefix>0.1.$(PatchVersion)</ExperimentalVersionPrefix>
     <!--
@@ -47,59 +47,59 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- Packages from dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-rc.1.20452.14</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-rc.1.20452.14</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-rc.1.20452.14</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-rc.2.20474.8</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-rc.2.20474.8</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-rc.2.20474.8</MicrosoftNETCoreAppInternalPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>1.0.0</MicrosoftBclAsyncInterfacesPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>5.0.0-rc.1.20452.14</MicrosoftWin32RegistryPackageVersion>
-    <MicrosoftExtensionsCachingAbstractionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsCachingAbstractionsPackageVersion>
-    <MicrosoftExtensionsCachingMemoryPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsCachingMemoryPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationIniPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationIniPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
-    <MicrosoftExtensionsConfigurationXmlPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationXmlPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersCompositePackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsFileProvidersCompositePackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftExtensionsHostingAbstractionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsHostingAbstractionsPackageVersion>
-    <MicrosoftExtensionsHostingPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsHostingPackageVersion>
-    <MicrosoftExtensionsHttpPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsHttpPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConfigurationPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingConfigurationPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingDebugPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingDebugPackageVersion>
-    <MicrosoftExtensionsLoggingEventLogPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingEventLogPackageVersion>
-    <MicrosoftExtensionsLoggingEventSourcePackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingEventSourcePackageVersion>
-    <MicrosoftExtensionsLoggingTraceSourcePackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
-    <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>5.0.0-rc.1.20452.14</MicrosoftExtensionsPrimitivesPackageVersion>
-    <SystemComponentModelAnnotationsPackageVersion>5.0.0-rc.1.20452.14</SystemComponentModelAnnotationsPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>5.0.0-rc.1.20452.14</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>5.0.0-rc.1.20452.14</SystemDiagnosticsEventLogPackageVersion>
-    <SystemIOPipelinesPackageVersion>5.0.0-rc.1.20452.14</SystemIOPipelinesPackageVersion>
-    <SystemReflectionMetadataPackageVersion>5.0.0-rc.1.20452.14</SystemReflectionMetadataPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>5.0.0-rc.1.20452.14</SystemRuntimeCompilerServicesUnsafePackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>5.0.0-rc.1.20452.14</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-rc.1.20452.14</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemServiceProcessServiceControllerPackageVersion>5.0.0-rc.1.20452.14</SystemServiceProcessServiceControllerPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>5.0.0-rc.1.20452.14</SystemTextEncodingsWebPackageVersion>
-    <SystemTextJsonPackageVersion>5.0.0-rc.1.20452.14</SystemTextJsonPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>5.0.0-rc.2.20474.8</MicrosoftWin32RegistryPackageVersion>
+    <MicrosoftExtensionsCachingAbstractionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsCachingAbstractionsPackageVersion>
+    <MicrosoftExtensionsCachingMemoryPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsCachingMemoryPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationIniPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationIniPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
+    <MicrosoftExtensionsConfigurationXmlPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationXmlPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersCompositePackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsFileProvidersCompositePackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
+    <MicrosoftExtensionsHostingAbstractionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsHostingAbstractionsPackageVersion>
+    <MicrosoftExtensionsHostingPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsHostingPackageVersion>
+    <MicrosoftExtensionsHttpPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsHttpPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingConfigurationPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingDebugPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingDebugPackageVersion>
+    <MicrosoftExtensionsLoggingEventLogPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingEventLogPackageVersion>
+    <MicrosoftExtensionsLoggingEventSourcePackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingEventSourcePackageVersion>
+    <MicrosoftExtensionsLoggingTraceSourcePackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsOptionsDataAnnotationsPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>5.0.0-rc.2.20474.8</MicrosoftExtensionsPrimitivesPackageVersion>
+    <SystemComponentModelAnnotationsPackageVersion>5.0.0-rc.2.20474.8</SystemComponentModelAnnotationsPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>5.0.0-rc.2.20474.8</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>5.0.0-rc.2.20474.8</SystemDiagnosticsEventLogPackageVersion>
+    <SystemIOPipelinesPackageVersion>5.0.0-rc.2.20474.8</SystemIOPipelinesPackageVersion>
+    <SystemReflectionMetadataPackageVersion>5.0.0-rc.2.20474.8</SystemReflectionMetadataPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>5.0.0-rc.2.20474.8</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>5.0.0-rc.2.20474.8</SystemSecurityCryptographyCngPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-rc.2.20474.8</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemServiceProcessServiceControllerPackageVersion>5.0.0-rc.2.20474.8</SystemServiceProcessServiceControllerPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>5.0.0-rc.2.20474.8</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>5.0.0-rc.2.20474.8</SystemTextJsonPackageVersion>
     <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-rc.1.20452.14</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-rc.2.20474.8</MicrosoftNETCorePlatformsPackageVersion>
     <!-- Packages from dotnet/arcade -->
-    <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.20431.1</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.20467.6</MicrosoftDotNetGenAPIPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetVersion>3.8.0-3.20416.3</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>

--- a/eng/common/internal/Directory.Build.props
+++ b/eng/common/internal/Directory.Build.props
@@ -1,4 +1,4 @@
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>

--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -8,7 +8,7 @@ param(
   [Parameter(Mandatory=$false)][string] $EnableSourceLinkValidation,
   [Parameter(Mandatory=$false)][string] $EnableSigningValidation,
   [Parameter(Mandatory=$false)][string] $EnableNugetValidation,
-  [Parameter(Mandatory=$true)][string] $PublishInstallersAndChecksums,
+  [Parameter(Mandatory=$false)][string] $PublishInstallersAndChecksums,
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $SigningValidationAdditionalParameters
 )
@@ -16,7 +16,7 @@ param(
 try {
   . $PSScriptRoot\post-build-utils.ps1
   # Hard coding darc version till the next arcade-services roll out, cos this version has required API changes for darc add-build-to-channel
-  . $PSScriptRoot\..\darc-init.ps1 -darcVersion "1.1.0-beta.20418.1"
+  $darc = Get-Darc "1.1.0-beta.20418.1"
 
   $optionalParams = [System.Collections.ArrayList]::new()
 
@@ -29,7 +29,7 @@ try {
     $optionalParams.Add("--no-wait") | Out-Null
   }
 
-  if ("true" -eq $PublishInstallersAndChecksums) {
+  if ("false" -ne $PublishInstallersAndChecksums) {
     $optionalParams.Add("--publish-installers-and-checksums") | Out-Null
   }
 
@@ -50,7 +50,7 @@ try {
     }
   }
 
-  & darc add-build-to-channel `
+  & $darc add-build-to-channel `
   --id $buildId `
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -141,11 +141,6 @@ $CountMissingSymbols = {
   if ($using:Clean) {
     Remove-Item $ExtractPath -Recurse -Force
   }
-
-  if ($MissingSymbols -ne 0)
-  {
-    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $MissingSymbols modules in the package $PackagePath"
-  }
   
   Pop-Location
 
@@ -165,6 +160,7 @@ function CheckJobResult(
     $DupedSymbols.Value++
   } 
   elseif ($jobResult.result -ne '0') {
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $result modules in the package $packagePath"
     $TotalFailures.Value++
   }
 }
@@ -201,7 +197,6 @@ function CheckSymbolsAvailable {
       Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName | Out-Null
 
       $NumJobs = @(Get-Job -State 'Running').Count
-      Write-Host $NumJobs
 
       while ($NumJobs -ge $MaxParallelJobs) {
         Write-Host "There are $NumJobs validation jobs running right now. Waiting $SecondsBetweenLoadChecks seconds to check again."

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.5.0-alpha" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.8.0-preview3" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/templates/post-build/channels/generic-internal-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-internal-channel.yml
@@ -4,7 +4,7 @@ parameters:
   artifactsPublishingAdditionalParameters: ''
   dependsOn:
   - Validate
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   symbolPublishingAdditionalParameters: ''
   stageName: ''
   channelName: ''
@@ -158,7 +158,7 @@ stages:
             /p:BlobBasePath='$(Build.ArtifactStagingDirectory)/BlobArtifacts/'
             /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts/'
             /p:Configuration=Release
-            /p:PublishInstallersAndChecksums=true
+            /p:PublishInstallersAndChecksums=${{ parameters.publishInstallersAndChecksums }}
             /p:ChecksumsTargetStaticFeed=$(InternalChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(InternalChecksumsBlobFeedKey)
             /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)

--- a/eng/common/templates/post-build/channels/generic-public-channel.yml
+++ b/eng/common/templates/post-build/channels/generic-public-channel.yml
@@ -4,7 +4,7 @@ parameters:
   artifactsPublishingAdditionalParameters: ''
   dependsOn:
   - Validate
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   symbolPublishingAdditionalParameters: ''
   stageName: ''
   channelName: ''

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -19,7 +19,7 @@ parameters:
   enableSigningValidation: true
   enableSymbolValidation: false
   enableNugetValidation: true
-  publishInstallersAndChecksums: false
+  publishInstallersAndChecksums: true
   SDLValidationParameters:
     enable: false
     continueOnError: false

--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -19,12 +19,18 @@ parameters:
   DisplayNamePrefix: 'Send job to Helix' # optional -- rename the beginning of the displayName of the steps in AzDO 
   condition: succeeded()                 # optional -- condition for step to execute; defaults to succeeded()
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
+  osGroup: ''                            # required -- operating system for the job
             
 
 steps:
-  - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$env:BuildConfig\SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
-    env:
+- template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+  parameters:
+    osGroup: ${{ parameters.osGroup }}
+    sendParams: $(Build.SourcesDirectory)/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+    displayName: ${{ parameters.DisplayNamePrefix }}
+    condition: ${{ parameters.condition }}
+    continueOnError: ${{ parameters.continueOnError }}
+    environment:
       BuildConfig: $(_BuildConfig)
       HelixSource: ${{ parameters.HelixSource }}
       HelixType: ${{ parameters.HelixType }}
@@ -42,27 +48,3 @@ steps:
       WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
       Creator: ${{ parameters.Creator }}
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}
-  - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Unix)
-    env:
-      BuildConfig: $(_BuildConfig)
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      Creator: ${{ parameters.Creator }}
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/publish-logs.yml
+++ b/eng/common/templates/steps/publish-logs.yml
@@ -3,20 +3,21 @@ parameters:
   JobLabel: ''
 
 steps:
-- task: CopyFiles@2
-  displayName: Copy Logs to $(Build.StagingDirectory)\BuildLogs
+- task: Powershell@2
+  displayName: Prepare Binlogs to Upload
   inputs:
-    SourceFolder: $(Build.SourcesDirectory)\artifacts
-    Contents: |
-      **/*.log
-      **/*.binlog
-    TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
+    targetType: inline
+    script: |
+      New-Item -ItemType Directory $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
+      Move-Item -Path $(Build.SourcesDirectory)/artifacts/log/Debug/* $(Build.SourcesDirectory)/PostBuildLogs/${{parameters.StageLabel}}/${{parameters.JobLabel}}/
   continueOnError: true
-  condition: succeededOrFailed()
+  condition: always()
 
-- task: PublishPipelineArtifact@1
-  displayName: Publish BuildLogs
+- task: PublishBuildArtifacts@1
+  displayName: Publish Logs
   inputs:
-    targetPath: '$(Build.StagingDirectory)\BuildLogs'
-    artifactName: ${{ parameters.JobLabel }}
-  condition: succeededOrFailed()
+    PathtoPublish: '$(Build.SourcesDirectory)/PostBuildLogs'
+    PublishLocation: Container
+    ArtifactName: PostBuildLogs
+  continueOnError: true
+  condition: always()

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.6.20310.4"
+    "version": "5.0.100-rc.1.20452.10"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.6.20310.4",
+    "dotnet": "5.0.100-rc.1.20452.10",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppInternalPackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20431.1",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20431.1"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20467.6",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20467.6"
   }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/Microsoft.AspNetCore.Testing.Tests.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/Microsoft.AspNetCore.Testing.Tests.csproj
@@ -7,6 +7,8 @@
     <NoWarn>$(NoWarn);xUnit1004</NoWarn>
     <!-- allow unused theory parameters -->
     <NoWarn>$(NoWarn);xUnit1026</NoWarn>
+    <!--skip platform compatiblity analyzer on test projects-->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
git checkout upstream/release/5.0
git merge upstream/release/5.0-rc2
fix merge conflicts in favour of rc2 branch
update branding

// verify by doing a git diff between branches and it should be just branding change

```diff
C:\git\extensions>git diff upstream/release/5.0-rc2
diff --git a/eng/Versions.props b/eng/Versions.props
index 4de5853fc..03521524e 100644
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,8 +10,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <ExperimentalVersionPrefix>0.1.$(PatchVersion)</ExperimentalVersionPrefix>
     <!--

C:\git\extensions>
```