### PR TITLE
Backport of Allow increased log level filtering for event source logger

### DIFF
--- a/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///
     /// SPEC =                          // empty spec, same as *
     ///      | NAME                     // Just a name the level is the default level
-    ///      | NAME : LEVEL            // specifies level for a particular logger (can have a * suffix).
+    ///      | NAME : LEVEL             // specifies level for a particular logger (can have a * suffix).
+    ///
+    /// When "UseAppFilters" is specified in the FilterSpecs, it avoids disabling all categories which happens by default otherwise.
     ///
     /// Where Name is the name of a ILoggger (case matters), Name can have a * which acts as a wildcard
     /// AS A SUFFIX.   Thus Net* will match any loggers that start with the 'Net'.
@@ -111,6 +113,7 @@ namespace Microsoft.Extensions.Logging.EventSource
         // having assignment in ctor would overwrite the value
         private LoggerFilterRule[] _filterSpec = new LoggerFilterRule[0];
         private CancellationTokenSource _cancellationTokenSource;
+        private const string UseAppFilters = "UseAppFilters";
 
         private LoggingEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
         {
@@ -317,39 +320,50 @@ namespace Microsoft.Extensions.Logging.EventSource
                 return new[] { new LoggerFilterRule(typeof(EventSourceLoggerProvider).FullName, null, defaultLevel, null) };
             }
 
-            var rules = new List<LoggerFilterRule>();
-
-            // All event source loggers are disabled by default
-            rules.Add(new LoggerFilterRule(typeof(EventSourceLoggerProvider).FullName, null, LogLevel.None, null));
-
-            if (filterSpec != null)
+            if (filterSpec == null)
             {
-                var ruleStrings = filterSpec.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var rule in ruleStrings)
+                // All event source loggers are disabled by default
+                return new[] { new LoggerFilterRule(typeof(EventSourceLoggerProvider).FullName, null, LogLevel.None, null) };
+            }
+
+            var rules = new List<LoggerFilterRule>();
+            int ruleStringsStartIndex = 0;
+            string[] ruleStrings = filterSpec.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            if (ruleStrings.Length > 0 && ruleStrings[0].Equals(UseAppFilters, StringComparison.OrdinalIgnoreCase))
+            {
+                // Avoid adding default rule to disable event source loggers
+                ruleStringsStartIndex = 1;
+            }
+            else
+            {
+                rules.Add(new LoggerFilterRule(typeof(EventSourceLoggerProvider).FullName, null, LogLevel.None, null));
+            }
+
+            for (int i = ruleStringsStartIndex; i < ruleStrings.Length; i++)
+            {
+                string rule = ruleStrings[i];
+                LogLevel level = defaultLevel;
+                string[] parts = rule.Split(new[] { ':' }, 2);
+                string loggerName = parts[0];
+                if (loggerName.Length == 0)
                 {
-                    var level = defaultLevel;
-                    var parts = rule.Split(new[] { ':' }, 2);
-                    var loggerName = parts[0];
-                    if (loggerName.Length == 0)
+                    continue;
+                }
+
+                if (loggerName[loggerName.Length - 1] == '*')
+                {
+                    loggerName = loggerName.Substring(0, loggerName.Length - 1);
+                }
+
+                if (parts.Length == 2)
+                {
+                    if (!TryParseLevel(defaultLevel, parts[1], out level))
                     {
                         continue;
                     }
-
-                    if (loggerName[loggerName.Length - 1] == '*')
-                    {
-                        loggerName = loggerName.Substring(0, loggerName.Length - 1);
-                    }
-
-                    if (parts.Length == 2)
-                    {
-                        if (!TryParseLevel(defaultLevel, parts[1], out level))
-                        {
-                            continue;
-                        }
-                    }
-
-                    rules.Add(new LoggerFilterRule(typeof(EventSourceLoggerProvider).FullName, loggerName, level, null));
                 }
+
+                rules.Add(new LoggerFilterRule(typeof(EventSourceLoggerProvider).FullName, loggerName, level, null));
             }
 
             return rules.ToArray();

--- a/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
+++ b/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
@@ -53,6 +53,113 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void FilterSpecs_UseAppFilters_IncreaseLoggingLevelForOneCategory_GuaranteesAllRulesRemainAvailable()
+        {
+            using (var testListener = new TestEventListener())
+            {
+                var loggerFactory = LoggerFactory.Create(builder =>
+                    builder
+                        .AddEventSourceLogger()
+                        .AddFilter("Logger1*", LogLevel.Warning)
+                        .AddFilter("Logger2*", LogLevel.Error)
+                        .AddFilter("Logger3*", LogLevel.Critical)
+                        .AddFilter<EventSourceLoggerProvider>("Logger4*", LogLevel.Error)
+                );
+
+                var listenerSettings = new TestEventListener.ListenerSettings();
+                listenerSettings.FilterSpec = "UseAppFilters;Logger3:1";
+                testListener.EnableEvents(listenerSettings);
+
+                var logger = loggerFactory.CreateLogger("Logger1");
+                var logger2 = loggerFactory.CreateLogger("Logger2");
+                var logger3 = loggerFactory.CreateLogger("Logger3");
+                var logger4 = loggerFactory.CreateLogger("Logger4");
+
+                Assert.False(logger.IsEnabled(LogLevel.None));
+                Assert.True(logger.IsEnabled(LogLevel.Critical));
+                Assert.True(logger.IsEnabled(LogLevel.Error));
+                Assert.True(logger.IsEnabled(LogLevel.Warning));
+                Assert.False(logger.IsEnabled(LogLevel.Information));
+                Assert.False(logger.IsEnabled(LogLevel.Debug));
+                Assert.False(logger.IsEnabled(LogLevel.Trace));
+
+                Assert.False(logger2.IsEnabled(LogLevel.None));
+                Assert.True(logger2.IsEnabled(LogLevel.Critical));
+                Assert.True(logger2.IsEnabled(LogLevel.Error));
+                Assert.False(logger2.IsEnabled(LogLevel.Warning));
+                Assert.False(logger2.IsEnabled(LogLevel.Information));
+                Assert.False(logger2.IsEnabled(LogLevel.Debug));
+                Assert.False(logger2.IsEnabled(LogLevel.Trace));
+
+                Assert.False(logger3.IsEnabled(LogLevel.None));
+                Assert.True(logger3.IsEnabled(LogLevel.Critical));
+                Assert.True(logger3.IsEnabled(LogLevel.Error));
+                Assert.True(logger3.IsEnabled(LogLevel.Warning));
+                Assert.True(logger3.IsEnabled(LogLevel.Information));
+                Assert.True(logger3.IsEnabled(LogLevel.Debug));
+                Assert.False(logger3.IsEnabled(LogLevel.Trace));
+
+                Assert.False(logger4.IsEnabled(LogLevel.None));
+                Assert.True(logger4.IsEnabled(LogLevel.Critical));
+                Assert.True(logger4.IsEnabled(LogLevel.Error));
+                Assert.False(logger4.IsEnabled(LogLevel.Warning));
+                Assert.False(logger4.IsEnabled(LogLevel.Information));
+                Assert.False(logger4.IsEnabled(LogLevel.Debug));
+                Assert.False(logger4.IsEnabled(LogLevel.Trace));
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("UseAppFilters_StartsThisWay:Debug;")]
+        public void FilterSpecs_IncreaseLoggingLevelForOneCategory_DisablesExistingRulesByDefault(string prefix)
+        {
+            using (var testListener = new TestEventListener())
+            {
+                var loggerFactory = LoggerFactory.Create(builder =>
+                    builder
+                        .AddEventSourceLogger()
+                        .AddFilter("Logger1*", LogLevel.Warning)
+                        .AddFilter("Logger2*", LogLevel.Error)
+                        .AddFilter("Logger3*", LogLevel.Critical)
+                        .AddFilter<EventSourceLoggerProvider>("Logger4*", LogLevel.Error)
+                );
+
+                var listenerSettings = new TestEventListener.ListenerSettings();
+                listenerSettings.FilterSpec = prefix + "Logger3:1";
+                testListener.EnableEvents(listenerSettings);
+
+                var logger = loggerFactory.CreateLogger("Logger1");
+                var logger2 = loggerFactory.CreateLogger("Logger2");
+                var logger3 = loggerFactory.CreateLogger("Logger3");
+                var logger4 = loggerFactory.CreateLogger("Logger4");
+                
+                foreach (LogLevel level in Enum.GetValues(typeof(LogLevel)))
+                {
+                    Assert.False(logger.IsEnabled(LogLevel.None));
+                    Assert.False(logger2.IsEnabled(LogLevel.None));
+                }
+
+                Assert.False(logger3.IsEnabled(LogLevel.None));
+                Assert.True(logger3.IsEnabled(LogLevel.Critical));
+                Assert.True(logger3.IsEnabled(LogLevel.Error));
+                Assert.True(logger3.IsEnabled(LogLevel.Warning));
+                Assert.True(logger3.IsEnabled(LogLevel.Information));
+                Assert.True(logger3.IsEnabled(LogLevel.Debug));
+                Assert.False(logger3.IsEnabled(LogLevel.Trace));
+
+                // Note: default disabling rule does not take precedence on filter rules that specify both a provider and a category
+                Assert.False(logger4.IsEnabled(LogLevel.None));
+                Assert.True(logger4.IsEnabled(LogLevel.Critical));
+                Assert.True(logger4.IsEnabled(LogLevel.Error));
+                Assert.False(logger4.IsEnabled(LogLevel.Warning));
+                Assert.False(logger4.IsEnabled(LogLevel.Information));
+                Assert.False(logger4.IsEnabled(LogLevel.Debug));
+                Assert.False(logger4.IsEnabled(LogLevel.Trace));
+            }
+        }
+
+        [Fact]
         public void Logs_AsExpected_WithDefaults()
         {
             using (var testListener = new TestEventListener())


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/50664.
Original change: https://github.com/dotnet/runtime/commit/df7f985f44712efd46b8b3bc5e4d83fe3d83ed4b