### PR TITLE
[release/2.1] Migrate to 1ES hosted pools

### DIFF
--- a/eng/templates/default-build.yml
+++ b/eng/templates/default-build.yml
@@ -52,8 +52,8 @@ jobs:
       vmImage: vs2017-win2016
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         # This override makes the specified vmImage irrelevant.
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Server.Amd64.VS2017
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2017
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
We need to migrate pools to 1ES hosted pools before 9/30. Only the pool/image names have to be changed. The supported functionality stays the same.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276