### PR TITLE
Removed unnecessary assignment and allocation

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -423,13 +423,13 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                     options.AbsoluteExpiration.Value,
                     "The absolute expiration value must be in the future.");
             }
-            var absoluteExpiration = options.AbsoluteExpiration;
+            
             if (options.AbsoluteExpirationRelativeToNow.HasValue)
             {
-                absoluteExpiration = creationTime + options.AbsoluteExpirationRelativeToNow;
+                return creationTime + options.AbsoluteExpirationRelativeToNow;
             }
 
-            return absoluteExpiration;
+            return options.AbsoluteExpiration;
         }
 
         public void Dispose()


### PR DESCRIPTION
Just a small micro optimization: in case options.AbsoluteExpirationRelativeToNow was there, there was a useless assignment to the variable absoluteExpiration from options.AbsoluteExpiration.

After having removed that, the variable itself became useless.