### PR TITLE
[release/2.1] Bump some versions

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <ExtensionsBaselineVersion>2.1.26</ExtensionsBaselineVersion>
+    <ExtensionsBaselineVersion>2.1.27</ExtensionsBaselineVersion>
   </PropertyGroup>
   <!-- Package: Microsoft.Extensions.Caching.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Caching.Abstractions' ">

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -1,4 +1,4 @@
-﻿<Baseline Version="2.1.26">
+﻿<Baseline Version="2.1.27">
   <Package Id="Microsoft.Extensions.Caching.Abstractions" Version="2.1.23" />
   <Package Id="Microsoft.Extensions.Caching.Memory" Version="2.1.23" />
   <Package Id="Microsoft.Extensions.Caching.Redis" Version="2.1.2" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -6,7 +6,8 @@
   <!-- These package versions may be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Auto">
     <InternalAspNetCoreSdkPackageVersion>2.1.7-build-20210413.1</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftNETCoreAppPackageVersion>2.1.26</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.1.27</MicrosoftNETCoreAppPackageVersion>
+
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <SystemDataSqlClientPackageVersion>4.5.3</SystemDataSqlClientPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -5,7 +5,7 @@
 
   <!-- These package versions may be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Auto">
-    <InternalAspNetCoreSdkPackageVersion>2.1.7-build-20200221.1</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.7-build-20210413.1</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.26</MicrosoftNETCoreAppPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <SystemDataSqlClientPackageVersion>4.5.3</SystemDataSqlClientPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.7-build-20210309.1
-commithash:661bf72b3a220a08f26c1919c6f33113e894466d
+version:2.1.7-build-20210413.1
+commithash:41a55f8d844c4be8c4afa5f70f72b80067f0d113

--- a/version.props
+++ b/version.props
@@ -3,7 +3,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
     <PatchVersion>28</PatchVersion>
-    <ValidateBaseline>false</ValidateBaseline>
+    <ValidateBaseline>true</ValidateBaseline>
 
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PreReleaseBrandingLabel></PreReleaseBrandingLabel>


### PR DESCRIPTION
- move to latest KoreBuild / .NET SDK
- update baselines
    - did not ship any C# packages in 2.1.27
    - re-enable baseline validation
- bump Microsoft.NETCore.App package version