### PR TITLE
Update Branding to 5.0.2 and disable building of packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -330,16 +330,17 @@ stages:
         artifactName: Source_Build_Logs
         artifactType: Container
         parallel: true
-    - task: PublishBuildArtifacts@1
-      displayName: Upload package artifacts
-      # Only capture source build artifacts in PRs for the sake of inspecting
-      # changes that impact source-build. The artifacts from this build pipeline are never actually used.
-      condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'))
-      inputs:
-        pathtoPublish: artifacts/packages/
-        artifactName: Source_Build_Packages
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['_extensionsBuildProducedPackages'], true) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload package artifacts
+        # Only capture source build artifacts in PRs for the sake of inspecting
+        # changes that impact source-build. The artifacts from this build pipeline are never actually used.
+        condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'))
+        inputs:
+          pathtoPublish: artifacts/packages/
+          artifactName: Source_Build_Packages
+          artifactType: Container
+          parallel: true
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -330,17 +330,16 @@ stages:
         artifactName: Source_Build_Logs
         artifactType: Container
         parallel: true
-    - ${{ if eq(variables['_extensionsBuildProducedPackages'], true) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload package artifacts
-        # Only capture source build artifacts in PRs for the sake of inspecting
-        # changes that impact source-build. The artifacts from this build pipeline are never actually used.
-        condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'))
-        inputs:
-          pathtoPublish: artifacts/packages/
-          artifactName: Source_Build_Packages
-          artifactType: Container
-          parallel: true
+    - task: PublishBuildArtifacts@1
+      displayName: Upload package artifacts
+      # Only capture source build artifacts in PRs for the sake of inspecting
+      # changes that impact source-build. The artifacts from this build pipeline are never actually used.
+      condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'), eq(variables['_extensionsBuildProducedPackages'], true))
+      inputs:
+        pathtoPublish: artifacts/packages/
+        artifactName: Source_Build_Packages
+        artifactType: Container
+        parallel: true
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- ItemsToSign will be empty when we are not building any packages.-->
+  <PropertyGroup>
+    <AllowEmptySignList>true</AllowEmptySignList>  
+  </PropertyGroup>
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   <PropertyGroup Label="Version settings">
     <MajorVersion>5</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -7,4 +7,10 @@
                  See $(RepoRoot)eng\tools\BaselineGenerator\README.md for instructions on updating this baseline." />
   </Target>
 
+  <Target Name="SetAzureDevOpsVariableForBuiltPackages"
+          Condition="'$(ContinuousIntegrationBuild)' == 'true'"
+          AfterTargets="Build;Pack">
+    <Message Condition="Exists('$(ArtifactsDir)packages')" Importance="High" Text="##vso[task.setvariable variable=_extensionsBuildProducedPackages]true" />
+  </Target>
+
 </Project>

--- a/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
+++ b/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
@@ -15,7 +15,7 @@
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageTags>analyzers;async</PackageTags>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>false</IsShipping>
     <!-- This project is not included in the shared framework -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cache;distributedcache;sqlserver</PackageTags>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 

--- a/src/Caching/StackExchangeRedis/src/Microsoft.Extensions.Caching.StackExchangeRedis.csproj
+++ b/src/Caching/StackExchangeRedis/src/Microsoft.Extensions.Caching.StackExchangeRedis.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cache;distributedcache;redis</PackageTags>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 

--- a/src/Configuration/Config.NewtonsoftJson/src/Microsoft.Extensions.Configuration.NewtonsoftJson.csproj
+++ b/src/Configuration/Config.NewtonsoftJson/src/Microsoft.Extensions.Configuration.NewtonsoftJson.csproj
@@ -4,7 +4,7 @@
     <Description>Newtonsoft JSON configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>$(PackageTags);json</PackageTags>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 

--- a/src/Hosting/Systemd/src/Microsoft.Extensions.Hosting.Systemd.csproj
+++ b/src/Hosting/Systemd/src/Microsoft.Extensions.Hosting.Systemd.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>hosting</PackageTags>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>true</IsShipping>
     <!-- This project is not included in the shared framework -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>

--- a/src/Hosting/WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>hosting</PackageTags>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 

--- a/src/HttpClientFactory/Polly/src/Microsoft.Extensions.Http.Polly.csproj
+++ b/src/HttpClientFactory/Polly/src/Microsoft.Extensions.Http.Polly.csproj
@@ -11,7 +11,7 @@
 
     <!-- Don't use Microsoft.Extensions.Http.Polly as a namespace, that introduces ambiguities with 'Polly' -->
     <RootNamespace>Microsoft.Extensions.Http</RootNamespace>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 

--- a/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <!-- This is currently an experimental, internal-only analyzer. -->
     <IsShipping>false</IsShipping>
     <!-- This project is not included in the shared framework -->

--- a/src/Shared/src/Directory.Build.props
+++ b/src/Shared/src/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- This does not represent the TFM for the code. It's only here because /t:Pack requires it. -->
     <TargetFramework>netstandard1.0</TargetFramework>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
     <IsSourcePackage>true</IsSourcePackage>
     <IsShipping>false</IsShipping>
     <NoBuild>true</NoBuild>


### PR DESCRIPTION
- Update branding to 5.0.2 as we didnt ship any of these packages after 5.0.1
- disabling the building of packages by default. we can enable the them when we have something to ship