### PR TITLE
Enable post-build signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ variables:
     value: true
   - name: _PublishUsingPipelines
     value: true
+  - name: PostBuildSign
+    value: true
   - name: _DotNetArtifactsCategory
     value: ASPNETEXTENSIONS
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.