### PR TITLE
Set PB_ variables in the environment

### DIFF
--- a/eng/templates/default-build.yml
+++ b/eng/templates/default-build.yml
@@ -69,6 +69,10 @@ jobs:
         _SignType: test
       ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
         _SignType: real
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      PB_PackageVersionPropsUrl: ''
+      PB_AssetRootUrl: ''
+      PB_RestoreSource: ''
   steps:
   - checkout: self
     clean: true
@@ -89,12 +93,20 @@ jobs:
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
     - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
       displayName: Run build.cmd
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
       condition: always()
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
     - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
       displayName: Run build.sh
     - script: eng/scripts/KillProcesses.sh
       displayName: Kill processes


### PR DESCRIPTION
Discovered while working on https://github.com/dotnet/aspnetcore/pull/28829 - These 3 `PB_` variables are considered secrets by the build, which means they aren't automatically set as environment variables like other `PB_` vars. Our build scripts try to read them from the environment, and silently do nothing when they aren't there. In the case of these 3 variables, the result was that we weren't actually restoring the latest bits during official pipebuilds, and were instead building against whatever was hard-coded in our dependency files. Luckily this repo doesn't repackage anything from the runtime, so we haven't really been bitten by this, but it should still be fixed.