### PR TITLE
Feature/azure sql access token

### DIFF
--- a/Extensions.sln
+++ b/Extensions.sln
@@ -58,6 +58,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.NewtonsoftJson.Tests", "src\Configuration\Config.NewtonsoftJson\test\Microsoft.Extensions.Configuration.NewtonsoftJson.Tests.csproj", "{2FEE9416-E709-4EA7-82A3-4A34816F75FD}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Shared\src\CommandLineUtils\Microsoft.Extensions.CommandLineUtils.Sources.projitems*{de47cb52-3e6f-4a6a-910e-ae118a00ce1a}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64

--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Internal;
@@ -334,7 +335,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
         {
             if (UseAccessToken)
             {
-                var provider = new AzureServiceTokenProvider(KeyVaultProviderConnectionString);
+                var provider = new AzureServiceTokenProvider(KeyVaultConnectionStringProvider);
                 return new SqlConnection(ConnectionString)
                 {
                     AccessToken = provider.GetAccessTokenAsync("https://database.windows.net/").GetAwaiter().GetResult()

--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
         protected string ConnectionString { get; }
 
-        protected string UseAccessToken { get; }
+        protected bool UseAccessToken { get; }
 
         protected string KeyVaultConnectionStringProvider { get; }
 

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Distributed cache implementation of Microsoft.Extensions.Caching.Distributed.IDistributedCache using Microsoft SQL Server.</Description>
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Data.SqlClient" />
     <Reference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" />
+    <Reference Include="Microsoft.Azure.Services.AppAuthentication" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
     internal class MonoDatabaseOperations : DatabaseOperations
     {
         public MonoDatabaseOperations(
-            string connectionString, string schemaName, string tableName, ISystemClock systemClock)
-            : base(connectionString, schemaName, tableName, systemClock)
+            string connectionString, bool useAccessToken, string keyVaultConnectionStringProvider, string schemaName, string tableName, ISystemClock systemClock)
+            : base(connectionString, useAccessToken, keyVaultConnectionStringProvider, schemaName, tableName, systemClock)
         {
         }
 

--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
             {
                 _dbOperations = new MonoDatabaseOperations(
                     cacheOptions.ConnectionString,
+                    cacheOptions.UseAccessToken,
+                    cacheOptions.KeyVaultProviderConnectionString,
                     cacheOptions.SchemaName,
                     cacheOptions.TableName,
                     _systemClock);
@@ -81,6 +83,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
             {
                 _dbOperations = new DatabaseOperations(
                     cacheOptions.ConnectionString,
+                    cacheOptions.UseAccessToken,
+                    cacheOptions.KeyVaultProviderConnectionString,
                     cacheOptions.SchemaName,
                     cacheOptions.TableName,
                     _systemClock);

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -29,6 +29,16 @@ namespace Microsoft.Extensions.Caching.SqlServer
         public string ConnectionString { get; set; }
 
         /// <summary>
+        /// Determines whether you should use the access key for a connnection or not.
+        /// </summary>
+        public bool UseAccessToken { get; set; }
+
+        /// <summary>
+        /// The connection string used to get the access token from the vey vault. Used mostly when wanting to connect using MSI.
+        /// </summary>
+        public string KeyVaultProviderConnectionString { get; set; }
+
+        /// <summary>
         /// The schema name of the table.
         /// </summary>
         public string SchemaName { get; set; }


### PR DESCRIPTION
This is to allow access tokens to connect to an Azure SQL Server.

You could also check to see if KeyVaultProviderConnectionString is empty or null instead of using a bool "UseAccessToken".

- Allow the passing of the KeyVaultProviderConnectionString.
  - This makes it so people can choose what they want to connect with (specific MSIs or Identity Principles)
- Allow the passing of UseAccessToken.
  - This simply lets you know whether you should use the access token to establish a connection or not.