### PR TITLE
Put in place support for curated static analysis and API reviews.

### DIFF
--- a/eng/Diags/ILLink.RoslynAnalyzer.yml
+++ b/eng/Diags/ILLink.RoslynAnalyzer.yml
@@ -1,0 +1,634 @@
+Origin:
+  AssemblyName: ILLink.RoslynAnalyzer
+  Version: 8.0.8.26003
+Diagnostics:
+  IL2026:
+    Metadata:
+      Category: Trimming
+      Title: Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2046:
+    Metadata:
+      Category: Trimming
+      Title: "'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2050:
+    Metadata:
+      Category: Trimming
+      Title: Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+      Description: https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-warnings/il2050
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2055:
+    Metadata:
+      Category: Trimming
+      Title: Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2060:
+    Metadata:
+      Category: Trimming
+      Title: Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2109:
+    Metadata:
+      Category: Trimming
+      Title: Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL3000:
+    Metadata:
+      Category: SingleFile
+      Title: Avoid accessing Assembly file path when publishing as a single file
+      Description: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL3001:
+    Metadata:
+      Category: SingleFile
+      Title: Avoid accessing Assembly file path when publishing as a single file
+      Description: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL3002:
+    Metadata:
+      Category: SingleFile
+      Title: Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+      Description: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3002
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL3003:
+    Metadata:
+      Category: SingleFile
+      Title: "'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2041:
+    Metadata:
+      Category: Trimming
+      Title: The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2062:
+    Metadata:
+      Category: Trimming
+      Title: The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2063:
+    Metadata:
+      Category: Trimming
+      Title: The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2064:
+    Metadata:
+      Category: Trimming
+      Title: The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2065:
+    Metadata:
+      Category: Trimming
+      Title: The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2066:
+    Metadata:
+      Category: Trimming
+      Title: The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2067:
+    Metadata:
+      Category: Trimming
+      Title: Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2068:
+    Metadata:
+      Category: Trimming
+      Title: Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2069:
+    Metadata:
+      Category: Trimming
+      Title: Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2070:
+    Metadata:
+      Category: Trimming
+      Title: "'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2071:
+    Metadata:
+      Category: Trimming
+      Title: Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2072:
+    Metadata:
+      Category: Trimming
+      Title: Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2073:
+    Metadata:
+      Category: Trimming
+      Title: Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2074:
+    Metadata:
+      Category: Trimming
+      Title: Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2075:
+    Metadata:
+      Category: Trimming
+      Title: "'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2076:
+    Metadata:
+      Category: Trimming
+      Title: Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2077:
+    Metadata:
+      Category: Trimming
+      Title: Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2078:
+    Metadata:
+      Category: Trimming
+      Title: Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2079:
+    Metadata:
+      Category: Trimming
+      Title: Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2080:
+    Metadata:
+      Category: Trimming
+      Title: "'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2081:
+    Metadata:
+      Category: Trimming
+      Title: Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2082:
+    Metadata:
+      Category: Trimming
+      Title: Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2083:
+    Metadata:
+      Category: Trimming
+      Title: Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2084:
+    Metadata:
+      Category: Trimming
+      Title: Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2085:
+    Metadata:
+      Category: Trimming
+      Title: "'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2086:
+    Metadata:
+      Category: Trimming
+      Title: Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2087:
+    Metadata:
+      Category: Trimming
+      Title: Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2088:
+    Metadata:
+      Category: Trimming
+      Title: Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2089:
+    Metadata:
+      Category: Trimming
+      Title: Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2090:
+    Metadata:
+      Category: Trimming
+      Title: "'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2091:
+    Metadata:
+      Category: Trimming
+      Title: Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2097:
+    Metadata:
+      Category: Trimming
+      Title: Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2098:
+    Metadata:
+      Category: Trimming
+      Title: Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2099:
+    Metadata:
+      Category: Trimming
+      Title: Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2106:
+    Metadata:
+      Category: Trimming
+      Title: Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2110:
+    Metadata:
+      Category: Trimming
+      Title: Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2111:
+    Metadata:
+      Category: Trimming
+      Title: Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2059:
+    Metadata:
+      Category: Trimming
+      Title: The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2093:
+    Metadata:
+      Category: Trimming
+      Title: "'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2092:
+    Metadata:
+      Category: Trimming
+      Title: "'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2095:
+    Metadata:
+      Category: Trimming
+      Title: "'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2094:
+    Metadata:
+      Category: Trimming
+      Title: "'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2043:
+    Metadata:
+      Category: Trimming
+      Title: "'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2103:
+    Metadata:
+      Category: Trimming
+      Title: Value passed to the parameter of method cannot be statically determined as a property accessor.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2096:
+    Metadata:
+      Category: Trimming
+      Title: Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  IL2057:
+    Metadata:
+      Category: Trimming
+      Title: Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2032:
+    Metadata:
+      Category: Trimming
+      Title: The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL2058:
+    Metadata:
+      Category: Trimming
+      Title: Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL3004:
+    Metadata:
+      Category: SingleFile
+      Title: The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  IL3050:
+    Metadata:
+      Category: AOT
+      Title: Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL3051:
+    Metadata:
+      Category: AOT
+      Title: "'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides."
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL3056:
+    Metadata:
+      Category: AOT
+      Title: The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IL2116:
+    Metadata:
+      Category: Trimming
+      Title: The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/Microsoft.AspNetCore.App.Analyzers.yml
+++ b/eng/Diags/Microsoft.AspNetCore.App.Analyzers.yml
@@ -1,0 +1,136 @@
+Origin:
+  AssemblyName: Microsoft.AspNetCore.App.Analyzers
+  Version: 7.0.423.11903
+Diagnostics:
+  ASP0003:
+    Metadata:
+      Category: Usage
+      Title: Do not use model binding attributes with route handlers
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0004:
+    Metadata:
+      Category: Usage
+      Title: Do not use action results with route handlers
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0005:
+    Metadata:
+      Category: Usage
+      Title: Do not place attribute on method called by route handler lambda
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0006:
+    Metadata:
+      Category: Usage
+      Title: Do not use non-literal sequence numbers
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0007:
+    Metadata:
+      Category: Usage
+      Title: Route parameter and argument optionality is mismatched
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0008:
+    Metadata:
+      Category: Usage
+      Title: Do not use ConfigureWebHost with WebApplicationBuilder.Host
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  ASP0009:
+    Metadata:
+      Category: Usage
+      Title: Do not use Configure with WebApplicationBuilder.WebHost
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  ASP0010:
+    Metadata:
+      Category: Usage
+      Title: Do not use UseStartup with WebApplicationBuilder.WebHost
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  ASP0011:
+    Metadata:
+      Category: Usage
+      Title: Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0012:
+    Metadata:
+      Category: Usage
+      Title: Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0013:
+    Metadata:
+      Category: Usage
+      Title: Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  ASP0014:
+    Metadata:
+      Category: Usage
+      Title: Suggest using top level route registrations
+      Description: ''
+      HelpLinkUri: https://aka.ms/aspnet/analyzers
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/Microsoft.AspNetCore.Components.Analyzers.yml
+++ b/eng/Diags/Microsoft.AspNetCore.Components.Analyzers.yml
@@ -1,0 +1,74 @@
+Origin:
+  AssemblyName: Microsoft.AspNetCore.Components.Analyzers
+  Version: 7.0.423.11903
+Diagnostics:
+  BL0001:
+    Metadata:
+      Category: Encapsulation
+      Title: Component parameter should have public setters.
+      Description: Component parameters should have public setters.
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  BL0002:
+    Metadata:
+      Category: Usage
+      Title: Component has multiple CaptureUnmatchedValues parameters
+      Description: Components may only define a single parameter with CaptureUnmatchedValues.
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  BL0003:
+    Metadata:
+      Category: Usage
+      Title: Component parameter with CaptureUnmatchedValues has the wrong type
+      Description: Component parameters with CaptureUnmatchedValues must be a correct type.
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  BL0004:
+    Metadata:
+      Category: Encapsulation
+      Title: Component parameter should be public.
+      Description: Component parameters should be public.
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  BL0005:
+    Metadata:
+      Category: Usage
+      Title: Component parameter should not be set outside of its component.
+      Description: Component parameters should not be set outside of their declared component. Doing so may result in unexpected behavior at runtime.
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  BL0006:
+    Metadata:
+      Category: Usage
+      Title: Do not use RenderTree types
+      Description: The types in 'Microsoft.AspNetCore.Components.RenderTree' are not recommended for use outside of the Blazor framework. These  type definitions will change in future releases.
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  BL0007:
+    Metadata:
+      Category: Usage
+      Title: Component parameters should be auto properties
+      Description: ''
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/Microsoft.CodeAnalysis.CSharp.CodeStyle.yml
+++ b/eng/Diags/Microsoft.CodeAnalysis.CSharp.CodeStyle.yml
@@ -1,0 +1,1745 @@
+Origin:
+  AssemblyName: Microsoft.CodeAnalysis.CSharp.CodeStyle
+  Version: 4.7.8.26202
+Diagnostics:
+  IDE0001:
+    Metadata:
+      Category: Style
+      Title: Simplify name
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+  IDE0002:
+    Metadata:
+      Category: Style
+      Title: Simplify name
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+  IDE0003:
+    Metadata:
+      Category: Style
+      Title: Remove this or Me qualification
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+        Options:
+        - dotnet_style_qualification_for_event = false
+        - dotnet_style_qualification_for_field = false
+        - dotnet_style_qualification_for_method = false
+        - dotnet_style_qualification_for_property = false
+  IDE0049:
+    Metadata:
+      Category: Style
+      Title: Use language keywords instead of framework type names for type references
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+        Options:
+        - dotnet_style_predefined_type_for_locals_parameters_members = true
+        - dotnet_style_predefined_type_for_member_access = true
+  IDE0053:
+    Metadata:
+      Category: Style
+      Title: Use block body for lambda expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+        Comment: This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+        Options:
+        - csharp_style_expression_bodied_lambdas = when_on_single_line
+  IDE0004:
+    Metadata:
+      Category: Style
+      Title: Remove Unnecessary Cast
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0005:
+    Metadata:
+      Category: Style
+      Title: Using directive is unnecessary.
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: S1128
+  IDE0005_gen:
+    Metadata:
+      Category: Style
+      Title: Using directive is unnecessary.
+      Description: ''
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Never
+      - NotConfigurable
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: S1128
+  IDE0007:
+    Metadata:
+      Category: Style
+      Title: Use implicit type
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_var_elsewhere = true
+        - csharp_style_var_for_built_in_types = false
+        - csharp_style_var_when_type_is_apparent = true
+  IDE0008:
+    Metadata:
+      Category: Style
+      Title: Use explicit type
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0009:
+    Metadata:
+      Category: Style
+      Title: Member access should be qualified.
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Never
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line
+  IDE0010:
+    Metadata:
+      Category: Style
+      Title: Add missing cases
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0011:
+    Metadata:
+      Category: Style
+      Title: Add braces
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_prefer_braces = true
+  IDE0016:
+    Metadata:
+      Category: Style
+      Title: Use 'throw' expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_throw_expression = true
+  IDE0017:
+    Metadata:
+      Category: Style
+      Title: Simplify object initialization
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_object_initializer = true
+  IDE0018:
+    Metadata:
+      Category: Style
+      Title: Inline variable declaration
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_inlined_variable_declaration = true
+  IDE0019:
+    Metadata:
+      Category: Style
+      Title: Use pattern matching
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_pattern_matching_over_is_with_cast_check = true
+  IDE0020:
+    Metadata:
+      Category: Style
+      Title: Use pattern matching
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_pattern_matching_over_is_with_cast_check
+  IDE0021:
+    Metadata:
+      Category: Style
+      Title: Use expression body for constructor
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_constructors = false
+  IDE0022:
+    Metadata:
+      Category: Style
+      Title: Use expression body for method
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_expression_bodied_methods = when_on_single_line
+  IDE0023:
+    Metadata:
+      Category: Style
+      Title: Use expression body for conversion operator
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_operators = false
+  IDE0024:
+    Metadata:
+      Category: Style
+      Title: Use expression body for operator
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_operators = false
+  IDE0025:
+    Metadata:
+      Category: Style
+      Title: Use expression body for property
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_properties = true
+  IDE0026:
+    Metadata:
+      Category: Style
+      Title: Use expression body for indexer
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_indexers = true
+  IDE0027:
+    Metadata:
+      Category: Style
+      Title: Use expression body for accessor
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_accessors = true
+  IDE0028:
+    Metadata:
+      Category: Style
+      Title: Simplify collection initialization
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_collection_initializer = true
+  IDE0029:
+    Metadata:
+      Category: Style
+      Title: Use coalesce expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_coalesce_expression = true
+  IDE0030:
+    Metadata:
+      Category: Style
+      Title: Use coalesce expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_coalesce_expression = true
+  IDE0031:
+    Metadata:
+      Category: Style
+      Title: Use null propagation
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_null_propagation = true
+  IDE0032:
+    Metadata:
+      Category: Style
+      Title: Use auto property
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_prefer_auto_properties = true
+  IDE0034:
+    Metadata:
+      Category: Style
+      Title: Simplify 'default' expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_prefer_simple_default_expression = true
+  IDE0035:
+    Metadata:
+      Category: Style
+      Title: Unreachable code detected
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Never
+      - NotConfigurable
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line
+  IDE0036:
+    Metadata:
+      Category: Style
+      Title: Order modifiers
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+  IDE0037:
+    Metadata:
+      Category: Style
+      Title: Use inferred member name
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - dotnet_style_prefer_inferred_anonymous_type_member_names = true
+        - dotnet_style_prefer_inferred_tuple_names = true
+  IDE0039:
+    Metadata:
+      Category: Style
+      Title: Use local function
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_local_over_anonymous_function = false
+  IDE0040:
+    Metadata:
+      Category: Style
+      Title: Add accessibility modifiers
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_require_accessibility_modifiers = for_non_interface_members
+  IDE0041:
+    Metadata:
+      Category: Style
+      Title: Use 'is null' check
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+  IDE0042:
+    Metadata:
+      Category: Style
+      Title: Deconstruct variable declaration
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_deconstructed_variable_declaration = true
+  IDE0043:
+    Metadata:
+      Category: Compiler
+      Title: Invalid format string
+      Description: ''
+      CustomTags:
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0045:
+    Metadata:
+      Category: Style
+      Title: Convert to conditional expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - dotnet_style_prefer_conditional_expression_over_assignment = true
+  IDE0046:
+    Metadata:
+      Category: Style
+      Title: Convert to conditional expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - dotnet_style_prefer_conditional_expression_over_return = true
+  IDE0047:
+    Metadata:
+      Category: Style
+      Title: Remove unnecessary parentheses
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+        - dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+        - dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+        - dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+  IDE0048:
+    Metadata:
+      Category: Style
+      Title: Add parentheses for clarity
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+        - dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+        - dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+        - dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+        - dotnet_style_predefined_type_for_locals_parameters_members = true
+        - dotnet_style_predefined_type_for_member_access = true
+  IDE0050:
+    Metadata:
+      Category: Style
+      Title: Convert to tuple
+      Description: ''
+      CustomTags:
+      - Telemetry
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line
+  IDE0051:
+    Metadata:
+      Category: CodeQuality
+      Title: Remove unused private members
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0052:
+    Metadata:
+      Category: CodeQuality
+      Title: Remove unread private members
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0054:
+    Metadata:
+      Category: Style
+      Title: Use compound assignment
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_prefer_compound_assignment = true
+  IDE0055:
+    Metadata:
+      Category: Style
+      Title: Fix formatting
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_namespace_match_folder = true
+        - csharp_new_line_before_catch = true
+        - csharp_new_line_before_else = true
+        - csharp_new_line_before_finally = true
+        - csharp_new_line_before_members_in_anonymous_types = true
+        - csharp_new_line_before_members_in_object_initializers = true
+        - csharp_new_line_before_open_brace = all
+        - csharp_new_line_between_query_expression_clauses = true
+        - csharp_indent_block_contents = true
+        - csharp_indent_braces = false
+        - csharp_indent_case_contents = true
+        - csharp_indent_case_contents_when_block = false
+        - csharp_indent_labels = flush_left
+        - csharp_indent_switch_labels = true
+        - csharp_space_after_cast = false
+        - csharp_space_after_colon_in_inheritance_clause = true
+        - csharp_space_after_comma = true
+        - csharp_space_after_dot = false
+        - csharp_space_after_keywords_in_control_flow_statements = true
+        - csharp_space_after_semicolon_in_for_statement = true
+        - csharp_space_around_binary_operators = before_and_after
+        - csharp_space_around_declaration_statements = false
+        - csharp_space_before_colon_in_inheritance_clause = true
+        - csharp_space_before_comma = false
+        - csharp_space_before_dot = false
+        - csharp_space_before_open_square_brackets = false
+        - csharp_space_before_semicolon_in_for_statement = false
+        - csharp_space_between_empty_square_brackets = false
+        - csharp_space_between_method_call_empty_parameter_list_parentheses = false
+        - csharp_space_between_method_call_name_and_opening_parenthesis = false
+        - csharp_space_between_method_call_parameter_list_parentheses = false
+        - csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+        - csharp_space_between_method_declaration_name_and_open_parenthesis = false
+        - csharp_space_between_method_declaration_parameter_list_parentheses = false
+        - csharp_space_between_parentheses = false
+        - csharp_space_between_square_brackets = false
+        - csharp_preserve_single_line_blocks = true
+        - csharp_preserve_single_line_statements = false
+  IDE0056:
+    Metadata:
+      Category: Style
+      Title: Use index operator
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_index_operator = true
+  IDE0057:
+    Metadata:
+      Category: Style
+      Title: Use range operator
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_range_operator = true:warning
+  IDE0058:
+    Metadata:
+      Category: Style
+      Title: Expression value is never used
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+        Options:
+        - csharp_style_unused_value_expression_statement_preference = discard_variable
+  IDE0059:
+    Metadata:
+      Category: Style
+      Title: Unnecessary assignment of a value
+      Description: Avoid unnecessary value assignments in your code, as these likely indicate redundant value computations. If the value computation is not redundant and you intend to retain the assignment, then change the assignment target to a local variable whose name starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CS0219
+        Options:
+        - csharp_style_unused_value_assignment_preference = discard_variable
+  IDE0060:
+    Metadata:
+      Category: Style
+      Title: Remove unused parameter
+      Description: Avoid unused parameters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_code_quality_unused_parameters = all
+  IDE0061:
+    Metadata:
+      Category: Style
+      Title: Use expression body for local function
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_expression_bodied_local_functions = true
+  IDE0062:
+    Metadata:
+      Category: Style
+      Title: Make local function 'static'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_prefer_static_local_function = true
+  IDE0063:
+    Metadata:
+      Category: Style
+      Title: Use simple 'using' statement
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_prefer_simple_using_statement = true
+  IDE0064:
+    Metadata:
+      Category: CodeQuality
+      Title: Make readonly fields writable
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0065:
+    Metadata:
+      Category: Style
+      Title: Misplaced using directive
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_separate_import_directive_groups = false
+        - dotnet_sort_system_directives_first = true
+        - csharp_using_directive_placement = outside_namespace:suggestion
+  IDE0066:
+    Metadata:
+      Category: Style
+      Title: Convert switch statement to expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_prefer_switch_expression = true:warning
+  IDE0071:
+    Metadata:
+      Category: Style
+      Title: Simplify interpolation
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_prefer_simplified_interpolation = true
+  IDE0072:
+    Metadata:
+      Category: Style
+      Title: Add missing cases
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0073:
+    Metadata:
+      Category: Style
+      Title: The file header does not match the required text
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0074:
+    Metadata:
+      Category: Style
+      Title: Use compound assignment
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line
+        Options:
+        - dotnet_style_prefer_compound_assignment = true
+  IDE0075:
+    Metadata:
+      Category: Style
+      Title: Simplify conditional expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_prefer_simplified_boolean_expressions = true
+  IDE0076:
+    Metadata:
+      Category: CodeQuality
+      Title: Invalid global 'SuppressMessageAttribute'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0077:
+    Metadata:
+      Category: CodeQuality
+      Title: Avoid legacy format target in 'SuppressMessageAttribute'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0078:
+    Metadata:
+      Category: Style
+      Title: Use pattern matching
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_pattern_matching = true
+  IDE0079:
+    Metadata:
+      Category: Style
+      Title: Remove unnecessary suppression
+      Description: ''
+      CustomTags:
+      - Telemetry
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+        Comment: This diagnostic only triggers in Visual Studio, not when building from the command-line
+        Options:
+        - dotnet_remove_unnecessary_suppression_exclusions = CS0618
+  IDE0080:
+    Metadata:
+      Category: Style
+      Title: Remove unnecessary suppression operator
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0082:
+    Metadata:
+      Category: Style
+      Title: "'typeof' can be converted  to 'nameof'"
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0083:
+    Metadata:
+      Category: Style
+      Title: Use pattern matching
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_not_pattern = true
+  IDE1005:
+    Metadata:
+      Category: Style
+      Title: Delegate invocation can be simplified.
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_conditional_delegate_call = true
+  IDE1006:
+    Metadata:
+      Category: Style
+      Title: Naming Styles
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+        - dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+        - dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+        - dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+        - dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+        - dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+        - dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+        - dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+        - dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+        - dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+        - dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+        - dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+        - dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+        - dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+        - dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+        - dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+        - dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+        - dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+        - dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+        - dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+        - dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+        - dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+        - dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+        - dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+        - dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+        - dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+        - dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+        - dotnet_naming_symbols.interface.applicable_kinds = interface
+        - dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+        - dotnet_naming_symbols.interface.required_modifiers =
+        - dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+        - dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+        - dotnet_naming_symbols.types.required_modifiers =
+        - dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+        - dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+        - dotnet_naming_symbols.non_field_members.required_modifiers =
+        - dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+        - dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+        - dotnet_naming_symbols.method_parameter.required_modifiers =
+        - dotnet_naming_symbols.local_variable.applicable_kinds = local
+        - dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+        - dotnet_naming_symbols.local_variable.required_modifiers =
+        - dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+        - dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+        - dotnet_naming_symbols.type_parameter.required_modifiers =
+        - dotnet_naming_symbols.constant.applicable_kinds = field, local
+        - dotnet_naming_symbols.constant.applicable_accessibilities = *
+        - dotnet_naming_symbols.constant.required_modifiers = const
+        - dotnet_naming_symbols.private_field.applicable_kinds = field
+        - dotnet_naming_symbols.private_field.applicable_accessibilities = private
+        - dotnet_naming_symbols.private_field.required_modifiers =
+        - dotnet_naming_symbols.field.applicable_kinds = field
+        - dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+        - dotnet_naming_symbols.field.required_modifiers =
+        - dotnet_naming_style.pascalcase.required_prefix =
+        - dotnet_naming_style.pascalcase.required_suffix =
+        - dotnet_naming_style.pascalcase.word_separator =
+        - dotnet_naming_style.pascalcase.capitalization = pascal_case
+        - dotnet_naming_style.ipascalcase.required_prefix = I
+        - dotnet_naming_style.ipascalcase.required_suffix =
+        - dotnet_naming_style.ipascalcase.word_separator =
+        - dotnet_naming_style.ipascalcase.capitalization = pascal_case
+        - dotnet_naming_style.camelcase.required_prefix =
+        - dotnet_naming_style.camelcase.required_suffix =
+        - dotnet_naming_style.camelcase.word_separator =
+        - dotnet_naming_style.camelcase.capitalization = camel_case
+        - dotnet_naming_style._camelcase.required_prefix = _
+        - dotnet_naming_style._camelcase.required_suffix =
+        - dotnet_naming_style._camelcase.word_separator =
+        - dotnet_naming_style._camelcase.capitalization = camel_case
+        - dotnet_naming_style.tpascalcase.required_prefix = T
+        - dotnet_naming_style.tpascalcase.required_suffix =
+        - dotnet_naming_style.tpascalcase.word_separator =
+        - dotnet_naming_style.tpascalcase.capitalization = pascal_case
+  RemoveUnnecessaryImportsFixable:
+    Metadata:
+      Category: Style
+      Title: ''
+      Description: ''
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Never
+      - NotConfigurable
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0090:
+    Metadata:
+      Category: Style
+      Title: Use 'new(...)'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_implicit_object_creation_when_type_is_apparent = true
+  IDE0110:
+    Metadata:
+      Category: Style
+      Title: Remove unnecessary discard
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0100:
+    Metadata:
+      Category: Style
+      Title: Remove redundant equality
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: S1125 triggers in more cases
+        Redundant: S1125
+  IDE0150:
+    Metadata:
+      Category: Style
+      Title: Prefer 'null' check over type check
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - csharp_style_prefer_null_check_over_type_check = true
+  IDE0120:
+    Metadata:
+      Category: Style
+      Title: Simplify LINQ expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0130:
+    Metadata:
+      Category: Style
+      Title: Namespace does not match folder structure
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE2001:
+    Metadata:
+      Category: Style
+      Title: Embedded statements must be on their own line
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE2000:
+    Metadata:
+      Category: Style
+      Title: Avoid multiple blank lines
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_allow_multiple_blank_lines_experimental = false
+  IDE2004:
+    Metadata:
+      Category: Style
+      Title: Blank line not allowed after constructor initializer colon
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE2003:
+    Metadata:
+      Category: Style
+      Title: Blank line required between block and subsequent statement
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE2002:
+    Metadata:
+      Category: Style
+      Title: Consecutive braces must not have blank line between them
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0160:
+    Metadata:
+      Category: Style
+      Title: Convert to block scoped namespace
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_namespace_declarations = file_scoped
+  IDE0161:
+    Metadata:
+      Category: Style
+      Title: Convert to file-scoped namespace
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_namespace_declarations = file_scoped
+  IDE0180:
+    Metadata:
+      Category: Style
+      Title: Use tuple to swap values
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_tuple_swap = true
+  IDE0190:
+    Metadata:
+      Category: Style
+      Title: Null check can be simplified
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0170:
+    Metadata:
+      Category: Style
+      Title: Property pattern can be simplified
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+        Options:
+        - csharp_style_prefer_extended_property_pattern = true
+  IDE0200:
+    Metadata:
+      Category: Style
+      Title: Remove unnecessary lambda expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0230:
+    Metadata:
+      Category: Style
+      Title: Use UTF-8 string literal
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0210:
+    Metadata:
+      Category: Style
+      Title: Convert to top-level statements
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0211:
+    Metadata:
+      Category: Style
+      Title: Convert to 'Program.Main' style program
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0220:
+    Metadata:
+      Category: Style
+      Title: Add explicit cast
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0241:
+    Metadata:
+      Category: Style
+      Title: Remove unnecessary nullable directive
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0240:
+    Metadata:
+      Category: Style
+      Title: Remove redundant nullable directive
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      - Unnecessary
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0250:
+    Metadata:
+      Category: Style
+      Title: Make struct 'readonly'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0260:
+    Metadata:
+      Category: Style
+      Title: Use pattern matching
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0280:
+    Metadata:
+      Category: Style
+      Title: Use 'nameof'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE2005:
+    Metadata:
+      Category: Style
+      Title: Blank line not allowed after conditional expression token
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE2006:
+    Metadata:
+      Category: Style
+      Title: Blank line not allowed after arrow expression clause token
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_WhenExplicitlyEnabled
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0270:
+    Metadata:
+      Category: Style
+      Title: Use coalesce expression
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  IDE0044:
+    Metadata:
+      Category: Style
+      Title: Add readonly modifier
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Silent
+  EnableGenerateDocumentationFile:
+    Metadata:
+      Category: Style
+      Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
+      Description: "Add the following PropertyGroup to your MSBuild project file to enable IDE0005 (Remove unnecessary usings/imports) on build:\r\n  <PropertyGroup>\r\n    <!--\r\n      Make sure any documentation comments which are included in code get checked for syntax during the build, but do\r\n      not report warnings for missing comments.\r\n      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)\r\n      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'\r\n      CS1712: Type parameter 'type_parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)\r\n    -->\r\n    <GenerateDocumentationFile>True</GenerateDocumentationFile>\r\n    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>\r\n  </PropertyGroup>\r\n    "
+      HelpLinkUri: https://github.com/dotnet/roslyn/issues/41640
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Never
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  IDE0251:
+    Metadata:
+      Category: Style
+      Title: Make member 'readonly'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None

--- a/eng/Diags/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.yml
+++ b/eng/Diags/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.yml
@@ -1,0 +1,542 @@
+Origin:
+  AssemblyName: Microsoft.CodeAnalysis.CSharp.NetAnalyzers
+  Version: 8.0.8.26002
+Diagnostics:
+  CA1001:
+    Metadata:
+      Category: Design
+      Title: Types that own disposable fields should be disposable
+      Description: A class declares and implements an instance field that is a System.IDisposable type, and the class does not implement IDisposable. A class that declares an IDisposable field indirectly owns an unmanaged resource and should implement the IDisposable interface.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1019:
+    Metadata:
+      Category: Design
+      Title: Define accessors for attribute arguments
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Suggestion
+      api:
+        Severity: Warning
+  CA1032:
+    Metadata:
+      Category: Design
+      Title: Implement standard exception constructors
+      Description: Failure to provide the full set of constructors can make it difficult to correctly handle exceptions.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1065:
+    Metadata:
+      Category: Design
+      Title: Do not raise exceptions in unexpected locations
+      Description: A method that is not expected to throw exceptions throws an exception.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1200:
+    Metadata:
+      Category: Documentation
+      Title: Avoid using cref tags with a prefix
+      Description: Use of cref tags with prefixes should be avoided, since it prevents the compiler from verifying references and the IDE from updating references during refactorings. It is permissible to suppress this error at a single documentation site if the cref must use a prefix because the type being mentioned is not findable by the compiler. For example, if a cref is mentioning a special attribute in the full framework but you're in a file that compiles against the portable framework, or if you want to reference a type at higher layer of Roslyn, you should suppress the error. You should not suppress the error just because you want to take a shortcut and avoid using the full syntax.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1309:
+    Metadata:
+      Category: Globalization
+      Title: Use ordinal string comparison
+      Description: A string comparison operation that is nonlinguistic does not set the StringComparison parameter to either Ordinal or OrdinalIgnoreCase. By explicitly setting the parameter to either StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase, your code often gains speed, becomes more correct, and becomes more reliable.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Suggestion
+      production:
+        Severity: Warning
+  CA1507:
+    Metadata:
+      Category: Maintainability
+      Title: Use nameof to express symbol names
+      Description: Using nameof helps keep your code valid when refactoring.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1812:
+    Metadata:
+      Category: Performance
+      Title: Avoid uninstantiated internal classes
+      Description: An instance of an assembly-level type is not created by code in the assembly.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: S1144 finds more cases and has no false positives
+        Redundant: S1144
+  CA1824:
+    Metadata:
+      Category: Performance
+      Title: Mark assemblies with NeutralResourcesLanguageAttribute
+      Description: The NeutralResourcesLanguage attribute informs the ResourceManager of the language that was used to display the resources of a neutral culture for an assembly. This improves lookup performance for the first resource that you load and can reduce your working set.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Suggestion
+      performance:
+        Severity: Warning
+  CA1825:
+    Metadata:
+      Category: Performance
+      Title: Avoid zero-length array allocations
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2016:
+    Metadata:
+      Category: Reliability
+      Title: Forward the 'CancellationToken' parameter to methods
+      Description: Forward the 'CancellationToken' parameter to methods to ensure the operation cancellation notifications gets properly propagated, or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2200:
+    Metadata:
+      Category: Usage
+      Title: Rethrow to preserve stack details
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2234:
+    Metadata:
+      Category: Usage
+      Title: Pass system uri objects instead of strings
+      Description: A call is made to a method that has a string parameter whose name contains "uri", "URI", "urn", "URN", "url", or "URL". The declaring type of the method contains a corresponding method overload that has a System.Uri parameter.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3076:
+    Metadata:
+      Category: Security
+      Title: Insecure XSLT script processing.
+      Description: Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argument with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3077:
+    Metadata:
+      Category: Security
+      Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
+      Description: Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false. 
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2354:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2355:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable type found in deserializable object graph
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2352:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2353:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in serializable type
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2362:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2356:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable type in web deserializable object graph
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2014:
+    Metadata:
+      Category: Reliability
+      Title: Do not use stackalloc in loops
+      Description: Stack space allocated by a stackalloc is only released at the end of the current method's invocation.  Using it in a loop can result in unbounded stack growth and eventual stack overflow conditions.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1805:
+    Metadata:
+      Category: Performance
+      Title: Do not initialize unnecessarily
+      Description: The .NET runtime initializes all fields of reference types to their default values before running the constructor. In most cases, explicitly initializing a field to its default value in a constructor is redundant, adding maintenance costs and potentially degrading performance (such as with increased assembly size), and the explicit initialization can be removed.  In some cases, such as with static readonly fields that permanently retain their default value, consider instead changing them to be constants or properties.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1801:
+    Metadata:
+      Category: Usage
+      Title: Review unused parameters
+      Description: Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0060
+  CA2252:
+    Metadata:
+      Category: Usage
+      Title: This API requires opting into preview features
+      Description: An assembly has to opt into preview features before using them.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  CA1841:
+    Metadata:
+      Category: Performance
+      Title: Prefer Dictionary.Contains methods
+      Description: Many dictionary implementations lazily initialize the Values collection. To avoid unnecessary allocations, prefer 'ContainsValue' over 'Values.Contains'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1845:
+    Metadata:
+      Category: Performance
+      Title: Use span-based 'string.Concat'
+      Description: It is more efficient to use 'AsSpan' and 'string.Concat', instead of 'Substring' and a concatenation operator.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1802:
+    Metadata:
+      Category: Performance
+      Title: Use literals where appropriate
+      Description: A field is declared static and read-only (Shared and ReadOnly in Visual Basic), and is initialized by using a value that is computable at compile time. Because the value that is assigned to the targeted field is computable at compile time, change the declaration to a const (Const in Visual Basic) field so that the value is computed at compile time instead of at run?time.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2260:
+    Metadata:
+      Category: Usage
+      Title: Use correct type parameter
+      Description: Generic math interfaces require the derived type itself to be used for the self recurring type parameter.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1311:
+    Metadata:
+      Category: Globalization
+      Title: Specify a culture or use an invariant version
+      Description: Specify culture to help avoid accidental implicit dependency on current culture. Using an invariant version yields consistent results regardless of the culture of an application.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1855:
+    Metadata:
+      Category: Performance
+      Title: Prefer 'Clear' over 'Fill'
+      Description: It is more efficient to use 'Clear', instead of 'Fill' with default value.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1851:
+    Metadata:
+      Category: Performance
+      Title: Possible multiple enumerations of 'IEnumerable' collection
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA2020:
+    Metadata:
+      Category: Reliability
+      Title: Prevent behavioral change
+      Description: Some built-in operators added in .NET 7 behave differently when overflowing than did the corresponding user-defined operators in .NET 6 and earlier versions. Some operators that previously threw in an unchecked context now don't throw unless wrapped within a checked context. Also, some operators that did not previously throw in a checked context now throw unless wrapped in an unchecked context.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1856:
+    Metadata:
+      Category: Performance
+      Title: Incorrect usage of ConstantExpected attribute
+      Description: ConstantExpected attribute is not applied correctly on the parameter.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  CA1857:
+    Metadata:
+      Category: Performance
+      Title: A constant is expected for the parameter
+      Description: The parameter expects a constant for optimal performance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/Microsoft.CodeAnalysis.CodeStyle.yml
+++ b/eng/Diags/Microsoft.CodeAnalysis.CodeStyle.yml
@@ -1,0 +1,49 @@
+Origin:
+  AssemblyName: Microsoft.CodeAnalysis.CodeStyle
+  Version: 4.7.8.26202
+Diagnostics:
+  IDE0033:
+    Metadata:
+      Category: Style
+      Title: Use explicitly provided tuple name
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_explicit_tuple_names = true
+  IDE0044:
+    Metadata:
+      Category: Style
+      Title: Add readonly modifier
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_HighlyRecommended
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - dotnet_style_readonly_field = true:warning
+  IDE0070:
+    Metadata:
+      Category: Style
+      Title: Use 'System.HashCode'
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+      CustomTags:
+      - Telemetry
+      - EnforceOnBuild_Recommended
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/Microsoft.CodeAnalysis.NetAnalyzers.yml
+++ b/eng/Diags/Microsoft.CodeAnalysis.NetAnalyzers.yml
@@ -1,0 +1,4460 @@
+Origin:
+  AssemblyName: Microsoft.CodeAnalysis.NetAnalyzers
+  Version: 8.0.8.26002
+Diagnostics:
+  CA1000:
+    Metadata:
+      Category: Design
+      Title: Do not declare static members on generic types
+      Description: When a static member of a generic type is called, the type argument must be specified for the type. When a generic instance member that does not support inference is called, the type argument must be specified for the member. In these two cases, the syntax for specifying the type argument is different and easily confused.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1002:
+    Metadata:
+      Category: Design
+      Title: Do not expose generic lists
+      Description: System.Collections.Generic.List<T> is a generic collection that's designed for performance and not inheritance. List<T> does not contain virtual members that make it easier to change the behavior of an inherited class.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1003:
+    Metadata:
+      Category: Design
+      Title: Use generic event handler instances
+      Description: A type contains an event that declares an EventHandler delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets Microsoft .NET Framework?2.0.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1005:
+    Metadata:
+      Category: Design
+      Title: Avoid excessive parameters on generic types
+      Description: The more type parameters a generic type contains, the more difficult it is to know and remember what each type parameter represents.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1008:
+    Metadata:
+      Category: Design
+      Title: Enums should have zero value
+      Description: The default value of an uninitialized enumeration, just as other value types, is zero. A nonflags-attributed enumeration should define a member by using the value of zero so that the default value is a valid value of the enumeration. If an enumeration that has the FlagsAttribute attribute applied defines a zero-valued member, its name should be ""None"" to indicate that no values have been set in the enumeration.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - RuleNoZero
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1010:
+    Metadata:
+      Category: Design
+      Title: Generic interface should also be implemented
+      Description: To broaden the usability of a type, implement one of the generic interfaces. This is especially true for collections as they can then be used to populate generic collection types.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+        Options:
+        - api_surface = all
+        - additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+        - additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+  CA1012:
+    Metadata:
+      Category: Design
+      Title: Abstract types should not have public constructors
+      Description: Constructors on abstract types can be called only by derived types. Because public constructors create instances of a type, and you cannot create instances of an abstract type, an abstract type that has a public constructor is incorrectly designed.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1014:
+    Metadata:
+      Category: Design
+      Title: Mark assemblies with CLSCompliant
+      Description: The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 99
+    Attributes:
+      general:
+        Severity: None
+  CA1016:
+    Metadata:
+      Category: Design
+      Title: Mark assemblies with assembly version
+      Description: The .NET Framework uses the version number to uniquely identify an assembly, and to bind to types in strongly named assemblies. The version number is used together with version and publisher policy. By default, applications run only with the assembly version with which they were built.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1017:
+    Metadata:
+      Category: Design
+      Title: Mark assemblies with ComVisible
+      Description: ComVisibleAttribute determines how COM clients access managed code. Good design dictates that assemblies explicitly indicate COM visibility. COM visibility can be set for the whole assembly and then overridden for individual types and type members. If this attribute is not present, the contents of the assembly are visible to COM clients.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 99
+    Attributes:
+      general:
+        Severity: None
+  CA1018:
+    Metadata:
+      Category: Design
+      Title: Mark attributes with AttributeUsageAttribute
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1021:
+    Metadata:
+      Category: Design
+      Title: Avoid out parameters
+      Description: Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods with multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  CA1024:
+    Metadata:
+      Category: Design
+      Title: Use properties where appropriate
+      Description: A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1027:
+    Metadata:
+      Category: Design
+      Title: Mark enums with FlagsAttribute
+      Description: An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1028:
+    Metadata:
+      Category: Design
+      Title: Enum Storage should be Int32
+      Description: An enumeration is a value type that defines a set of related named constants. By default, the System.Int32 data type is used to store the constant value. Although you can change this underlying type, it is not required or recommended for most scenarios.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  CA1030:
+    Metadata:
+      Category: Design
+      Title: Use events where appropriate
+      Description: This rule detects methods that have names that ordinarily would be used for events. If a method is called in response to a clearly defined state change, the method should be invoked by an event handler. Objects that call the method should raise events instead of calling the method directly.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1031:
+    Metadata:
+      Category: Design
+      Title: Do not catch general exception types
+      Description: A general exception such as System.Exception or System.SystemException or a disallowed exception type is caught in a catch statement, or a general catch clause is used. General and disallowed exceptions should not be caught.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1033:
+    Metadata:
+      Category: Design
+      Title: Interface methods should be callable by child types
+      Description: An unsealed externally visible type provides an explicit method implementation of a public interface and does not provide an alternative externally visible method that has the same name.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1034:
+    Metadata:
+      Category: Design
+      Title: Nested types should not be visible
+      Description: A nested type is a type that is declared in the scope of another type. Nested types are useful to encapsulate private implementation details of the containing type. Used for this purpose, nested types should not be externally visible.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1036:
+    Metadata:
+      Category: Design
+      Title: Override methods on comparable types
+      Description: A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1040:
+    Metadata:
+      Category: Design
+      Title: Avoid empty interfaces
+      Description: Interfaces define members that provide a behavior or usage contract. The functionality that is described by the interface can be adopted by any type, regardless of where the type appears in the inheritance hierarchy. A type implements an interface by providing implementations for the members of the interface. An empty interface does not define any members; therefore, it does not define a contract that can be implemented.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Comment: Reasonably frequent in modern .NET programming
+  CA1041:
+    Metadata:
+      Category: Design
+      Title: Provide ObsoleteAttribute message
+      Description: A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1043:
+    Metadata:
+      Category: Design
+      Title: Use Integral Or String Argument For Indexers
+      Description: Indexers, that is, indexed properties, should use integer or string types for the index. These types are typically used for indexing data structures and increase the usability of the library. Use of the Object type should be restricted to those cases where the specific integer or string type cannot be specified at design time. If the design requires other types for the index, reconsider whether the type represents a logical data store. If it does not represent a logical data store, use a method.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public, protected
+  CA1044:
+    Metadata:
+      Category: Design
+      Title: Properties should not be write only
+      Description: Although it is acceptable and often necessary to have a read-only property, the design guidelines prohibit the use of write-only properties. This is because letting a user set a value, and then preventing the user from viewing that value, does not provide any security. Also, without read access, the state of shared objects cannot be viewed, which limits their usefulness.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1045:
+    Metadata:
+      Category: Design
+      Title: Do not pass types by reference
+      Description: Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Suggestion
+        Options:
+        - api_surface = public
+  CA1046:
+    Metadata:
+      Category: Design
+      Title: Do not overload equality operator on reference types
+      Description: For reference types, the default implementation of the equality operator is almost always correct. By default, two references are equal only if they point to the same object. If the operator is providing meaningful value equality, the type should implement the generic 'System.IEquatable' interface.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1047:
+    Metadata:
+      Category: Design
+      Title: Do not declare protected member in sealed type
+      Description: Types declare protected members so that inheriting types can access or override the member. By definition, you cannot inherit from a sealed type, which means that protected methods on sealed types cannot be called.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1050:
+    Metadata:
+      Category: Design
+      Title: Declare types in namespaces
+      Description: Types are declared in namespaces to prevent name collisions and as a way to organize related types in an object hierarchy.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1051:
+    Metadata:
+      Category: Design
+      Title: Do not declare visible instance fields
+      Description: The primary use of a field should be as an implementation detail. Fields should be private or internal and should be exposed by using properties.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1052:
+    Metadata:
+      Category: Design
+      Title: Static holder types should be Static or NotInheritable
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1054:
+    Metadata:
+      Category: Design
+      Title: URI-like parameters should not be strings
+      Description: This rule assumes that the parameter represents a Uniform Resource Identifier (URI). A string representation or a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. 'System.Uri' class provides these services in a safe and secure manner.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1055:
+    Metadata:
+      Category: Design
+      Title: URI-like return values should not be strings
+      Description: This rule assumes that the method returns a URI. A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. The System.Uri class provides these services in a safe and secure manner.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1056:
+    Metadata:
+      Category: Design
+      Title: URI-like properties should not be strings
+      Description: This rule assumes that the property represents a Uniform Resource Identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. The System.Uri class provides these services in a safe and secure manner.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1058:
+    Metadata:
+      Category: Design
+      Title: Types should not extend certain base types
+      Description: An externally visible type extends certain base types. Use one of the alternatives.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1060:
+    Metadata:
+      Category: Design
+      Title: Move pinvokes to native methods class
+      Description: Platform Invocation methods, such as those that are marked by using the System.Runtime.InteropServices.DllImportAttribute attribute, or methods that are defined by using the Declare keyword in Visual Basic, access unmanaged code. These methods should be of the NativeMethods, SafeNativeMethods, or UnsafeNativeMethods class.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1061:
+    Metadata:
+      Category: Design
+      Title: Do not hide base class methods
+      Description: A method in a base type is hidden by an identically named method in a derived type when the parameter signature of the derived method differs only by types that are more weakly derived than the corresponding types in the parameter signature of the base method.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1062:
+    Metadata:
+      Category: Design
+      Title: Validate arguments of public methods
+      Description: An externally visible method dereferences one of its reference arguments without verifying whether that argument is 'null' ('Nothing' in Visual Basic). All reference arguments that are passed to externally visible methods should be checked against 'null'. If appropriate, throw an 'ArgumentNullException' when the argument is 'null'. If the method is designed to be called only by known assemblies, you should make the method internal.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+      CustomTags:
+      - PortedFromFxCop
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public, protected
+        - exclude_extension_method_this_parameter = false
+        - null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+  CA1063:
+    Metadata:
+      Category: Design
+      Title: Implement IDisposable Correctly
+      Description: All IDisposable types should implement the Dispose pattern correctly.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA1064:
+    Metadata:
+      Category: Design
+      Title: Exceptions should be public
+      Description: An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+      production:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1066:
+    Metadata:
+      Category: Design
+      Title: Implement IEquatable when overriding Object.Equals
+      Description: When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable<T>, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable<T>.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1067:
+    Metadata:
+      Category: Design
+      Title: Override Object.Equals(object) when implementing IEquatable<T>
+      Description: When a type T implements the interface IEquatable<T>, it suggests to a user who sees a call to the Equals method in source code that an instance of the type can be equated with an instance of any other type. The user might be confused if their attempt to equate the type with an instance of another type fails to compile. This violates the "principle of least surprise".
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1068:
+    Metadata:
+      Category: Design
+      Title: CancellationToken parameters must come last
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public, protected
+  CA1069:
+    Metadata:
+      Category: Design
+      Title: Enums values should not be duplicated
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1070:
+    Metadata:
+      Category: Design
+      Title: Do not declare event fields as virtual
+      Description: Do not declare virtual events in a base class. Overridden events in a derived class have undefined behavior. The C# compiler does not handle this correctly and it is unpredictable whether a subscriber to the derived event will actually be subscribing to the base class event.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA1303:
+    Metadata:
+      Category: Globalization
+      Title: Do not pass literals as localized parameters
+      Description: A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable. To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the ResourceManager class.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+      CustomTags:
+      - PortedFromFxCop
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1304:
+    Metadata:
+      Category: Globalization
+      Title: Specify CultureInfo
+      Description: A method or constructor calls a member that has an overload that accepts a System.Globalization.CultureInfo parameter, and the method or constructor does not call the overload that takes the CultureInfo parameter. When a CultureInfo or System.IFormatProvider object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales. If the result will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'CultureInfo' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1305:
+    Metadata:
+      Category: Globalization
+      Title: Specify IFormatProvider
+      Description: A method or constructor calls one or more members that have overloads that accept a System.IFormatProvider parameter, and the method or constructor does not call the overload that takes the IFormatProvider parameter. When a System.Globalization.CultureInfo or IFormatProvider object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales. If the result will be based on the input from/output displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider'. Otherwise, if the result will be stored and accessed by software, such as when it is loaded from disk/database and when it is persisted to disk/database, specify 'CultureInfo.InvariantCulture'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1307:
+    Metadata:
+      Category: Globalization
+      Title: Specify StringComparison for clarity
+      Description: A string comparison operation uses a method overload that does not set a StringComparison parameter. It is recommended to use the overload with StringComparison parameter for clarity of intent. If the result will be displayed to the user, such as when sorting a list of items for display in a list box, specify 'StringComparison.CurrentCulture' or 'StringComparison.CurrentCultureIgnoreCase' as the 'StringComparison' parameter. If comparing case-insensitive identifiers, such as file paths, environment variables, or registry keys and values, specify 'StringComparison.OrdinalIgnoreCase'. Otherwise, if comparing case-sensitive identifiers, specify 'StringComparison.Ordinal'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1308:
+    Metadata:
+      Category: Globalization
+      Title: Normalize strings to uppercase
+      Description: Strings should be normalized to uppercase. A small group of characters cannot make a round trip when they are converted to lowercase. To make a round trip means to convert the characters from one locale to another locale that represents character data differently, and then to accurately retrieve the original characters from the converted characters.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1310:
+    Metadata:
+      Category: Globalization
+      Title: Specify StringComparison for correctness
+      Description: A string comparison operation uses a method overload that does not set a StringComparison parameter, hence its behavior could vary based on the current user's locale settings. It is strongly recommended to use the overload with StringComparison parameter for correctness and clarity of intent. If the result will be displayed to the user, such as when sorting a list of items for display in a list box, specify 'StringComparison.CurrentCulture' or 'StringComparison.CurrentCultureIgnoreCase' as the 'StringComparison' parameter. If comparing case-insensitive identifiers, such as file paths, environment variables, or registry keys and values, specify 'StringComparison.OrdinalIgnoreCase'. Otherwise, if comparing case-sensitive identifiers, specify 'StringComparison.Ordinal'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1401:
+    Metadata:
+      Category: Interoperability
+      Title: P/Invokes should not be visible
+      Description: A public or protected method in a public type has the System.Runtime.InteropServices.DllImportAttribute attribute (also implemented by the Declare keyword in Visual Basic). Such methods should not be exposed.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA1416:
+    Metadata:
+      Category: Interoperability
+      Title: Validate platform compatibility
+      Description: Using platform dependent API on a component makes the code no longer work across all platforms.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1417:
+    Metadata:
+      Category: Interoperability
+      Title: Do not use 'OutAttribute' on string parameters for P/Invokes
+      Description: String parameters passed by value with the 'OutAttribute' can destabilize the runtime if the string is an interned string.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1501:
+    Metadata:
+      Category: Maintainability
+      Title: Avoid excessive inheritance
+      Description: Deeply nested type hierarchies can be difficult to follow, understand, and maintain. This rule limits analysis to hierarchies in the same module. To fix a violation of this rule, derive the type from a base type that is less deep in the inheritance hierarchy or eliminate some of the intermediate base types.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1502:
+    Metadata:
+      Category: Maintainability
+      Title: Avoid excessive complexity
+      Description: 'Cyclomatic complexity measures the number of linearly independent paths through the method, which is determined by the number and complexity of conditional branches. A low cyclomatic complexity generally indicates a method that is easy to understand, test, and maintain. The cyclomatic complexity is calculated from a control flow graph of the method and is given as follows: `cyclomatic complexity = the number of edges - the number of nodes + 1`, where a node represents a logic branch point and an edge represents a line between nodes.'
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: Code gets complicated
+  CA1505:
+    Metadata:
+      Category: Maintainability
+      Title: Avoid unmaintainable code
+      Description: 'The maintainability index is calculated by using the following metrics: lines of code, program volume, and cyclomatic complexity. Program volume is a measure of the difficulty of understanding of a symbol that is based on the number of operators and operands in the code. Cyclomatic complexity is a measure of the structural complexity of the type or method. A low maintainability index indicates that code is probably difficult to maintain and would be a good candidate to redesign.'
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1506:
+    Metadata:
+      Category: Maintainability
+      Title: Avoid excessive class coupling
+      Description: This rule measures class coupling by counting the number of unique type references that a symbol contains. Symbols that have a high degree of class coupling can be difficult to maintain. It is a good practice to have types and methods that exhibit low coupling and high cohesion. To fix this violation, try to redesign the code to reduce the number of types to which it is coupled.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: Code gets complicated
+  CA1508:
+    Metadata:
+      Category: Maintainability
+      Title: Avoid dead conditional code
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1509:
+    Metadata:
+      Category: Maintainability
+      Title: Invalid entry in code metrics rule specification file
+      Description: Invalid entry in code metrics rule specification file.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+      CustomTags:
+      - Telemetry
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1700:
+    Metadata:
+      Category: Naming
+      Title: Do not name enum values 'Reserved'
+      Description: This rule assumes that an enumeration member that has a name that contains "reserved" is not currently used but is a placeholder to be renamed or removed in a future version. Renaming or removing a member is a breaking change.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1707:
+    Metadata:
+      Category: Naming
+      Title: Identifiers should not contain underscores
+      Description: By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Comment: StyleCop handles this
+  CA1708:
+    Metadata:
+      Category: Naming
+      Title: Identifiers should differ by more than case
+      Description: Identifiers for namespaces, types, members, and parameters cannot differ only by case because languages that target the common language runtime are not required to be case-sensitive.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Silent
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1710:
+    Metadata:
+      Category: Naming
+      Title: Identifiers should have correct suffix
+      Description: By convention, the names of types that extend certain base types or that implement certain interfaces, or types that are derived from these types, have a suffix that is associated with the base type or interface.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Silent
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1711:
+    Metadata:
+      Category: Naming
+      Title: Identifiers should not have incorrect suffix
+      Description: By convention, only the names of types that extend certain base types or that implement certain interfaces, or types that are derived from these types, should end with specific reserved suffixes. Other type names should not use these reserved suffixes.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Silent
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1712:
+    Metadata:
+      Category: Naming
+      Title: Do not prefix enum values with type name
+      Description: An enumeration's values should not start with the type name of the enumeration.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1713:
+    Metadata:
+      Category: Naming
+      Title: Events should not have 'Before' or 'After' prefix
+      Description: Event names should describe the action that raises the event. To name related events that are raised in a specific sequence, use the present or past tense to indicate the relative position in the sequence of actions. For example, when naming a pair of events that is raised when closing a resource, you might name it 'Closing' and 'Closed', instead of 'BeforeClose' and 'AfterClose'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1715:
+    Metadata:
+      Category: Naming
+      Title: Identifiers should have correct prefix
+      Description: The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  CA1716:
+    Metadata:
+      Category: Naming
+      Title: Identifiers should not match keywords
+      Description: A namespace name or a type name matches a reserved keyword in a programming language. Identifiers for namespaces and types should not match keywords that are defined by languages that target the common language runtime.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+        - analyzed_symbol_kinds = all
+  CA1720:
+    Metadata:
+      Category: Naming
+      Title: Identifier contains type name
+      Description: Names of parameters and members are better used to communicate their meaning than to describe their type, which is expected to be provided by development tools. For names of members, if a data type name must be used, use a language-independent name instead of a language-specific one.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Silent
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1721:
+    Metadata:
+      Category: Naming
+      Title: Property names should not match get methods
+      Description: The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1724:
+    Metadata:
+      Category: Naming
+      Title: Type names should not match namespaces
+      Description: Type names should not match the names of namespaces that are defined in the .NET Framework class library. Violating this rule can reduce the usability of the library.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA1725:
+    Metadata:
+      Category: Naming
+      Title: Parameter names should match base declaration
+      Description: Consistent naming of parameters in an override hierarchy increases the usability of the method overrides. A parameter name in a derived method that differs from the name in the base declaration can cause confusion about whether the method is an override of the base method or a new overload of the method.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1801:
+    Metadata:
+      Category: Usage
+      Title: Review unused parameters
+      Description: Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0060
+  CA1802:
+    Metadata:
+      Category: Performance
+      Title: Use literals where appropriate
+      Description: A field is declared static and read-only (Shared and ReadOnly in Visual Basic), and is initialized by using a value that is computable at compile time. Because the value that is assigned to the targeted field is computable at compile time, change the declaration to a const (Const in Visual Basic) field so that the value is computed at compile time instead of at run?time.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1805:
+    Metadata:
+      Category: Performance
+      Title: Do not initialize unnecessarily
+      Description: The .NET runtime initializes all fields of reference types to their default values before running the constructor. In most cases, explicitly initializing a field to its default value in a constructor is redundant, adding maintenance costs and potentially degrading performance (such as with increased assembly size), and the explicit initialization can be removed.  In some cases, such as with static readonly fields that permanently retain their default value, consider instead changing them to be constants or properties.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1806:
+    Metadata:
+      Category: Performance
+      Title: Do not ignore method results
+      Description: A new object is created but never used; or a method that creates and returns a new string is called and the new string is never used; or a COM or P/Invoke method returns an HRESULT or error code that is never used.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1810:
+    Metadata:
+      Category: Performance
+      Title: Initialize reference type static fields inline
+      Description: A reference type declares an explicit static constructor. To fix a violation of this rule, initialize all static data when it is declared and remove the static constructor.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1813:
+    Metadata:
+      Category: Performance
+      Title: Avoid unsealed attributes
+      Description: The .NET Framework class library provides methods for retrieving custom attributes. By default, these methods search the attribute inheritance hierarchy. Sealing the attribute eliminates the search through the inheritance hierarchy and can improve performance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1814:
+    Metadata:
+      Category: Performance
+      Title: Prefer jagged arrays over multidimensional
+      Description: A jagged array is an array whose elements are arrays. The arrays that make up the elements can be of different sizes, leading to less wasted space for some sets of data.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1815:
+    Metadata:
+      Category: Performance
+      Title: Override equals and operator equals on value types
+      Description: For value types, the inherited implementation of Equals uses the Reflection library and compares the contents of all fields. Reflection is computationally expensive, and comparing every field for equality might be unnecessary. If you expect users to compare or sort instances, or to use instances as hash table keys, your value type should implement Equals.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1816:
+    Metadata:
+      Category: Usage
+      Title: Dispose methods should call SuppressFinalize
+      Description: A method that is an implementation of Dispose does not call GC.SuppressFinalize; or a method that is not an implementation of Dispose calls GC.SuppressFinalize; or a method calls GC.SuppressFinalize and passes something other than this (Me in Visual Basic).
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1819:
+    Metadata:
+      Category: Performance
+      Title: Properties should not return arrays
+      Description: Arrays that are returned by properties are not write-protected, even when the property is read-only. To keep the array tamper-proof, the property must return a copy of the array. Typically, users will not understand the adverse performance implications of calling such a property.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1820:
+    Metadata:
+      Category: Performance
+      Title: Test for empty strings using string length
+      Description: Comparing strings by using the String.Length property or the String.IsNullOrEmpty method is significantly faster than using Equals.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1821:
+    Metadata:
+      Category: Performance
+      Title: Remove empty Finalizers
+      Description: Finalizers should be avoided where possible, to avoid the additional performance overhead involved in tracking object lifetime.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1822:
+    Metadata:
+      Category: Performance
+      Title: Mark members as static
+      Description: Members that do not access instance data or call instance methods can be marked as static. After you mark the methods as static, the compiler will emit nonvirtual call sites to these members. This can give you a measurable performance gain for performance-sensitive code.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1823:
+    Metadata:
+      Category: Performance
+      Title: Avoid unused private fields
+      Description: Private fields were detected that do not appear to be accessed in the assembly.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 99
+    Attributes:
+      general:
+        Severity: None
+        Redundant: S1144
+  CA1826:
+    Metadata:
+      Category: Performance
+      Title: Do not use Enumerable methods on indexable collections
+      Description: This collection is directly indexable. Going through LINQ here causes unnecessary allocations and CPU work.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1827:
+    Metadata:
+      Category: Performance
+      Title: Do not use Count() or LongCount() when Any() can be used
+      Description: For non-empty collections, Count() and LongCount() enumerate the entire sequence, while Any() stops at the first item or the first item that satisfies a condition.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1828:
+    Metadata:
+      Category: Performance
+      Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+      Description: For non-empty collections, CountAsync() and LongCountAsync() enumerate the entire sequence, while AnyAsync() stops at the first item or the first item that satisfies a condition.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1829:
+    Metadata:
+      Category: Performance
+      Title: Use Length/Count property instead of Count() when available
+      Description: Enumerable.Count() potentially enumerates the sequence while a Length/Count property is a direct access.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1830:
+    Metadata:
+      Category: Performance
+      Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+      Description: StringBuilder.Append and StringBuilder.Insert provide overloads for multiple types beyond System.String.  When possible, prefer the strongly-typed overloads over using ToString() and the string-based overload.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1831:
+    Metadata:
+      Category: Performance
+      Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+      Description: The Range-based indexer on string values produces a copy of requested portion of the string. This copy is usually unnecessary when it is implicitly used as a ReadOnlySpan or ReadOnlyMemory value. Use the AsSpan method to avoid the unnecessary copy.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1832:
+    Metadata:
+      Category: Performance
+      Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+      Description: The Range-based indexer on array values produces a copy of requested portion of the array. This copy is usually unnecessary when it is implicitly used as a ReadOnlySpan or ReadOnlyMemory value. Use the AsSpan method to avoid the unnecessary copy.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1833:
+    Metadata:
+      Category: Performance
+      Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+      Description: The Range-based indexer on array values produces a copy of requested portion of the array. This copy is often unwanted when it is implicitly used as a Span or Memory value. Use the AsSpan method to avoid the copy.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1834:
+    Metadata:
+      Category: Performance
+      Title: Consider using 'StringBuilder.Append(char)' when applicable
+      Description: "'StringBuilder.Append(char)' is more efficient than 'StringBuilder.Append(string)' when the string is a single character. When calling 'Append' with a constant, prefer using a constant char rather than a constant string containing one character."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1835:
+    Metadata:
+      Category: Performance
+      Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+      Description: "'Stream' has a 'ReadAsync' overload that takes a 'Memory<Byte>' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory<Byte>' as the first argument. Prefer calling the memory based overloads, which are more efficient."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1836:
+    Metadata:
+      Category: Performance
+      Title: Prefer IsEmpty over Count
+      Description: For determining whether the object contains or not any items, prefer using 'IsEmpty' property rather than retrieving the number of items from the 'Count' property and comparing it to 0 or 1.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1837:
+    Metadata:
+      Category: Performance
+      Title: Use 'Environment.ProcessId'
+      Description: "'Environment.ProcessId' is simpler and faster than 'Process.GetCurrentProcess().Id'."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1838:
+    Metadata:
+      Category: Performance
+      Title: Avoid 'StringBuilder' parameters for P/Invokes
+      Description: Marshalling of 'StringBuilder' always creates a native buffer copy, resulting in multiple allocations for one marshalling operation.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2000:
+    Metadata:
+      Category: Reliability
+      Title: Dispose objects before losing scope
+      Description: If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+      CustomTags:
+      - PortedFromFxCop
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2002:
+    Metadata:
+      Category: Reliability
+      Title: Do not lock on objects with weak identity
+      Description: An object is said to have a weak identity when it can be directly accessed across application domain boundaries. A thread that tries to acquire a lock on an object that has a weak identity can be blocked by a second thread in a different application domain that has a lock on the same object.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2007:
+    Metadata:
+      Category: Reliability
+      Title: Consider calling ConfigureAwait on the awaited task
+      Description: When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2008:
+    Metadata:
+      Category: Reliability
+      Title: Do not create tasks without passing a TaskScheduler
+      Description: Do not create tasks unless you are using one of the overloads that takes a TaskScheduler. The default is to schedule on TaskScheduler.Current, which would lead to deadlocks. Either use TaskScheduler.Default to schedule on the thread pool, or explicitly pass TaskScheduler.Current to make your intentions clear.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2009:
+    Metadata:
+      Category: Reliability
+      Title: Do not call ToImmutableCollection on an ImmutableCollection value
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA2011:
+    Metadata:
+      Category: Reliability
+      Title: Avoid infinite recursion
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Error
+  CA2012:
+    Metadata:
+      Category: Reliability
+      Title: Use ValueTasks correctly
+      Description: ValueTasks returned from member invocations are intended to be directly awaited.  Attempts to consume a ValueTask multiple times or to directly access one's result before it's known to be completed may result in an exception or corruption.  Ignoring such a ValueTask is likely an indication of a functional bug and may degrade performance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA2013:
+    Metadata:
+      Category: Reliability
+      Title: Do not use ReferenceEquals with value types
+      Description: Value type typed arguments are uniquely boxed for each call to this method, therefore the result can be unexpected.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2014:
+    Metadata:
+      Category: Reliability
+      Title: Do not use stackalloc in loops
+      Description: Stack space allocated by a stackalloc is only released at the end of the current method's invocation.  Using it in a loop can result in unbounded stack growth and eventual stack overflow conditions.
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2015:
+    Metadata:
+      Category: Reliability
+      Title: Do not define finalizers for types derived from MemoryManager<T>
+      Description: Adding a finalizer to a type derived from MemoryManager<T> may permit memory to be freed while it is still in use by a Span<T>.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2100:
+    Metadata:
+      Category: Security
+      Title: Review SQL queries for security vulnerabilities
+      Description: SQL queries that directly use user input can be vulnerable to SQL injection attacks. Review this SQL query for potential vulnerabilities, and consider using a parameterized SQL query.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+      CustomTags:
+      - PortedFromFxCop
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2101:
+    Metadata:
+      Category: Globalization
+      Title: Specify marshaling for P/Invoke string arguments
+      Description: A platform invoke member allows partially trusted callers, has a string parameter, and does not explicitly marshal the string. This can cause a potential security vulnerability.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA2109:
+    Metadata:
+      Category: Security
+      Title: Review visible event handlers
+      Description: A public or protected event-handling method was detected. Event-handling methods should not be exposed unless absolutely necessary.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA2119:
+    Metadata:
+      Category: Security
+      Title: Seal methods that satisfy private interfaces
+      Description: An inheritable public type provides an overridable method implementation of an internal (Friend in Visual Basic) interface. To fix a violation of this rule, prevent the method from being overridden outside the assembly.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2153:
+    Metadata:
+      Category: Security
+      Title: Do Not Catch Corrupted State Exceptions
+      Description: Catching corrupted state exceptions could mask errors (such as access violations), resulting in inconsistent state of execution or making it easier for attackers to compromise system. Instead, catch and handle a more specific set of exception type(s) or re-throw the exception.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2201:
+    Metadata:
+      Category: Usage
+      Title: Do not raise reserved exception types
+      Description: An exception of type that is not sufficiently specific or reserved by the runtime should never be raised by user code. This makes the original error difficult to detect and debug. If this exception instance might be thrown, use a different exception type.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2207:
+    Metadata:
+      Category: Usage
+      Title: Initialize value type static fields inline
+      Description: A value type declares an explicit static constructor. To fix a violation of this rule, initialize all static data when it is declared and remove the static constructor.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2208:
+    Metadata:
+      Category: Usage
+      Title: Instantiate argument exceptions correctly
+      Description: A call is made to the default (parameterless) constructor of an exception type that is or derives from ArgumentException, or an incorrect string argument is passed to a parameterized constructor of an exception type that is or derives from ArgumentException.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2211:
+    Metadata:
+      Category: Usage
+      Title: Non-constant fields should not be visible
+      Description: Static fields that are neither constants nor read-only are not thread-safe. Access to such a field must be carefully controlled and requires advanced programming techniques to synchronize access to the class object.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA2213:
+    Metadata:
+      Category: Usage
+      Title: Disposable fields should be disposed
+      Description: A type that implements System.IDisposable declares fields that are of types that also implement IDisposable. The Dispose method of the field is not called by the Dispose method of the declaring type. To fix a violation of this rule, call Dispose on fields that are of types that implement IDisposable if you are responsible for allocating and releasing the unmanaged resources held by the field.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+      CustomTags:
+      - PortedFromFxCop
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2214:
+    Metadata:
+      Category: Usage
+      Title: Do not call overridable methods in constructors
+      Description: Virtual methods defined on the class should not be called from constructors. If a derived class has overridden the method, the derived class version will be called (before the derived class constructor is called).
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2215:
+    Metadata:
+      Category: Usage
+      Title: Dispose methods should call base class dispose
+      Description: A type that implements System.IDisposable inherits from a type that also implements IDisposable. The Dispose method of the inheriting type does not call the Dispose method of the parent type. To fix a violation of this rule, call base.Dispose in your Dispose method.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2216:
+    Metadata:
+      Category: Usage
+      Title: Disposable types should declare finalizer
+      Description: A type that implements System.IDisposable and has fields that suggest the use of unmanaged resources does not implement a finalizer, as described by Object.Finalize.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2217:
+    Metadata:
+      Category: Usage
+      Title: Do not mark enums with FlagsAttribute
+      Description: An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+        Options:
+        - api_surface = all
+  CA2219:
+    Metadata:
+      Category: Usage
+      Title: Do not raise exceptions in finally clauses
+      Description: When an exception is raised in a finally clause, the new exception hides the active exception. This makes the original error difficult to detect and debug.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2225:
+    Metadata:
+      Category: Usage
+      Title: Operator overloads have named alternates
+      Description: An operator overload was detected, and the expected named alternative method was not found. The named alternative member provides access to the same functionality as the operator and is provided for developers who program in languages that do not support overloaded operators.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+        Options:
+        - api_surface = public
+  CA2226:
+    Metadata:
+      Category: Usage
+      Title: Operators should have symmetrical overloads
+      Description: A type implements the equality or inequality operator and does not implement the opposite operator.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CS0216
+  CA2227:
+    Metadata:
+      Category: Usage
+      Title: Collection properties should be read only
+      Description: A writable collection property allows a user to replace the collection with a different collection. A read-only property stops the collection from being replaced but still allows the individual members to be set.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  CA2229:
+    Metadata:
+      Category: Usage
+      Title: Implement serialization constructors
+      Description: To fix a violation of this rule, implement the serialization constructor. For a sealed class, make the constructor private; otherwise, make it protected.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Comment: Obsolete
+  CA2231:
+    Metadata:
+      Category: Usage
+      Title: Overload operator equals on overriding value type Equals
+      Description: In most programming languages there is no default implementation of the equality operator (==) for value types. If your programming language supports operator overloads, you should consider implementing the equality operator. Its behavior should be identical to that of Equals.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Error
+  CA2235:
+    Metadata:
+      Category: Usage
+      Title: Mark all non-serializable fields
+      Description: An instance field of a type that is not serializable is declared in a type that is serializable.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Comment: Obsolete
+  CA2237:
+    Metadata:
+      Category: Usage
+      Title: Mark ISerializable types with serializable
+      Description: To be recognized by the common language runtime as serializable, types must be marked by using the SerializableAttribute attribute even when the type uses a custom serialization routine through implementation of the ISerializable interface.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Comment: Obsolete
+  CA2241:
+    Metadata:
+      Category: Usage
+      Title: Provide correct arguments to formatting methods
+      Description: The format argument that is passed to System.String.Format does not contain a format item that corresponds to each object argument, or vice versa.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2242:
+    Metadata:
+      Category: Usage
+      Title: Test for NaN correctly
+      Description: This expression tests a value against Single.Nan or Double.Nan. Use Single.IsNan(Single) or Double.IsNan(Double) to test the value.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2243:
+    Metadata:
+      Category: Usage
+      Title: Attribute string literals should parse correctly
+      Description: The string literal parameter of an attribute does not parse correctly for a URL, a GUID, or a version.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2244:
+    Metadata:
+      Category: Usage
+      Title: Do not duplicate indexed element initializations
+      Description: Indexed elements in objects initializers must initialize unique elements. A duplicate index might overwrite a previous element initialization.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2245:
+    Metadata:
+      Category: Usage
+      Title: Do not assign a property to itself
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2246:
+    Metadata:
+      Category: Usage
+      Title: Assigning symbol and its member in the same statement
+      Description: Assigning to a symbol and its member (field/property) in the same statement is not recommended. It is not clear if the member access was intended to use symbol's old value prior to the assignment or new value from the assignment in this statement. For clarity, consider splitting the assignments into separate statements.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA2247:
+    Metadata:
+      Category: Usage
+      Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+      Description: TaskCompletionSource has constructors that take TaskCreationOptions that control the underlying Task, and constructors that take object state that's stored in the task.  Accidentally passing a TaskContinuationOptions instead of a TaskCreationOptions will result in the call treating the options as state.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2248:
+    Metadata:
+      Category: Usage
+      Title: Provide correct 'enum' argument to 'Enum.HasFlag'
+      Description: "'Enum.HasFlag' method expects the 'enum' argument to be of the same 'enum' type as the instance on which the method is invoked and that this 'enum' is marked with 'System.FlagsAttribute'. If these are different 'enum' types, an unhandled exception will be thrown at runtime. If the 'enum' type is not marked with 'System.FlagsAttribute' the call will always return 'false' at runtime."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA2249:
+    Metadata:
+      Category: Usage
+      Title: Consider using 'string.Contains' instead of 'string.IndexOf'
+      Description: Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2300:
+    Metadata:
+      Category: Security
+      Title: Do not use insecure deserializer BinaryFormatter
+      Description: The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect BinaryFormatter deserialization without a SerializationBinder set, then disable rule CA2300, and enable rules CA2301 and CA2302.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2301:
+    Metadata:
+      Category: Security
+      Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2302:
+    Metadata:
+      Category: Security
+      Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2305:
+    Metadata:
+      Category: Security
+      Title: Do not use insecure deserializer LosFormatter
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2310:
+    Metadata:
+      Category: Security
+      Title: Do not use insecure deserializer NetDataContractSerializer
+      Description: The method '{0}' is insecure when deserializing untrusted data.  If you need to instead detect NetDataContractSerializer deserialization without a SerializationBinder set, then disable rule CA2310, and enable rules CA2311 and CA2312.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2311:
+    Metadata:
+      Category: Security
+      Title: Do not deserialize without first setting NetDataContractSerializer.Binder
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2312:
+    Metadata:
+      Category: Security
+      Title: Ensure NetDataContractSerializer.Binder is set before deserializing
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2315:
+    Metadata:
+      Category: Security
+      Title: Do not use insecure deserializer ObjectStateFormatter
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2321:
+    Metadata:
+      Category: Security
+      Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2322:
+    Metadata:
+      Category: Security
+      Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2326:
+    Metadata:
+      Category: Security
+      Title: Do not use TypeNameHandling values other than None
+      Description: Deserializing JSON when using a TypeNameHandling value other than None can be insecure.  If you need to instead detect Json.NET deserialization when a SerializationBinder isn't specified, then disable rule CA2326, and enable rules CA2327, CA2328, CA2329, and CA2330.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2327:
+    Metadata:
+      Category: Security
+      Title: Do not use insecure JsonSerializerSettings
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2328:
+    Metadata:
+      Category: Security
+      Title: Ensure that JsonSerializerSettings are secure
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2329:
+    Metadata:
+      Category: Security
+      Title: Do not deserialize with JsonSerializer using an insecure configuration
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2330:
+    Metadata:
+      Category: Security
+      Title: Ensure that JsonSerializer has a secure configuration when deserializing
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2350:
+    Metadata:
+      Category: Security
+      Title: Do not use DataTable.ReadXml() with untrusted data
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2351:
+    Metadata:
+      Category: Security
+      Title: Do not use DataSet.ReadXml() with untrusted data
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2352:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2353:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in serializable type
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2354:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2355:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable type found in deserializable object graph
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2356:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable type in web deserializable object graph
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2361:
+    Metadata:
+      Category: Security
+      Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2362:
+    Metadata:
+      Category: Security
+      Title: Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3001:
+    Metadata:
+      Category: Security
+      Title: Review code for SQL injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3002:
+    Metadata:
+      Category: Security
+      Title: Review code for XSS vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3003:
+    Metadata:
+      Category: Security
+      Title: Review code for file path injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3004:
+    Metadata:
+      Category: Security
+      Title: Review code for information disclosure vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3005:
+    Metadata:
+      Category: Security
+      Title: Review code for LDAP injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3006:
+    Metadata:
+      Category: Security
+      Title: Review code for process command injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3007:
+    Metadata:
+      Category: Security
+      Title: Review code for open redirect vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3008:
+    Metadata:
+      Category: Security
+      Title: Review code for XPath injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3009:
+    Metadata:
+      Category: Security
+      Title: Review code for XML injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3010:
+    Metadata:
+      Category: Security
+      Title: Review code for XAML injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3011:
+    Metadata:
+      Category: Security
+      Title: Review code for DLL injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3012:
+    Metadata:
+      Category: Security
+      Title: Review code for regex injection vulnerabilities
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3061:
+    Metadata:
+      Category: Security
+      Title: Do Not Add Schema By URL
+      Description: This overload of XmlSchemaCollection.Add method internally enables DTD processing on the XML reader instance used, and uses UrlResolver for resolving external XML entities. The outcome is information disclosure. Content from file system or network shares for the machine processing the XML can be exposed to attacker. In addition, an attacker can use this as a DoS vector.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Silent
+  CA3075:
+    Metadata:
+      Category: Security
+      Title: Insecure DTD processing in XML
+      Description: Using XmlTextReader.Load(), creating an insecure XmlReaderSettings instance when invoking XmlReader.Create(), setting the InnerXml property of the XmlDocument and enabling DTD processing using XmlUrlResolver insecurely can lead to information disclosure. Replace it with a call to the Load() method overload that takes an XmlReader instance, use XmlReader.Create() to accept XmlReaderSettings arguments or consider explicitly setting secure values. The DataViewSettingCollectionString property of DataViewManager should always be assigned from a trusted source, the DtdProcessing property should be set to false, and the XmlResolver property should be changed to XmlSecureResolver or null.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3147:
+    Metadata:
+      Category: Security
+      Title: Mark Verb Handlers With Validate Antiforgery Token
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5350:
+    Metadata:
+      Category: Security
+      Title: Do Not Use Weak Cryptographic Algorithms
+      Description: Cryptographic algorithms degrade over time as attacks become for advances to attacker get access to more computation. Depending on the type and application of this cryptographic algorithm, further degradation of the cryptographic strength of it may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA-2 512, SHA-2 384, or SHA-2 256.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Error
+  CA5351:
+    Metadata:
+      Category: Security
+      Title: Do Not Use Broken Cryptographic Algorithms
+      Description: An attack making it computationally feasible to break this algorithm exists. This allows attackers to break the cryptographic guarantees it is designed to provide. Depending on the type and application of this cryptographic algorithm, this may allow attackers to read enciphered messages, tamper with enciphered  messages, forge digital signatures, tamper with hashed content, or otherwise compromise any cryptosystem based on this algorithm. Replace encryption uses with the AES algorithm (AES-256, AES-192 and AES-128 are acceptable) with a key length greater than or equal to 128 bits. Replace hashing uses with a hashing function in the SHA-2 family, such as SHA512, SHA384, or SHA256. Replace digital signature uses with RSA with a key length greater than or equal to 2048-bits, or ECDSA with a key length greater than or equal to 256 bits.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Error
+  CA5358:
+    Metadata:
+      Category: Security
+      Title: Review cipher mode usage with cryptography experts
+      Description: These cipher modes might be vulnerable to attacks. Consider using recommended modes (CBC, CTS).
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5359:
+    Metadata:
+      Category: Security
+      Title: Do Not Disable Certificate Validation
+      Description: A certificate can help authenticate the identity of the server. Clients should validate the server certificate to ensure requests are sent to the intended server. If the ServerCertificateValidationCallback always returns 'true', any certificate will pass validation.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5360:
+    Metadata:
+      Category: Security
+      Title: Do Not Call Dangerous Methods In Deserialization
+      Description: Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5361:
+    Metadata:
+      Category: Security
+      Title: Do Not Disable SChannel Use of Strong Crypto
+      Description: Starting with the .NET Framework 4.6, the System.Net.ServicePointManager and System.Net.Security.SslStream classes are recommended to use new protocols. The old ones have protocol weaknesses and are not supported. Setting Switch.System.Net.DontEnableSchUseStrongCrypto with true will use the old weak crypto check and opt out of the protocol migration.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5362:
+    Metadata:
+      Category: Security
+      Title: Potential reference cycle in deserialized object graph
+      Description: Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5363:
+    Metadata:
+      Category: Security
+      Title: Do Not Disable Request Validation
+      Description: Request validation is a feature in ASP.NET that examines HTTP requests and determines whether they contain potentially dangerous content. This check adds protection from markup or code in the URL query string, cookies, or posted form values that might have been added for malicious purposes. So, it is generally desirable and should be left enabled for defense in depth.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5364:
+    Metadata:
+      Category: Security
+      Title: Do Not Use Deprecated Security Protocols
+      Description: Using a deprecated security protocol rather than the system default is risky.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5365:
+    Metadata:
+      Category: Security
+      Title: Do Not Disable HTTP Header Checking
+      Description: HTTP header checking enables encoding of the carriage return and newline characters, \r and \n, that are found in response headers. This encoding can help to avoid injection attacks that exploit an application that echoes untrusted data contained by the header.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5366:
+    Metadata:
+      Category: Security
+      Title: Use XmlReader for 'DataSet.ReadXml()'
+      Description: Processing XML from untrusted data may load dangerous external references, which should be restricted by using an XmlReader with a secure resolver or with DTD processing disabled.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5367:
+    Metadata:
+      Category: Security
+      Title: Do Not Serialize Types With Pointer Fields
+      Description: Pointers are not "type safe" in the sense that you cannot guarantee the correctness of the memory they point at. So, serializing types with pointer fields is dangerous, as it may allow an attacker to control the pointer.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5368:
+    Metadata:
+      Category: Security
+      Title: Set ViewStateUserKey For Classes Derived From Page
+      Description: Setting the ViewStateUserKey property can help you prevent attacks on your application by allowing you to assign an identifier to the view-state variable for individual users so that they cannot use the variable to generate an attack. Otherwise, there will be cross-site request forgery vulnerabilities.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5369:
+    Metadata:
+      Category: Security
+      Title: Use XmlReader for 'XmlSerializer.Deserialize()'
+      Description: Processing XML from untrusted data may load dangerous external references, which should be restricted by using an XmlReader with a secure resolver or with DTD processing disabled.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5370:
+    Metadata:
+      Category: Security
+      Title: Use XmlReader for XmlValidatingReader constructor
+      Description: Processing XML from untrusted data may load dangerous external references, which should be restricted by using an XmlReader with a secure resolver or with DTD processing disabled.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5371:
+    Metadata:
+      Category: Security
+      Title: Use XmlReader for 'XmlSchema.Read()'
+      Description: Processing XML from untrusted data may load dangerous external references, which should be restricted by using an XmlReader with a secure resolver or with DTD processing disabled.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5372:
+    Metadata:
+      Category: Security
+      Title: Use XmlReader for XPathDocument constructor
+      Description: Processing XML from untrusted data may load dangerous external references, which should be restricted by using an XmlReader with a secure resolver or with DTD processing disabled.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5373:
+    Metadata:
+      Category: Security
+      Title: Do not use obsolete key derivation function
+      Description: Password-based key derivation should use PBKDF2 with SHA-2. Avoid using PasswordDeriveBytes since it generates a PBKDF1 key. Avoid using Rfc2898DeriveBytes.CryptDeriveKey since it doesn't use the iteration count or salt.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5374:
+    Metadata:
+      Category: Security
+      Title: Do Not Use XslTransform
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5375:
+    Metadata:
+      Category: Security
+      Title: Do Not Use Account Shared Access Signature
+      Description: Shared Access Signatures(SAS) are a vital part of the security model for any application using Azure Storage, they should provide limited and safe permissions to your storage account to clients that don't have the account key. All of the operations available via a service SAS are also available via an account SAS, that is, account SAS is too powerful. So it is recommended to use Service SAS to delegate access more carefully.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5376:
+    Metadata:
+      Category: Security
+      Title: Use SharedAccessProtocol HttpsOnly
+      Description: HTTPS encrypts network traffic. Use HttpsOnly, rather than HttpOrHttps, to ensure network traffic is always encrypted to help prevent disclosure of sensitive data.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5377:
+    Metadata:
+      Category: Security
+      Title: Use Container Level Access Policy
+      Description: No access policy identifier is specified, making tokens non-revocable.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5378:
+    Metadata:
+      Category: Security
+      Title: Do not disable ServicePointManagerSecurityProtocols
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5379:
+    Metadata:
+      Category: Security
+      Title: Ensure Key Derivation Function algorithm is sufficiently strong
+      Description: Some implementations of the Rfc2898DeriveBytes class allow for a hash algorithm to be specified in a constructor parameter or overwritten in the HashAlgorithm property. If a hash algorithm is specified, then it should be SHA-256 or higher.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5380:
+    Metadata:
+      Category: Security
+      Title: Do Not Add Certificates To Root Store
+      Description: By default, the Trusted Root Certification Authorities certificate store is configured with a set of public CAs that has met the requirements of the Microsoft Root Certificate Program. Since all trusted root CAs can issue certificates for any domain, an attacker can pick a weak or coercible CA that you install by yourself to target for an attack - and a single vulnerable, malicious or coercible CA undermines the security of the entire system. To make matters worse, these attacks can go unnoticed quite easily.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5381:
+    Metadata:
+      Category: Security
+      Title: Ensure Certificates Are Not Added To Root Store
+      Description: By default, the Trusted Root Certification Authorities certificate store is configured with a set of public CAs that has met the requirements of the Microsoft Root Certificate Program. Since all trusted root CAs can issue certificates for any domain, an attacker can pick a weak or coercible CA that you install by yourself to target for an attack - and a single vulnerable, malicious or coercible CA undermines the security of the entire system. To make matters worse, these attacks can go unnoticed quite easily.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5382:
+    Metadata:
+      Category: Security
+      Title: Use Secure Cookies In ASP.NET Core
+      Description: Applications available over HTTPS must use secure cookies.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5383:
+    Metadata:
+      Category: Security
+      Title: Ensure Use Secure Cookies In ASP.NET Core
+      Description: Applications available over HTTPS must use secure cookies.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5384:
+    Metadata:
+      Category: Security
+      Title: Do Not Use Digital Signature Algorithm (DSA)
+      Description: DSA is too weak to use.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5385:
+    Metadata:
+      Category: Security
+      Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+      Description: Encryption algorithms are vulnerable to brute force attacks when too small a key size is used.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5386:
+    Metadata:
+      Category: Security
+      Title: Avoid hardcoding SecurityProtocolType value
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5387:
+    Metadata:
+      Category: Security
+      Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+      Description: When deriving cryptographic keys from user-provided inputs such as password, use sufficient iteration count (at least 100k).
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5388:
+    Metadata:
+      Category: Security
+      Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+      Description: When deriving cryptographic keys from user-provided inputs such as password, use sufficient iteration count (at least 100k).
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5389:
+    Metadata:
+      Category: Security
+      Title: Do Not Add Archive Item's Path To The Target File System Path
+      Description: When extracting files from an archive and using the archive item's path, check if the path is safe. Archive path can be relative and can lead to file system access outside of the expected file system target path, leading to malicious config changes and remote code execution via lay-and-wait technique.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5390:
+    Metadata:
+      Category: Security
+      Title: Do not hard-code encryption key
+      Description: SymmetricAlgorithm's .Key property, or a method's rgbKey parameter, should never be a hard-coded value.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5391:
+    Metadata:
+      Category: Security
+      Title: Use antiforgery tokens in ASP.NET Core MVC controllers
+      Description: Handling a POST, PUT, PATCH, or DELETE request without validating an antiforgery token may be vulnerable to cross-site request forgery attacks. A cross-site request forgery attack can send malicious requests from an authenticated user to your ASP.NET Core MVC controller.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5392:
+    Metadata:
+      Category: Security
+      Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
+      Description: By default, P/Invokes using DllImportAttribute probe a number of directories, including the current working directory for the library to load. This can be a security issue for certain applications, leading to DLL hijacking.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5393:
+    Metadata:
+      Category: Security
+      Title: Do not use unsafe DllImportSearchPath value
+      Description: There could be a malicious DLL in the default DLL search directories. Or, depending on where your application is run from, there could be a malicious DLL in the application's directory. Use a DllImportSearchPath value that specifies an explicit search path instead. The DllImportSearchPath flags that this rule looks for can be configured in .editorconfig.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5394:
+    Metadata:
+      Category: Security
+      Title: Do not use insecure randomness
+      Description: Using a cryptographically weak pseudo-random number generator may allow an attacker to predict what security-sensitive value will be generated. Use a cryptographically strong random number generator if an unpredictable value is required, or ensure that weak pseudo-random numbers aren't used in a security-sensitive manner.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5395:
+    Metadata:
+      Category: Security
+      Title: Miss HttpVerb attribute for action methods
+      Description: All the methods that create, edit, delete, or otherwise modify data do so in the [HttpPost] overload of the method, which needs to be protected with the anti forgery attribute from request forgery. Performing a GET operation should be a safe operation that has no side effects and doesn't modify your persisted data.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5396:
+    Metadata:
+      Category: Security
+      Title: Set HttpOnly to true for HttpCookie
+      Description: As a defense in depth measure, ensure security sensitive HTTP cookies are marked as HttpOnly. This indicates web browsers should disallow scripts from accessing the cookies. Injected malicious scripts are a common way of stealing cookies.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5397:
+    Metadata:
+      Category: Security
+      Title: Do not use deprecated SslProtocols values
+      Description: Older protocol versions of Transport Layer Security (TLS) are less secure than TLS 1.2 and TLS 1.3, and are more likely to have new vulnerabilities. Avoid older protocol versions to minimize risk.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5398:
+    Metadata:
+      Category: Security
+      Title: Avoid hardcoded SslProtocols values
+      Description: Current Transport Layer Security protocol versions may become deprecated if vulnerabilities are found. Avoid hardcoding SslProtocols values to keep your application secure. Use 'None' to let the Operating System choose a version.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5399:
+    Metadata:
+      Category: Security
+      Title: HttpClients should enable certificate revocation list checks
+      Description: Using HttpClient without providing a platform specific handler (WinHttpHandler or CurlHandler or HttpClientHandler) where the CheckCertificateRevocationList property is set to true, will allow revoked certificates to be accepted by the HttpClient as valid.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5400:
+    Metadata:
+      Category: Security
+      Title: Ensure HttpClient certificate revocation list check is not disabled
+      Description: Using HttpClient without providing a platform specific handler (WinHttpHandler or CurlHandler or HttpClientHandler) where the CheckCertificateRevocationList property is set to true, will allow revoked certificates to be accepted by the HttpClient as valid.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5401:
+    Metadata:
+      Category: Security
+      Title: Do not use CreateEncryptor with non-default IV
+      Description: Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5402:
+    Metadata:
+      Category: Security
+      Title: 'Use CreateEncryptor with the default IV '
+      Description: Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5403:
+    Metadata:
+      Category: Security
+      Title: Do not hard-code certificate
+      Description: Hard-coded certificates in source code are vulnerable to being exploited.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+      CustomTags:
+      - Dataflow
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  IL3000:
+    Metadata:
+      Category: Publish
+      Title: Avoid using accessing Assembly file path when publishing as a single-file
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  IL3001:
+    Metadata:
+      Category: Publish
+      Title: Avoid using accessing Assembly file path when publishing as a single-file
+      Description: ''
+      HelpLinkUri: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2200:
+    Metadata:
+      Category: Usage
+      Title: Rethrow to preserve stack details
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA3077:
+    Metadata:
+      Category: Security
+      Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
+      Description: Enabling DTD processing on all instances derived from XmlTextReader or  XmlDocument and using XmlUrlResolver for resolving external XML entities may lead to information disclosure. Ensure to set the XmlResolver property to null, create an instance of XmlSecureResolver when processing untrusted input, or use XmlReader.Create method with a secure XmlReaderSettings argument. Unless you need to enable it, ensure the DtdProcessing property is set to false.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA3076:
+    Metadata:
+      Category: Security
+      Title: Insecure XSLT script processing
+      Description: Providing an insecure XsltSettings instance and an insecure XmlResolver instance to XslCompiledTransform.Load method is potentially unsafe as it allows processing script within XSL, which on an untrusted XSL input may lead to malicious code execution. Either replace the insecure XsltSettings argument with XsltSettings.Default or an instance that has disabled document function and script execution, or replace the XmlResolver argument with null or an XmlSecureResolver instance. This message may be suppressed if the input is known to be from a trusted source and external resource resolution from locations that are not known in advance must be supported.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA1842:
+    Metadata:
+      Category: Performance
+      Title: Do not use 'WhenAll' with a single task
+      Description: Using 'WhenAll' with a single task may result in performance loss, await or return the task instead.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1843:
+    Metadata:
+      Category: Performance
+      Title: Do not use 'WaitAll' with a single task
+      Description: Using 'WaitAll' with a single task may result in performance loss, await or return the task instead.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA5405:
+    Metadata:
+      Category: Security
+      Title: Do not always skip token validation in delegates
+      Description: By setting critical TokenValidationParameter validation delegates to true, important authentication safeguards are disabled which can lead to tokens from any issuer or expired tokens being wrongly validated.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA5404:
+    Metadata:
+      Category: Security
+      Title: Do not disable token validation checks
+      Description: Token validation checks ensure that while validating tokens, all aspects are analyzed and verified. Turning off validation can lead to security holes by allowing untrusted tokens to make it through validation.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  CA2018:
+    Metadata:
+      Category: Reliability
+      Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
+      Description: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument. Using 'Array.Length' may not match the number of bytes that needs to be copied."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA1727:
+    Metadata:
+      Category: Naming
+      Title: Use PascalCase for named placeholders
+      Description: Use PascalCase for named placeholders in the logging message template.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Silent
+  CA1848:
+    Metadata:
+      Category: Performance
+      Title: Use the LoggerMessage delegates
+      Description: For improved performance, use the LoggerMessage delegates.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: Use R9 logging model instead
+  CA2253:
+    Metadata:
+      Category: Usage
+      Title: Named placeholders should not be numeric values
+      Description: Named placeholders in the logging message template should not be comprised of only numeric characters.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA2254:
+    Metadata:
+      Category: Usage
+      Title: Template should be a static expression
+      Description: The logging message template should not vary between calls.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Suggestion
+  CA2017:
+    Metadata:
+      Category: Reliability
+      Title: Parameter count mismatch
+      Description: Number of parameters supplied in the logging message template do not match the number of named placeholders.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA2255:
+    Metadata:
+      Category: Usage
+      Title: The 'ModuleInitializer' attribute should not be used in libraries
+      Description: Module initializers are intended to be used by application code to ensure an application's components are initialized before the application code begins executing. If library code declares a method with the 'ModuleInitializerAttribute', it can interfere with application initialization and also lead to limitations in that application's trimming abilities. Instead of using methods marked with 'ModuleInitializerAttribute', the library should expose methods that can be used to initialize any components within the library and allow the application to invoke the method during application initialization.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1846:
+    Metadata:
+      Category: Performance
+      Title: Prefer 'AsSpan' over 'Substring'
+      Description: "'AsSpan' is more efficient then 'Substring'. 'Substring' performs an O(n) string copy, while 'AsSpan' does not and has a constant cost."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1844:
+    Metadata:
+      Category: Performance
+      Title: Provide memory-based overrides of async methods when subclassing 'Stream'
+      Description: To improve performance, override the memory-based async methods when subclassing 'Stream'. Then implement the array-based methods in terms of the memory-based methods.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1849:
+    Metadata:
+      Category: Performance
+      Title: Call async methods when in an async method
+      Description: When inside a Task-returning method, use the async version of methods, if they exist.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2250:
+    Metadata:
+      Category: Usage
+      Title: Use 'ThrowIfCancellationRequested'
+      Description: "'ThrowIfCancellationRequested' automatically checks whether the token has been canceled, and throws an 'OperationCanceledException' if it has."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1839:
+    Metadata:
+      Category: Performance
+      Title: Use 'Environment.ProcessPath'
+      Description: "'Environment.ProcessPath' is simpler and faster than 'Process.GetCurrentProcess().MainModule.FileName'."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1840:
+    Metadata:
+      Category: Performance
+      Title: Use 'Environment.CurrentManagedThreadId'
+      Description: "'Environment.CurrentManagedThreadId' is simpler and faster than 'Thread.CurrentThread.ManagedThreadId'."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2251:
+    Metadata:
+      Category: Usage
+      Title: Use 'string.Equals'
+      Description: It is both clearer and likely faster to use 'string.Equals' instead of comparing the result of 'string.Compare' to zero.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1847:
+    Metadata:
+      Category: Performance
+      Title: Use char literal for a single character lookup
+      Description: "'string.Contains(char)' is available as a better performing overload for single char lookup."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA2258:
+    Metadata:
+      Category: Usage
+      Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+      Description: Providing a functional 'DynamicInterfaceCastableImplementationAttribute'-attributed interface requires the Default Interface Members feature, which is unsupported in Visual Basic.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2256:
+    Metadata:
+      Category: Usage
+      Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+      Description: Types attributed with 'DynamicInterfaceCastableImplementationAttribute' act as an interface implementation for a type that implements the 'IDynamicInterfaceCastable' type. As a result, it must provide an implementation of all of the members defined in the inherited interfaces, because the type that implements 'IDynamicInterfaceCastable' will not provide them otherwise.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Error
+  CA2257:
+    Metadata:
+      Category: Usage
+      Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+      Description: Since a type that implements 'IDynamicInterfaceCastable' may not implement a dynamic interface in metadata, calls to an instance interface member that is not an explicit implementation defined on this type are likely to fail at runtime. Mark new interface members 'static' to avoid runtime errors.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1419:
+    Metadata:
+      Category: Interoperability
+      Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+      Description: Providing a parameterless constructor that is as visible as the containing type for a type derived from 'System.Runtime.InteropServices.SafeHandle' enables better performance and usage with source-generated interop solutions.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1418:
+    Metadata:
+      Category: Interoperability
+      Title: Use valid platform string
+      Description: Platform compatibility analyzer requires a valid platform name and version.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1019:
+    Metadata:
+      Category: Design
+      Title: Define accessors for attribute arguments
+      Description: ''
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1065:
+    Metadata:
+      Category: Design
+      Title: Do not raise exceptions in unexpected locations
+      Description: A method that is not expected to throw exceptions throws an exception.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+      CustomTags:
+      - PortedFromFxCop
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1854:
+    Metadata:
+      Category: Performance
+      Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+      Description: Prefer a 'TryGetValue' call over a Dictionary indexer access guarded by a 'ContainsKey' check. 'ContainsKey' and the indexer both would lookup the key under the hood, so using 'TryGetValue' removes the extra lookup.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  CA1852:
+    Metadata:
+      Category: Performance
+      Title: Seal internal types
+      Description: When a type is not accessible outside its assembly and has no subtypes within its containing assembly, it can be safely sealed. Sealing types can improve performance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      - CompilationEnd
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: R9A013
+  CA2259:
+    Metadata:
+      Category: Usage
+      Title: "'ThreadStatic' only affects static fields"
+      Description: "'ThreadStatic' only affects static fields. When applied to instance fields, it has no impact on behavior."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA2019:
+    Metadata:
+      Category: Reliability
+      Title: Improper 'ThreadStatic' field initialization
+      Description: "'ThreadStatic' fields should be initialized lazily on use, not with inline initialization nor explicitly in a static constructor, which would only initialize the field on the thread that runs the type's static constructor."
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  CA1853:
+    Metadata:
+      Category: Performance
+      Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
+      Description: Do not guard 'Dictionary.Remove(key)' with 'Dictionary.ContainsKey(key)'. The former already checks whether the key exists, and will not throw if it does not.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Suggestion
+  CA1850:
+    Metadata:
+      Category: Performance
+      Title: Prefer static 'HashData' method over 'ComputeHash'
+      Description: It is more efficient to use the static 'HashData' method over creating and managing a HashAlgorithm instance to call 'ComputeHash'.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Suggestion
+  CA1420:
+    Metadata:
+      Category: Interoperability
+      Title: Property, type, or attribute requires runtime marshalling
+      Description: Using features that require runtime marshalling when runtime marshalling is disabled will result in runtime exceptions.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1421:
+    Metadata:
+      Category: Interoperability
+      Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+      Description: This method uses runtime marshalling even when runtime marshalling is disabled, which can cause unexpected behavior differences at runtime due to different expectations of a type's native layout.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1422:
+    Metadata:
+      Category: Interoperability
+      Title: Validate platform compatibility
+      Description: Using platform dependent API on a component makes the code no longer work across all platforms.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  CA1861:
+    Metadata:
+      Category: Performance
+      Title: Avoid constant arrays as arguments
+      Description: Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA2021:
+    Metadata:
+      Category: Reliability
+      Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+      Description: >-
+        Enumerable.Cast<T> and Enumerable.OfType<T> require compatible types to function expectedly.  
+
+        The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast<T> will throw InvalidCastException at runtime on elements of the types specified.  
+
+        The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType<T> will never succeed with elements of types specified, resulting in an empty sequence.  
+
+        Widening and user defined conversions are not supported with generic types.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  CA1510:
+    Metadata:
+      Category: Maintainability
+      Title: Use ArgumentNullException throw helper
+      Description: Throw helpers are simpler and more efficient than an if block constructing a new exception instance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1511:
+    Metadata:
+      Category: Maintainability
+      Title: Use ArgumentException throw helper
+      Description: Throw helpers are simpler and more efficient than an if block constructing a new exception instance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1512:
+    Metadata:
+      Category: Maintainability
+      Title: Use ArgumentOutOfRangeException throw helper
+      Description: Throw helpers are simpler and more efficient than an if block constructing a new exception instance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1513:
+    Metadata:
+      Category: Maintainability
+      Title: Use ObjectDisposedException throw helper
+      Description: Throw helpers are simpler and more efficient than an if block constructing a new exception instance.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1860:
+    Metadata:
+      Category: Performance
+      Title: Avoid using 'Enumerable.Any()' extension method
+      Description: Prefer using 'IsEmpty', 'Count' or 'Length' properties whichever available, rather than calling 'Enumerable.Any()'. The intent is clearer and it is more performant than using 'Enumerable.Any()' extension method.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1859:
+    Metadata:
+      Category: Performance
+      Title: Use concrete types when possible for improved performance
+      Description: Using concrete types avoids virtual or interface call overhead and enables inlining.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  CA1858:
+    Metadata:
+      Category: Performance
+      Title: Use 'StartsWith' instead of 'IndexOf'
+      Description: It is both clearer and faster to use 'StartsWith' instead of comparing the result of 'IndexOf' to zero.
+      HelpLinkUri: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+      CustomTags:
+      - Telemetry
+      - EnabledRuleInAggressiveMode
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion

--- a/eng/Diags/Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0.yml
+++ b/eng/Diags/Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0.yml
@@ -1,0 +1,256 @@
+Origin:
+  AssemblyName: Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0
+  Version: 42.42.42.42424
+Diagnostics:
+  R9A000:
+    Metadata:
+      Category: Performance
+      Title: Use source generated logging methods for improved performance
+      Description: Identifies calls to legacy logging methods
+      HelpLinkUri: https://TODO/r9a000
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A018:
+    Metadata:
+      Category: Performance
+      Title: Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+      Description: Identifies uses of 'String.Format' and 'StringBuilder.AppendFormat'
+      HelpLinkUri: https://TODO/r9a018
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A019:
+    Metadata:
+      Category: Performance
+      Title: Remove unnecessary dictionary lookups
+      Description: Encourages optimal use of dictionary lookup
+      HelpLinkUri: https://TODO/r9a019
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A020:
+    Metadata:
+      Category: Performance
+      Title: Remove unnecessary set lookups
+      Description: Encourages optimal use of set lookup
+      HelpLinkUri: https://TODO/r9a020
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A022:
+    Metadata:
+      Category: Reliability
+      Title: Use 'System.TimeProvider' to make the code easier to test
+      Description: Identifies uses of time dependent APIs that can lead to flaky tests
+      HelpLinkUri: https://TODO/r9a022
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  R9A021:
+    Metadata:
+      Category: Performance
+      Title: Perform message formatting in the body of the logging method
+      Description: Identifies calls to the 'ToString' method as arguments to a logging method
+      HelpLinkUri: https://TODO/r9a021
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A029:
+    Metadata:
+      Category: Reliability
+      Title: Using experimental API
+      Description: Indicates that code is depending on an experimental API
+      HelpLinkUri: https://TODO/r9a029
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      general_externalonly:
+        Severity: Warning
+  R9A031:
+    Metadata:
+      Category: Performance
+      Title: Make types declared in an executable internal
+      Description: Making an executable's types internal enables dead code analysis along with other potential optimizations
+      HelpLinkUri: https://TODO/r9a031
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A030:
+    Metadata:
+      Category: Performance
+      Title: Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+      Description: When checking for a single character, prefer the character overloads of 'String.StartsWith' and 'String.EndsWith' for improved performance
+      HelpLinkUri: https://TODO/r9a030
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A033:
+    Metadata:
+      Category: Performance
+      Title: Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+      Description: Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+      HelpLinkUri: https://TODO/r9a033
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A037:
+    Metadata:
+      Category: Performance
+      Title: Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+      Description: Using 'System.ValueTuple' avoids allocations and is generally more efficient than 'System.Tuple'
+      HelpLinkUri: https://TODO/r9a037
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A032:
+    Metadata:
+      Category: Performance
+      Title: Consider using an array instead of a collection
+      Description: Dictionaries and sets which use enums and bytes as keys can often be replaced with simple arrays for improved performance
+      HelpLinkUri: https://TODO/r9a032
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: None
+  R9A040:
+    Metadata:
+      Category: Performance
+      Title: Use generic collections instead of legacy collections for improved performance
+      Description: Using generic collections can avoid boxing overhead and provides strong typing
+      HelpLinkUri: https://TODO/r9a040
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A043:
+    Metadata:
+      Category: Performance
+      Title: Use 'System.MemoryExtensions.Split' for improved performance
+      Description: Use 'System.MemoryExtensions.Split' for improved performance
+      HelpLinkUri: https://TODO/r9a043
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A044:
+    Metadata:
+      Category: Performance
+      Title: Assign array of literal values to a static field for improved performance
+      Description: Arrays of literal values should generally be assigned to static fields in order to avoid creating them redundantly over time
+      HelpLinkUri: https://TODO/r9a044
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A056:
+    Metadata:
+      Category: Correctness
+      Title: Fire-and-forget async call inside a 'using' block
+      Description: When skipping the await keyword for asynchronous operations inside a using block, then a disposable object could be disposed before the asynchronous invocation finishes. This might result in incorrect behavior and very often ends with a runtime exception notifying that the code is trying to operate on a disposed object.
+      HelpLinkUri: https://TODO/r9a056
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A058:
+    Metadata:
+      Category: Performance
+      Title: Consider removing unnecessary conditional access operator (?)
+      Description: Using the conditional access operator (?) to access values which are statically known not to be null causes superfluous null checks to be performed at runtime
+      HelpLinkUri: https://TODO/r9a058
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  R9A059:
+    Metadata:
+      Category: Performance
+      Title: Consider removing unnecessary null coalescing assignment (??=)
+      Description: Using the null coalescing assignment operator (??=) with values which are statically known not to be null causes superfluous null checks to be performed at runtime
+      HelpLinkUri: https://TODO/r9a059
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  R9A060:
+    Metadata:
+      Category: Performance
+      Title: Consider removing unnecessary null coalescing operator (??)
+      Description: Using the null coalescing operator (??) with values which are statically known to be null causes superfluous null checks to be performed at runtime
+      HelpLinkUri: https://TODO/r9a060
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  R9A061:
+    Metadata:
+      Category: Resilience
+      Title: The async method doesn't support cancellation
+      Description: Accepting a CancellationToken as a parameter allows caller to express a loss of interest in the result enabling the method to save cycles by finishing early
+      HelpLinkUri: https://TODO/r9a061
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning

--- a/eng/Diags/Microsoft.Extensions.LocalAnalyzers.yml
+++ b/eng/Diags/Microsoft.Extensions.LocalAnalyzers.yml
@@ -1,0 +1,118 @@
+Origin:
+  AssemblyName: Microsoft.Extensions.LocalAnalyzers
+  Version: 42.42.42.42424
+Diagnostics:
+  R9A014:
+    Metadata:
+      Category: Performance
+      Title: Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+      Description: Recommends replacing explicit argument throwing with the more efficient 'Microsoft.Extensions.Diagnostics.Throws' class
+      HelpLinkUri: https://TODO/r9a014
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A015:
+    Metadata:
+      Category: Performance
+      Title: Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+      Description: Recommends replacing explicit argument throwing with the more efficient 'Microsoft.Shared.Diagnostics.Throws' class
+      HelpLinkUri: https://TODO/r9a015
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A036:
+    Metadata:
+      Category: Performance
+      Title: Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+      Description: "'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' provides caching for common numeric values, avoiding the need to allocate new strings in many situations"
+      HelpLinkUri: https://TODO/r9a036
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  R9A049:
+    Metadata:
+      Category: Correctness
+      Title: Newly added symbols must be marked as experimental
+      Description: Symbols being added to the public API of an assembly must be marked as experimental until they have been appoved
+      HelpLinkUri: https://TODO/r9a049
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A050:
+    Metadata:
+      Category: Correctness
+      Title: Experimental symbols cannot be marked as obsolete
+      Description: Symbols being added to the public API of an assembly cannot be marked as obsolete
+      HelpLinkUri: https://TODO/r9a050
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A051:
+    Metadata:
+      Category: Correctness
+      Title: Published symbols cannot be marked experimental
+      Description: Previously published symbols in the public API of an assembly cannot be marked experimental
+      HelpLinkUri: https://TODO/r9a051
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A052:
+    Metadata:
+      Category: Correctness
+      Title: Published symbols cannot be deleted to maintain compatibility
+      Description: Published symbols cannot be deleted to maintain compatibility
+      HelpLinkUri: https://TODO/r9a052
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A053:
+    Metadata:
+      Category: Correctness
+      Title: A deprecated API is not annotated with the obsolete attribute
+      Description: Deprecated API should have annotation that will guide customers regarding its replacement and the release in which it will be removed
+      HelpLinkUri: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A054:
+    Metadata:
+      Category: Correctness
+      Title: A deprecated API is marked as experimental
+      Description: Deprecated API cannot be marked as experimental
+      HelpLinkUri: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  R9A055:
+    Metadata:
+      Category: Correctness
+      Title: Published symbols cannot be changed to maintain compatibility
+      Description: Published symbols cannot change to maintain compatibility
+      HelpLinkUri: https://TODO/r9a055
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/Microsoft.VisualStudio.Threading.Analyzers.CSharp.yml
+++ b/eng/Diags/Microsoft.VisualStudio.Threading.Analyzers.CSharp.yml
@@ -1,0 +1,198 @@
+Origin:
+  AssemblyName: Microsoft.VisualStudio.Threading.Analyzers.CSharp
+  Version: 17.5.22.27812
+Diagnostics:
+  VSTHRD001:
+    Metadata:
+      Category: Usage
+      Title: Avoid legacy thread switching APIs
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD002:
+    Metadata:
+      Category: Usage
+      Title: Avoid problematic synchronous waits
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD003:
+    Metadata:
+      Category: Usage
+      Title: Avoid awaiting foreign Tasks
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD004:
+    Metadata:
+      Category: Usage
+      Title: Await SwitchToMainThreadAsync
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  VSTHRD010:
+    Metadata:
+      Category: Usage
+      Title: Invoke single-threaded types on Main thread
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+      CustomTags:
+      - CompilationEnd
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD011:
+    Metadata:
+      Category: Usage
+      Title: Use AsyncLazy<T>
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  VSTHRD012:
+    Metadata:
+      Category: Usage
+      Title: Provide JoinableTaskFactory where allowed
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD102:
+    Metadata:
+      Category: Usage
+      Title: Implement internal logic asynchronously
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Suggestion
+  VSTHRD103:
+    Metadata:
+      Category: Usage
+      Title: Call async methods when in an async method
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  VSTHRD104:
+    Metadata:
+      Category: Usage
+      Title: Offer async methods
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  VSTHRD105:
+    Metadata:
+      Category: Usage
+      Title: Avoid method overloads that assume TaskScheduler.Current
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD107:
+    Metadata:
+      Category: Usage
+      Title: Await Task within using expression
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  VSTHRD108:
+    Metadata:
+      Category: Usage
+      Title: Assert thread affinity unconditionally
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD109:
+    Metadata:
+      Category: Usage
+      Title: Switch instead of assert in async methods
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  VSTHRD110:
+    Metadata:
+      Category: Usage
+      Title: Observe result of async calls
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CS4014, IDE0058
+  VSTHRD112:
+    Metadata:
+      Category: Usage
+      Title: Implement System.IAsyncDisposable
+      Description: The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Suggestion
+  VSTHRD114:
+    Metadata:
+      Category: Usage
+      Title: Avoid returning a null Task
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error

--- a/eng/Diags/Microsoft.VisualStudio.Threading.Analyzers.yml
+++ b/eng/Diags/Microsoft.VisualStudio.Threading.Analyzers.yml
@@ -1,0 +1,83 @@
+Origin:
+  AssemblyName: Microsoft.VisualStudio.Threading.Analyzers
+  Version: 17.5.22.27812
+Diagnostics:
+  VSTHRD100:
+    Metadata:
+      Category: Usage
+      Title: Avoid async void methods
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Error
+  VSTHRD101:
+    Metadata:
+      Category: Usage
+      Title: Avoid unsupported async delegates
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  VSTHRD106:
+    Metadata:
+      Category: Usage
+      Title: Use InvokeAsync to raise async events
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  VSTHRD200:
+    Metadata:
+      Category: Style
+      Title: Use "Async" suffix for async methods
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  VSTHRD111:
+    Metadata:
+      Category: Usage
+      Title: Use ConfigureAwait(bool)
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+      DefaultSeverity: None
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2007
+  VSTHRD113:
+    Metadata:
+      Category: Usage
+      Title: Check for System.IAsyncDisposable
+      Description: The System.IAsyncDisposable interface is defined in the Microsoft.Bcl.AsyncInterfaces NuGet package.
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Suggestion
+  VSTHRD114:
+    Metadata:
+      Category: Usage
+      Title: Avoid returning a null Task
+      Description: ''
+      HelpLinkUri: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/README.md
+++ b/eng/Diags/README.md
@@ -1,0 +1,6 @@
+# Diagnostic Configuration
+
+This folder defines the configuration state for all analyzers used and recommended by the Microsoft.Extensions.StaticAnalysis package.
+
+These files are processed by the DiagConfig tool. Check out the README file for eng/Tools/DiagConfig to learn
+more about these mysterious YAML files.

--- a/eng/Diags/SonarAnalyzer.CSharp.yml
+++ b/eng/Diags/SonarAnalyzer.CSharp.yml
@@ -1,0 +1,6391 @@
+Origin:
+  AssemblyName: SonarAnalyzer.CSharp
+  Version: 8.52.0.60960
+Diagnostics:
+  S100:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Methods and properties should be named in PascalCase
+      Description: Shared naming conventions allow teams to collaborate efficiently. This rule checks whether or not method and property names are PascalCased. To reduce noise, two consecutive upper case characters are allowed unless they form the whole name. So, MyXMethod is compliant, but XM on its own is not.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-100
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  S1006:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Method overrides should not change parameter defaults
+      Description: Default arguments are determined by the static type of the object. If a default argument is different for a parameter in an overriding method, the value used in the call will be different when calls are made via the base or derived object, which may be contrary to developer expectations.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1006
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S101:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Types should be named in PascalCase
+      Description: Shared naming conventions allow teams to collaborate efficiently. This rule checks whether or not type names are using PascalCase. To reduce noise, two consecutive upper case characters are allowed unless they form the whole type name. So, MyXClass is compliant, but XC on its own is not.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-101
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  S103:
+    Metadata:
+      Category: Major Code Smell
+      Title: Lines should not be too long
+      Description: Having to scroll horizontally makes it harder to get a quick overview and understanding of any piece of code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-103
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S104:
+    Metadata:
+      Category: Major Code Smell
+      Title: Files should not have too many lines of code
+      Description: A source file that grows too much tends to aggregate too many responsibilities and inevitably becomes harder to understand and therefore to maintain. Above a specific threshold, it is strongly advised to refactor it into smaller pieces of code which focus on well defined tasks. Those smaller files will not only be easier to understand but also probably easier to test.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-104
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1048:
+    Metadata:
+      Category: Blocker Bug
+      Title: Destructors should not throw exceptions
+      Description: If Finalize or an override of Finalize throws an exception, and the runtime is not hosted by an application that overrides the default policy, the runtime terminates the process immediately without graceful cleanup (finally blocks and finalizers are not executed). This behavior ensures process integrity if the finalizer cannot free or destroy resources.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1048
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1065
+  S105:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Tabulation characters should not be used
+      Description: Developers should not need to configure the tab width of their text editors in order to be able to read source code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-105
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: SA1027
+  S106:
+    Metadata:
+      Category: Major Code Smell
+      Title: Standard outputs should not be used directly to log anything
+      Description: 'When logging a message there are several important requirements which must be fulfilled:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-106
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  S1066:
+    Metadata:
+      Category: Major Code Smell
+      Title: Collapsible "if" statements should be merged
+      Description: Merging collapsible if statements increases the code’s readability.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1066
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S1067:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Expressions should not be too complex
+      Description: 'The complexity of an expression is defined by the number of &&, || and condition ? ifTrue : ifFalse operators it contains.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1067
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S107:
+    Metadata:
+      Category: Major Code Smell
+      Title: Methods should not have too many parameters
+      Description: A long parameter list can indicate that a new structure should be created to wrap the numerous parameters or that the function is doing too many things.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-107
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1075:
+    Metadata:
+      Category: Minor Code Smell
+      Title: URIs should not be hardcoded
+      Description: 'Hardcoding a URI makes it difficult to test a program: path literals are not always portable across operating systems, a given absolute path may not exist on a specific test environment, a specified Internet URL may not be available when executing the tests, production environment filesystems usually differ from the development environment, …​etc. For all those reasons, a URI should never be hardcoded. Instead, it should be replaced by customizable parameter.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1075
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S108:
+    Metadata:
+      Category: Major Code Smell
+      Title: Nested blocks of code should not be left empty
+      Description: Most of the time a block of code is empty when a piece of code is really missing. So such empty block must be either filled or removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-108
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S109:
+    Metadata:
+      Category: Major Code Smell
+      Title: Magic numbers should not be used
+      Description: A magic number is a number that comes out of nowhere, and is directly used in a statement. Magic numbers are often used, for instance to limit the number of iterations of a loop, to test the value of a property, etc.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-109
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S110:
+    Metadata:
+      Category: Major Code Smell
+      Title: Inheritance tree of classes should not be too deep
+      Description: Inheritance is certainly one of the most valuable concepts in object-oriented programming. It’s a way to compartmentalize and reuse code by creating collections of attributes and behaviors called classes which can be based on previously created classes. But abusing this concept by creating a deep inheritance tree can lead to very complex and unmaintainable source code. Most of the time a too deep inheritance tree is due to bad object oriented design which has led to systematically use 'inheritance' when for instance 'composition' would suit better.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-110
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1104:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Fields should not have public accessibility
+      Description: 'Public fields in public classes do not respect the encapsulation principle and has three main disadvantages:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1104
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1051
+  S1109:
+    Metadata:
+      Category: Minor Code Smell
+      Title: A close curly brace should be located at the beginning of a line
+      Description: Shared coding conventions make it possible for a team to efficiently collaborate. This rule makes it mandatory to place a close curly brace at the beginning of a line.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1109
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: SA1500
+  S1110:
+    Metadata:
+      Category: Major Code Smell
+      Title: Redundant pairs of parentheses should be removed
+      Description: The use of parentheses, even those not required to enforce a desired order of operations, can clarify the intent behind a piece of code. But redundant pairs of parentheses could be misleading, and should be removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1110
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: SA1119
+  S1116:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Empty statements should be removed
+      Description: 'Empty statements, i.e. ;, are usually introduced by mistake, for example because:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1116
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: SA1106
+  S1117:
+    Metadata:
+      Category: Major Code Smell
+      Title: Local variables should not shadow class fields
+      Description: Overriding or shadowing a variable declared in an outer scope can strongly impact the readability, and therefore the maintainability, of a piece of code. Further, it could lead maintainers to introduce bugs because they think they’re using one variable but are really using another.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1117
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1118:
+    Metadata:
+      Category: Major Code Smell
+      Title: Utility classes should not have public constructors
+      Description: Utility classes, which are collections of static members, are not meant to be instantiated.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1118
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1052
+  S112:
+    Metadata:
+      Category: Major Code Smell
+      Title: General exceptions should never be thrown
+      Description: Throwing such general exceptions as Exception, SystemException, ApplicationException, IndexOutOfRangeException, NullReferenceException, OutOfMemoryException and ExecutionEngineException prevents calling methods from handling true, system-generated exceptions differently than application-generated errors.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-112
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2219
+  S1121:
+    Metadata:
+      Category: Major Code Smell
+      Title: Assignments should not be made from within sub-expressions
+      Description: Assignments within sub-expressions are hard to spot and therefore make the code less readable. Ideally, sub-expressions should not have side-effects.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1121
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1123:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"Obsolete" attributes should include explanations'
+      Description: The Obsolete attribute can be applied with or without a message argument. Marking something Obsolete without including advice on why it’s obsolete or what to use instead will lead maintainers to waste time trying to figure those things out.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1123
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1041
+  S1125:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Boolean literals should not be redundant
+      Description: Redundant Boolean literals should be removed from expressions to improve readability.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1125
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1128:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Unused "using" should be removed
+      Description: 'Although unnecessary using won’t change anything to the produced application, removing them:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1128
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S113:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Files should contain an empty newline at the end
+      Description: Some tools work better when files end with an empty line.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-113
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S1134:
+    Metadata:
+      Category: Major Code Smell
+      Title: Track uses of "FIXME" tags
+      Description: FIXME tags are commonly used to mark places where a bug is suspected, but which the developer wants to deal with later.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1134
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1135:
+    Metadata:
+      Category: Info Code Smell
+      Title: Track uses of "TODO" tags
+      Description: TODO tags are commonly used to mark places where some more code is required, but which the developer wants to implement later.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1135
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1144:
+    Metadata:
+      Category: Major Code Smell
+      Title: Unused private types or members should be removed
+      Description: 'private or internal types or private members that are never executed or referenced are dead code: unnecessary, inoperative code that should be removed. Cleaning out dead code decreases the size of the maintained codebase, making it easier to understand the program and preventing bugs from being introduced.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1144
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1145:
+    Metadata:
+      Category: Major Bug
+      Title: Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+      Description: if statements with conditions that are always false have the effect of making blocks of code non-functional. if statements with conditions that are always true are completely redundant, and make the code less readable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1145
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1147:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Exit methods should not be called
+      Description: Calling Environment.Exit(exitCode) or Application.Exit() terminates the process and returns an exit code to the operating system..
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1147
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1151:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"switch case" clauses should not have too many lines of code'
+      Description: The switch statement should be used only to clearly define some new branches in the control flow. As soon as a case clause contains too many statements this highly decreases the readability of the overall control flow statement. In such case, the content of the case clause should be extracted into a dedicated method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1151
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S1155:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"Any()" should be used to test for emptiness'
+      Description: 'Using .Count() to test for emptiness works, but using .Any() makes the intent clearer, and the code more readable. However, there are some cases where special attention should be paid:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1155
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1163:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Exceptions should not be thrown in finally blocks
+      Description: Throwing an exception from within a finally block will mask any exception which was previously thrown in the try or catch block, and the masked’s exception message and stack trace will be lost.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1163
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2219
+  S1168:
+    Metadata:
+      Category: Major Code Smell
+      Title: Empty arrays and collections should be returned instead of null
+      Description: Returning null or default instead of an actual collection forces the method callers to explicitly test for null, making the code more complex and less readable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1168
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1172:
+    Metadata:
+      Category: Major Code Smell
+      Title: Unused method parameters should be removed
+      Description: Unused parameters are misleading. Whatever the values passed to such parameters, the behavior will be the same.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1172
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0060
+  S1185:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Overriding members should do more than simply call the same member in the base class
+      Description: Overriding a method just to call the same method from the base class without performing any other actions is useless and misleading. The only time this is justified is in sealed overriding methods, where the effect is to lock in the parent class behavior. This rule ignores overrides of Equals and GetHashCode.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1185
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1186:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Methods should not be empty
+      Description: 'There are several reasons for a method not to have a method body:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1186
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1192:
+    Metadata:
+      Category: Minor Code Smell
+      Title: String literals should not be duplicated
+      Description: Duplicated string literals make the process of refactoring error-prone, since you must be sure to update all occurrences.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1192
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Suggestion
+  S1199:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Nested code blocks should not be used
+      Description: Nested code blocks can be used to create a new scope and restrict the visibility of the variables defined inside it. Using this feature in a method typically indicates that the method has too many responsibilities, and should be refactored into smaller methods.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1199
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1200:
+    Metadata:
+      Category: Major Code Smell
+      Title: Classes should not be coupled to too many other classes (Single Responsibility Principle)
+      Description: 'According to the Single Responsibility Principle, introduced by Robert C. Martin in his book "Principles of Object Oriented Design", a class should have only one responsibility:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1200
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S1206:
+    Metadata:
+      Category: Minor Bug
+      Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
+      Description: 'There is a contract between Equals(object) and GetHashCode(): If two objects are equal according to the Equals(object) method, then calling GetHashCode() on each of them must yield the same result. If this is not the case, many collections won’t handle class instances correctly.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1206
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CS0659
+  S121:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Control structures should use curly braces
+      Description: While not technically incorrect, the omission of curly braces can be misleading, and may lead to the introduction of errors during maintenance.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-121
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: SA1503
+  S1210:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
+      Description: When you implement IComparable or IComparable<T> on a class you should also override Equals(object) and overload the comparison operators (==, !=, <, <=, >, >=). That’s because the CLR cannot automatically call your CompareTo implementation from Equals(object) or from the base comparison operator implementations. Additionally, it is best practice to override GetHashCode along with Equals.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1210
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1036
+  S1215:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"GC.Collect" should not be called'
+      Description: Calling GC.Collect is rarely necessary, and can significantly affect application performance. That’s because it triggers a blocking operation that examines every object in memory for cleanup. Further, you don’t have control over when this blocking cleanup will actually run.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1215
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      performance:
+        Severity: Warning
+  S122:
+    Metadata:
+      Category: Major Code Smell
+      Title: Statements should be on separate lines
+      Description: For better readability, do not put more than one statement on a single line.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-122
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S1226:
+    Metadata:
+      Category: Minor Bug
+      Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+      Description: While it is technically correct to assign to parameters from within method bodies, doing so before the parameter value is read is likely a bug. Instead, initial values of parameters, caught exceptions, and foreach parameters should be, if not treated as final, then at least read before reassignment.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1226
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1227:
+    Metadata:
+      Category: Minor Code Smell
+      Title: break statements should not be used except for switch cases
+      Description: break; is an unstructured control flow statement which makes code harder to read.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1227
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S1244:
+    Metadata:
+      Category: Major Bug
+      Title: Floating point numbers should not be tested for equality
+      Description: Floating point math is imprecise because of the challenges of storing such values in a binary representation. Even worse, floating point math is not associative; push a float or a double through a series of simple mathematical operations and the answer will be different based on the order of those operation because of the rounding that takes place at each step.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1244
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Error
+  S125:
+    Metadata:
+      Category: Major Code Smell
+      Title: Sections of code should not be commented out
+      Description: Programmers should not comment out code as it bloats programs and reduces readability.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-125
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S126:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"if ... else if" constructs should end with "else" clauses'
+      Description: This rule applies whenever an if statement is followed by one or more else if statements; the final else if should be followed by an else statement.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-126
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S1264:
+    Metadata:
+      Category: Minor Code Smell
+      Title: A "while" loop should be used instead of a "for" loop
+      Description: When only the condition expression is defined in a for loop, and the initialization and increment expressions are missing, a while loop should be used instead to increase readability.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1264
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S127:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"for" loop stop conditions should be invariant'
+      Description: A for loop stop condition should test the loop counter against an invariant value (i.e. one that is true at both the beginning and ending of every loop iteration). Ideally, this means that the stop condition is set to a local variable just before the loop begins.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-127
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1301:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"switch" statements should have at least 3 "case" clauses'
+      Description: switch statements and expressions are useful when there are many different cases depending on the value of the same expression.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1301
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S1309:
+    Metadata:
+      Category: Info Code Smell
+      Title: Track uses of in-source issue suppressions
+      Description: 'This rule allows you to track the usage of the SuppressMessage attributes and #pragma warning disable mechanism.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1309
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Suppressions are frequently necessary.
+  S131:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
+      Description: The requirement for a final default clause is defensive programming. The clause should either take appropriate action, or contain a suitable comment as to why no action is taken. Even when the switch covers all current values of an enum, a default case should still be used because there is no guarantee that the enum won’t be extended.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-131
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S1313:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Using hardcoded IP addresses is security-sensitive
+      Description: 'Hardcoding IP addresses is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1313
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S134:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+      Description: Nested if, switch, for, foreach, while, do, and try statements are key ingredients for making what’s known as "Spaghetti code".
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-134
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S138:
+    Metadata:
+      Category: Major Code Smell
+      Title: Functions should not have too many lines of code
+      Description: A function that grows too large tends to aggregate too many responsibilities.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-138
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S1449:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Culture should be specified for "string" operations
+      Description: string.ToLower(), ToUpper, IndexOf, LastIndexOf, and Compare are all culture-dependent, as are some (floating point number and DateTime-related) calls to ToString. Fortunately, all have variants which accept an argument specifying the culture or formatter to use. Leave that argument off and the call will use the system default culture, possibly creating problems with international characters.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1449
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1450:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Private fields only used as local variables in methods should become local variables
+      Description: When the value of a private field is always assigned to in a class' methods before being read, then it is not being used to store class information. Therefore, it should become a local variable in the relevant methods to prevent any misunderstanding.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1450
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1451:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Track lack of copyright and license headers
+      Description: Each source file should start with a header stating file ownership and the license which must be used to distribute the application.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1451
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0073
+  S1479:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"switch" statements should not have too many "case" clauses'
+      Description: When switch statements have large sets of case clauses, it is usually an attempt to map two sets of data. A Dictionary should be used instead to make the code more readable and maintainable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1479
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1481:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Unused local variables should be removed
+      Description: If a local variable is declared but not used, it is dead code and should be removed. Doing so will improve maintainability because developers will not wonder what the variable is used for.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1481
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CS0168
+  S1541:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Methods and properties should not be too complex
+      Description: The cyclomatic complexity of methods and properties should not exceed a defined threshold. Complex code can perform poorly and will in any case be difficult to understand and therefore to maintain.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1541
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S1607:
+    Metadata:
+      Category: Major Code Smell
+      Title: Tests should not be ignored
+      Description: When a test fails due, for example, to infrastructure issues, you might want to ignore it temporarily. But without some kind of notation about why the test is being ignored, it may never be reactivated. Such tests are difficult to address without comprehensive knowledge of the project, and end up polluting their projects.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1607
+      CustomTags:
+      - C#
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1643:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Strings should not be concatenated using '+' in a loop
+      Description: StringBuilder is more efficient than string concatenation, especially when the operator is repeated over and over as in loops.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1643
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1656:
+    Metadata:
+      Category: Major Bug
+      Title: Variables should not be self-assigned
+      Description: There is no reason to re-assign a variable to itself. Either this statement is redundant and should be removed, or the re-assignment is a mistake and some other value or variable was intended for the assignment instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1656
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1659:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Multiple variables should not be declared on the same line
+      Description: Declaring multiple variable on one line is difficult to read.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1659
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1694:
+    Metadata:
+      Category: Minor Code Smell
+      Title: An abstract class should have both abstract and concrete methods
+      Description: The purpose of an abstract class is to provide some heritable behaviors while also defining methods which must be implemented by sub-classes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1694
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S1696:
+    Metadata:
+      Category: Major Code Smell
+      Title: NullReferenceException should not be caught
+      Description: NullReferenceException should be avoided, not caught. Any situation in which NullReferenceException is explicitly caught can easily be converted to a null test, and any behavior being carried out in the catch block can easily be moved to the "is null" branch of the conditional.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1696
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1697:
+    Metadata:
+      Category: Major Bug
+      Title: Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+      Description: When either the equality operator in a null test or the logical operator that follows it is reversed, the code has the appearance of safely null-testing the object before dereferencing it. Unfortunately the effect is just the opposite - the object is null-tested and then dereferenced only if it is null, leading to a guaranteed null pointer dereference.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1697
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1698:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"==" should not be used when "Equals" is overridden'
+      Description: Using the equality == and inequality != operators to compare two objects generally works. The operators can be overloaded, and therefore the comparison can resolve to the appropriate method. However, when the operators are used on interface instances, then == resolves to reference equality, which may result in unexpected behavior if implementing classes override Equals. Similarly, when a class overrides Equals, but instances are compared with non-overloaded ==, there is a high chance that value comparison was meant instead of the reference one.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1698
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1699:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Constructors should only call non-overridable methods
+      Description: Calling an overridable method from a constructor could result in failures or strange behaviors when instantiating a subclass which overrides the method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1699
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1751:
+    Metadata:
+      Category: Major Bug
+      Title: Loops with at most one iteration should be refactored
+      Description: A loop with at most one iteration is equivalent to the use of an if statement to conditionally execute one piece of code. If the initial intention of the author was really to conditionally execute one piece of code, an if statement should be used instead. If that was not the initial intention of the author, the body of the loop should be fixed to use the nested return, break or throw statements in a more appropriate way.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1751
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1764:
+    Metadata:
+      Category: Major Bug
+      Title: Identical expressions should not be used on both sides of a binary operator
+      Description: Using the same value on either side of a binary operator is almost always a mistake. In the case of logical operators, it is either a copy/paste error and therefore a bug, or it is simply wasted code, and should be simplified. In the case of bitwise operators and most binary mathematical operators, having the same value on both sides of an operator yields predictable results, and should be simplified.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1764
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1821:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"switch" statements should not be nested'
+      Description: Nested switch structures are difficult to understand because you can easily confuse the cases of an inner switch as belonging to an outer statement. Therefore nested switch statements should be avoided.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1821
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S1848:
+    Metadata:
+      Category: Major Bug
+      Title: Objects should not be created to be dropped immediately without being used
+      Description: There is no good reason to create a new object to not do anything with it. Most of the time, this is due to a missing piece of code and so could lead to an unexpected behavior in production.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1848
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1854:
+    Metadata:
+      Category: Major Code Smell
+      Title: Unused assignments should be removed
+      Description: A dead store happens when a local variable is assigned a value that is not read by any subsequent instruction. Calculating or retrieving a value only to then overwrite it or throw it away, could indicate a serious error in the code. Even if it’s not an error, it is at best a waste of resources. Therefore all calculated values should be used.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1854
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0059
+  S1858:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"ToString()" calls should not be redundant'
+      Description: Invoking a method designed to return a string representation of an object which is already a string is a waste of keystrokes. Similarly, explicitly invoking ToString() when the compiler would do it implicitly is also needless code-bloat.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1858
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1862:
+    Metadata:
+      Category: Major Bug
+      Title: Related "if/else if" statements should not have the same condition
+      Description: 'A chain of if/else if statements is evaluated from top to bottom. At most, only one branch will be executed: the first one with a condition that evaluates to true.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1862
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1871:
+    Metadata:
+      Category: Major Code Smell
+      Title: Two branches in a conditional structure should not have exactly the same implementation
+      Description: Having two cases in the same switch statement or branches in the same if structure with the same implementation is at best duplicate code, and at worst a coding error. If the same logic is truly needed for both instances, then in an if structure they should be combined, or for a switch, one should fall through to the other.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1871
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1905:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Redundant casts should not be used
+      Description: Unnecessary casting expressions make the code harder to read and understand.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1905
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0004
+  S1939:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Inheritance list should not be redundant
+      Description: 'An inheritance list entry is redundant if:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1939
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1940:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Boolean checks should not be inverted
+      Description: It is needlessly complex to invert the result of a boolean comparison. The opposite comparison should be made instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1940
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S1944:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Inappropriate casts should not be made
+      Description: Inappropriate casts are issues that will lead to unexpected behavior or runtime errors, such as InvalidCastExceptions. The compiler will catch bad casts from one class to another, but not bad casts to interfaces. Nor will it catch nullable values that are known to be null but that are cast to their underlying value types anyway.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1944
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S1994:
+    Metadata:
+      Category: Critical Code Smell
+      Title: "\"for\" loop increment clauses should modify the loops' counters"
+      Description: It can be extremely confusing when a for loop’s counter is incremented outside of its increment clause. In such cases, the increment should be moved to the loop’s increment clause if at all possible.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-1994
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2053:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Hashes should include an unpredictable salt
+      Description: In cryptography, a "salt" is an extra piece of data which is included when hashing a password. This makes rainbow-table attacks more difficult. Using a cryptographic hash function without an unpredictable salt increases the likelihood that an attacker could successfully find the hash value in databases of precomputed hashes (called rainbow-tables).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2053
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Analysis is too slow
+  S2068:
+    Metadata:
+      Category: Blocker Security Hotspot
+      Title: Hard-coded credentials are security-sensitive
+      Description: Because it is easy to extract strings from an application source code or binary, credentials should not be hard-coded. This is particularly true for applications that are distributed or that are open-source.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2068
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2070:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+      Description: 'The MD5 algorithm and its successor, SHA-1, are no longer considered secure, because it is too easy to create hash collisions with them. That is, it takes too little computational effort to come up with a different input that produces the same MD5 or SHA-1 hash, and using the new, same-hash value gives an attacker the same access as if he had the originally-hashed value. This applies as well to the other Message-Digest algorithms: MD2, MD4, MD6.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2070
+      CustomTags:
+      - C#
+      - MainSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA5350
+  S2077:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Formatting SQL queries is security-sensitive
+      Description: Formatted SQL queries can be difficult to maintain, debug and can increase the risk of SQL injection when concatenating untrusted values into the query. However, this rule doesn’t detect SQL injections (unlike rule {rule:csharpsquid:S3649}), the goal is only to highlight complex/formatted queries.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2077
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2092:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Creating cookies without the "secure" flag is security-sensitive
+      Description: When a cookie is protected with the secure attribute set to true it will not be send by the browser over an unencrypted HTTP request and thus cannot be observed by an unauthorized person during a man-in-the-middle attack.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2092
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2114:
+    Metadata:
+      Category: Major Bug
+      Title: Collections should not be passed as arguments to their own methods
+      Description: Passing a collection as an argument to the collection’s own method is either an error - some other argument was intended - or simply nonsensical code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2114
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2123:
+    Metadata:
+      Category: Major Bug
+      Title: Values should not be uselessly incremented
+      Description: A value that is incremented or decremented and then not stored is at best wasted code and at worst a bug.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2123
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2148:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Underscores should be used to make large numbers readable
+      Description: Beginning with C# 7, it is possible to add underscores ('_') to numeric literals to enhance readability. The addition of underscores in this manner has no semantic meaning, but makes it easier for maintainers to understand the code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2148
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S2156:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"sealed" classes should not have "protected" members'
+      Description: The difference between private and protected visibility is that child classes can see and use protected members, but they cannot see private ones. Since a sealed class cannot have children, marking its members protected is confusingly pointless.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2156
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2178:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Short-circuit logic should be used in boolean contexts
+      Description: The use of non-short-circuit logic in a boolean context is likely a mistake - one that could cause serious program errors as conditions are evaluated under the wrong circumstances.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2178
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2183:
+    Metadata:
+      Category: Minor Bug
+      Title: Integral numbers should not be shifted by zero or more than their number of bits-1
+      Description: Shifting an integral number by 0 is equivalent to doing nothing but makes the code confusing for maintainers.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2183
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2184:
+    Metadata:
+      Category: Minor Bug
+      Title: Results of integer division should not be assigned to floating point variables
+      Description: When division is performed on ints, the result will always be an int. You can assign that result to a double, float or decimal with automatic type conversion, but having started as an int, the result will likely not be what you expect. If the result of int division is assigned to a floating-point variable, precision will have been lost before the assignment. Instead, at least one operand should be cast or promoted to the final type before the operation takes place.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2184
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2187:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: TestCases should contain tests
+      Description: There’s no point in having a test class without any test methods.This could lead a maintainer to assume a class is covered by tests even though it is not.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2187
+      CustomTags:
+      - C#
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2190:
+    Metadata:
+      Category: Blocker Bug
+      Title: Recursion should not be infinite
+      Description: Recursion happens when control enters a loop that has no exit. This can happen a method invokes itself, when a pair of methods invoke each other, or when goto statements are used to move between two segments of code. It can be a useful tool, but unless the method includes a provision to break out of the recursion and return, the recursion will continue until the stack overflows and the program crashes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2190
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2197:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Modulus results should not be checked for direct equality
+      Description: When the modulus of a negative number is calculated, the result will either be negative or zero. Thus, comparing the modulus of a variable for equality with a positive number (or a negative one) could result in unexpected results.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2197
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2201:
+    Metadata:
+      Category: Major Bug
+      Title: Return values from functions without side effects should not be ignored
+      Description: When the call to a function doesn’t have any side effects, what is the point of making the call if the results are ignored? In such case, either the function call is useless and should be dropped or the source code doesn’t behave as expected.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2201
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1806
+  S2219:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Runtime type checking should be simplified
+      Description: 'To check the type of an object there are several options:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2219
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2221:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"Exception" should not be caught'
+      Description: Catching System.Exception seems like an efficient way to handle multiple possible exceptions. Unfortunately, it traps all exception types, including the ones that were not intended to be caught. To prevent any misunderstandings, the exception filters should be used. Alternatively each exception type should be in a separate catch block.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2221
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S2223:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Non-constant static fields should not be visible
+      Description: A static field that is neither constant nor read-only is not thread-safe. Correctly accessing these fields from different threads needs synchronization with locks. Improper synchronization may lead to unexpected results, thus publicly visible static fields are best suited for storing non-changing data shared by many consumers. To enforce this intent, these fields should be marked readonly or converted to constants.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2223
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2225:
+    Metadata:
+      Category: Major Bug
+      Title: '"ToString()" method should not return null'
+      Description: Calling ToString() on an object should always return a string. Returning null instead contravenes the method’s implicit contract.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2225
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2228:
+    Metadata:
+      Category: Minor Vulnerability
+      Title: Console logging should not be used
+      Description: Debug statements are always useful during development. But include them in production code - particularly in code that runs client-side - and you run the risk of inadvertently exposing sensitive information.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2228
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  S2234:
+    Metadata:
+      Category: Major Code Smell
+      Title: Parameters should be passed in the correct order
+      Description: When the names of parameters in a method call match the names of the method arguments, it contributes to clearer, more readable code. However, when the names match, but are passed in a different order than the method arguments, it indicates a mistake in the parameter order which will likely lead to unexpected results.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2234
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2245:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using pseudorandom number generators (PRNGs) is security-sensitive
+      Description: 'Using pseudorandom number generators (PRNGs) is security-sensitive. For example, it has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2245
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2251:
+    Metadata:
+      Category: Major Bug
+      Title: A "for" loop update clause should move the counter in the right direction
+      Description: A for loop with a counter that moves in the wrong direction is not an infinite loop. Because of wraparound, the loop will eventually reach its stop condition, but in doing so, it will run many, many more times than anticipated, potentially causing unexpected behavior.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2251
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2252:
+    Metadata:
+      Category: Major Bug
+      Title: For-loop conditions should be true at least once
+      Description: If a for loop’s condition is false before the first loop iteration, the loop will never be executed. Such loops are almost always bugs, particularly when the initial value and stop conditions are hard-coded.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2252
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2255:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Writing cookies is security-sensitive
+      Description: 'Using cookies is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2255
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2257:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using non-standard cryptographic algorithms is security-sensitive
+      Description: The use of a non-standard algorithm is dangerous because a determined attacker may be able to break the algorithm and compromise whatever data has been protected. Standard algorithms like AES, RSA, SHA, …​ should be used instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2257
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2259:
+    Metadata:
+      Category: Major Bug
+      Title: Null pointers should not be dereferenced
+      Description: A reference to null should never be dereferenced/accessed. Doing so will cause a NullReferenceException to be thrown. At best, such an exception will cause abrupt program termination. At worst, it could expose debugging information that would be useful to an attacker, or it could allow an attacker to bypass security measures.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2259
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Redundant, covered by modern C# compiler
+  S2275:
+    Metadata:
+      Category: Blocker Bug
+      Title: Composite format strings should not lead to unexpected behavior at runtime
+      Description: Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behaviors or runtime errors. This rule statically validates the good behavior of composite formats when calling the methods of String.Format, StringBuilder.AppendFormat, Console.Write, Console.WriteLine, TextWriter.Write, TextWriter.WriteLine, Debug.WriteLine(String, Object[]), Trace.TraceError(String, Object[]), Trace.TraceInformation(String, Object[]), Trace.TraceWarning(String, Object[]) and TraceSource.TraceInformation(String, Object[]).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2275
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2278:
+    Metadata:
+      Category: Blocker Vulnerability
+      Title: Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+      Description: 'According to the US National Institute of Standards and Technology (NIST), the Data Encryption Standard (DES) is no longer considered secure:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2278
+      CustomTags:
+      - C#
+      - MainSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2290:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Field-like events should not be virtual
+      Description: Field-like events are events that do not have explicit add and remove methods. The compiler generates a private delegate field to back the event, as well as generating the implicit add and remove methods.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2290
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2291:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Overflow checking should not be disabled for "Enumerable.Sum"
+      Description: Enumerable.Sum() always executes addition in a checked context, so an OverflowException will be thrown if the value exceeds MaxValue even if an unchecked context was specified. Using an unchecked context anyway represents a misunderstanding of how Sum works.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2291
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2292:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Trivial properties should be auto-implemented
+      Description: Trivial properties, which include no logic but setting and getting a backing field should be converted to auto-implemented properties, yielding cleaner and more readable code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2292
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0032
+  S2302:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"nameof" should be used'
+      Description: Because parameter names could be changed during refactoring, they should not be spelled out literally in strings. Instead, use nameof(), and the string that’s output will always be correct.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2302
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2306:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: '"async" and "await" should not be used as identifiers'
+      Description: Since C# 5.0, async and await are contextual keywords. Contextual keywords do have a particular meaning in some contexts, but can still be used as variable names. Keywords, on the other hand, are always reserved, and therefore are not valid variable names. To avoid any confusion though, it is best to not use async and await as identifiers.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2306
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2325:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Methods and properties that don't access instance data should be static
+      Description: Methods and properties that don’t access instance data can be static to prevent any misunderstanding about the contract of the method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2325
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1822
+  S2326:
+    Metadata:
+      Category: Major Code Smell
+      Title: Unused type parameters should be removed
+      Description: Type parameters that aren’t used are dead code, which can only distract and possibly confuse developers during maintenance. Therefore, unused type parameters should be removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2326
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Valid pattern used in a number of places
+  S2327:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
+      Description: When multiple, adjacent try statements have duplicate catch and/or finally blocks, they should be merged to consolidate the catch/finally logic for cleaner, more readable code. Note that this applies even when there is intervening code outside any try block.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2327
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2328:
+    Metadata:
+      Category: Minor Bug
+      Title: '"GetHashCode" should not reference mutable fields'
+      Description: GetHashCode is used to file an object in a Dictionary or Hashtable. If GetHashCode uses non-readonly fields and those fields change after the object is stored, the object immediately becomes mis-filed in the Hashtable. Any subsequent test to see if the object is in the Hashtable will return a false negative.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2328
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2330:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Array covariance should not be used
+      Description: Array covariance is the principle that if an implicit or explicit reference conversion exits from type A to B, then the same conversion exists from the array type A[] to B[].
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2330
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2333:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Redundant modifiers should not be used
+      Description: 'Unnecessary keywords simply clutter the code and should be removed. Specifically:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2333
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2339:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Public constant members should not be used
+      Description: Constant members are copied at compile time to the call sites, instead of being fetched at runtime.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2339
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S2342:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Enumeration types should comply with a naming convention
+      Description: Shared naming conventions allow teams to collaborate efficiently. This rule checks that all enum names match a provided regular expression.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2342
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S2344:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Enumeration type names should not have "Flags" or "Enum" suffixes
+      Description: The information that an enumeration type is actually an enumeration or a set of flags should not be duplicated in its name.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2344
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S2345:
+    Metadata:
+      Category: Minor Bug
+      Title: Flags enumerations should explicitly initialize all their members
+      Description: Flags enumerations should not rely on the language to initialize the values of their members. Implicit initialization will set the first member to 0, and increment the value by one for each subsequent member. This implicit behavior does not allow members to be combined using the bitwise or operator in a useful way.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2345
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2346:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Flags enumerations zero-value members should be named "None"
+      Description: Consistent use of "None" in flags enumerations indicates that all flag values are cleared. The value 0 should not be used to indicate any other state, since there is no way to check that the bit 0 is set.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2346
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1008
+  S2357:
+    Metadata:
+      Category: Major Code Smell
+      Title: Fields should be private
+      Description: Fields should not be part of an API, and therefore should always be private. Indeed, they cannot be added to an interface for instance, and validation cannot be added later on without breaking backward compatibility. Instead, developers should encapsulate their fields into properties. Explicit property getters and setters can be introduced for validation purposes or to smooth the transition to a newer system.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2357
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1051
+  S2360:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Optional parameters should not be used
+      Description: 'The overloading mechanism should be used in place of optional parameters for several reasons:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2360
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S2365:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Properties should not make collection or array copies
+      Description: Most developers expect property access to be as efficient as field access. However, if a property returns a copy of an array or collection, it will be much slower than simple field access, contrary to the caller’s likely expectations. Therefore, such properties should be refactored into methods so that callers are not surprised by the unexpectedly poor performance.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2365
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2368:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Public methods should not have multidimensional array parameters
+      Description: Exposing methods with multidimensional array parameters requires developers to have advanced knowledge about the language in order to be able to use them. Moreover, what exactly to pass to such parameters is not intuitive. Therefore, such methods should not be exposed, but can be used internally.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2368
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2372:
+    Metadata:
+      Category: Major Code Smell
+      Title: Exceptions should not be thrown from property getters
+      Description: Property getters should be simple operations that are always safe to call. If exceptions need to be thrown, it is best to convert the property to a method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2372
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2376:
+    Metadata:
+      Category: Major Code Smell
+      Title: Write-only properties should not be used
+      Description: Properties with only setters are confusing and counterintuitive. Instead, a property getter should be added if possible, or the property should be replaced with a setter method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2376
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2386:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Mutable fields should not be "public static"
+      Description: public static mutable fields of classes which are accessed directly should be protected to the degree possible. This can be done by reducing the accessibility of the field or by changing the return type to an immutable type.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2386
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2387:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Child class fields should not shadow parent class fields
+      Description: Having a variable with the same name in two unrelated classes is fine, but do the same thing within a class hierarchy and you’ll get confusion at best, chaos at worst.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2387
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2436:
+    Metadata:
+      Category: Major Code Smell
+      Title: Types and methods should not have too many generic parameters
+      Description: A method or class with too many type parameters has likely aggregated too many responsibilities and should be split.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2436
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1005
+  S2437:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Silly bit operations should not be performed
+      Description: Certain bit operations are just silly and should not be performed because their results are predictable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2437
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2479:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Whitespace and control characters in string literals should be explicit
+      Description: 'Non-encoded control characters and whitespace characters are often injected in the source code because of a bad manipulation. They are either invisible or difficult to recognize, which can result in bugs when the string is not what the developer expects. If you actually need to use a control character use their encoded version (ex: ASCII \n,\t,…​ or Unicode U+000D, U+0009,…​).'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2479
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2486:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Generic exceptions should not be ignored
+      Description: When exceptions occur, it is usually a bad idea to simply ignore them. Instead, it is better to handle them properly, or at least to log them.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2486
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2551:
+    Metadata:
+      Category: Critical Bug
+      Title: Shared resources should not be used for locking
+      Description: Shared resources should not be used for locking as it increases the chance of deadlocks. Any other thread could acquire (or attempt to acquire) the same lock for another unrelated purpose.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2551
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2583:
+    Metadata:
+      Category: Major Bug
+      Title: Conditionally executed code should be reachable
+      Description: Conditional expressions which are always true or false can lead to dead code. Such code is always buggy and should never be used in production.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2583
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1508
+  S2589:
+    Metadata:
+      Category: Major Code Smell
+      Title: Boolean expressions should not be gratuitous
+      Description: If a boolean expression doesn’t change the evaluation of the condition, then it is entirely unnecessary, and can be removed. If it is gratuitous because it does not match the programmer’s intent, then it’s a bug and the expression should be fixed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2589
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2674:
+    Metadata:
+      Category: Minor Bug
+      Title: The length returned from a stream read should be checked
+      Description: You cannot assume that any given stream reading call will fill the byte[] passed in to the method with the number of bytes requested. Instead, you must check the value returned by the read method to see how many bytes were read. Fail to do so, and you introduce a bug that is both harmful and difficult to reproduce.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2674
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2681:
+    Metadata:
+      Category: Major Code Smell
+      Title: Multiline blocks should be enclosed in curly braces
+      Description: Curly braces can be omitted from a one-line block, such as with an if statement or for loop, but doing so can be misleading and induce bugs.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2681
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2688:
+    Metadata:
+      Category: Major Bug
+      Title: '"NaN" should not be used in comparisons'
+      Description: NaN is not equal to anything, even itself. Testing for equality or inequality against NaN will yield predictable results, but probably not the ones you want.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2688
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2692:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"IndexOf" checks should not be for positive numbers'
+      Description: Most checks against an IndexOf value compare it with -1 because 0 is a valid index. Any checks which look for values > 0 ignore the first element, which is likely a bug. If the intent is merely to check inclusion of a value in a string, List, or an array, consider using the Contains method instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2692
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2696:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Instance members should not write to "static" fields
+      Description: Correctly updating a static field from a non-static method is tricky to get right and could easily lead to bugs if there are multiple class instances and/or multiple threads in play.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2696
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2699:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Tests should include assertions
+      Description: A test case without assertions ensures only that no exceptions are thrown. Beyond basic runnability, it ensures nothing about the behavior of the code under test.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2699
+      CustomTags:
+      - C#
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2701:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Literal boolean values should not be used in assertions
+      Description: There’s no reason to use literal boolean values in assertions. Doing so is at best confusing for maintainers, and at worst a bug.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2701
+      CustomTags:
+      - C#
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2737:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"catch" clauses should do more than rethrow'
+      Description: A catch clause that only rethrows the caught exception has the same effect as omitting the catch altogether and letting it bubble up automatically, but with more code and the additional detriment of leaving maintainers scratching their heads.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2737
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2743:
+    Metadata:
+      Category: Major Code Smell
+      Title: Static fields should not be used in generic types
+      Description: A static field in a generic type is not shared among instances of different closed constructed types, thus LengthLimitedSingletonCollection<int>.instances and LengthLimitedSingletonCollection<string>.instances will point to different objects, even though instances is seemingly shared among all LengthLimitedSingletonCollection<> generic classes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2743
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S2755:
+    Metadata:
+      Category: Blocker Vulnerability
+      Title: XML parsers should not be vulnerable to XXE attacks
+      Description: XML standard allows the use of entities, declared in the DOCTYPE of the document, which can be internal or external.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2755
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2757:
+    Metadata:
+      Category: Major Bug
+      Title: '"=+" should not be used instead of "+="'
+      Description: The use of operators pairs ( =+, =- or =! ) where the reversed, single operator was meant (+=, -= or !=) will compile and run, but not produce the expected results.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2757
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2758:
+    Metadata:
+      Category: Major Bug
+      Title: The ternary operator should not return the same value regardless of the condition
+      Description: 'When the second and third operands of a ternary operator are the same, the operator will always return the same value regardless of the condition. Either the operator itself is pointless, or a mistake was made in coding it. '
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2758
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2760:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Sequential tests should not check the same condition
+      Description: When the same condition is checked twice in a row, it is either confusing - why have separate checks? - or an error - some other condition should have been checked in the second test.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2760
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S2761:
+    Metadata:
+      Category: Major Bug
+      Title: Doubled prefix operators "!!" and "~~" should not be used
+      Description: 'Calling the ! or ~ prefix operator twice does nothing: the second invocation undoes the first. Such mistakes are typically caused by accidentally double-tapping the key in question without noticing.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2761
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2857:
+    Metadata:
+      Category: Blocker Bug
+      Title: SQL keywords should be delimited by whitespace
+      Description: Badly formed SQL is likely to cause errors at runtime.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2857
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2930:
+    Metadata:
+      Category: Blocker Bug
+      Title: '"IDisposables" should be disposed'
+      Description: "When writing managed code, you don’t need to worry about allocating or freeing memory: The garbage collector takes care of it. For efficiency reasons, some objects such as Bitmap use unmanaged memory, enabling for example the use of pointer arithmetic. Such objects have potentially huge unmanaged memory footprints, but will have tiny managed ones. Unfortunately, the garbage collector only sees the tiny managed footprint, and fails to reclaim the unmanaged memory (by calling Bitmap's finalizer method) in a timely fashion."
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2930
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2000
+  S2931:
+    Metadata:
+      Category: Blocker Bug
+      Title: Classes with "IDisposable" members should implement "IDisposable"
+      Description: 'An IDisposable object should be disposed (there are some rare exceptions where not disposing is fine, most notably Task). If a class has an IDisposable field, there can be two situations:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2931
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1001
+  S2933:
+    Metadata:
+      Category: Major Code Smell
+      Title: Fields that are only assigned in the constructor should be "readonly"
+      Description: readonly fields can only be assigned in a class constructor. If a class has a field that’s not marked readonly but is only set in the constructor, it could cause confusion about the field’s intended use. To avoid confusion, such fields should be marked readonly to make their intended use explicit, and to prevent future maintainers from inadvertently changing their use.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2933
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0044
+  S2934:
+    Metadata:
+      Category: Minor Bug
+      Title: Property assignments should not be made for "readonly" fields not constrained to reference types
+      Description: While the properties of a readonly reference type field can still be changed after initialization, those of a readonly value field, such as a struct, cannot.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2934
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2952:
+    Metadata:
+      Category: Critical Bug
+      Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
+      Description: It is possible in an IDisposable to call Dispose on class members from any method, but the contract of Dispose is that it will clean up all unmanaged resources. Move disposing of members to some other method, and you risk resource leaks.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2952
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2953:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Methods named "Dispose" should implement "IDisposable.Dispose"
+      Description: Dispose as a method name should be used exclusively to implement IDisposable.Dispose to prevent any confusion.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2953
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2955:
+    Metadata:
+      Category: Minor Bug
+      Title: Generic parameters not constrained to reference types should not be compared to "null"
+      Description: When constraints have not been applied to restrict a generic type parameter to be a reference type, then a value type, such as a struct, could also be passed. In such cases, comparing the type parameter to null would always be false, because a struct can be empty, but never null. If a value type is truly what’s expected, then the comparison should use default(). If it’s not, then constraints should be added so that no value type can be passed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2955
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2971:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"IEnumerable" LINQs should be simplified'
+      Description: In the interests of readability, code that can be simplified should be simplified. To that end, there are several ways IEnumerable language integrated queries (LINQ) can be simplified
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2971
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2995:
+    Metadata:
+      Category: Major Bug
+      Title: '"Object.ReferenceEquals" should not be used for value types'
+      Description: Using Object.ReferenceEquals to compare the references of two value types simply won’t return the expected results most of the time because such types are passed by value, not by reference.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2995
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2996:
+    Metadata:
+      Category: Major Bug
+      Title: '"ThreadStatic" fields should not be initialized'
+      Description: When an object has a field annotated with ThreadStatic, that field is shared within a given thread, but unique across threads. Since a class' static initializer is only invoked for the first thread created, it also means that only the first thread will have the expected initial values.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2996
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2997:
+    Metadata:
+      Category: Major Bug
+      Title: '"IDisposables" created in a "using" statement should not be returned'
+      Description: Typically you want to use using to create a local IDisposable variable; it will trigger disposal of the object when control passes out of the block’s scope. The exception to this rule is when your method returns that IDisposable. In that case using disposes of the object before the caller can make use of it, likely causing exceptions at runtime. So you should either remove using or avoid returning the IDisposable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2997
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3005:
+    Metadata:
+      Category: Major Bug
+      Title: '"ThreadStatic" should not be used on non-static fields'
+      Description: When a non-static class field is annotated with ThreadStatic, the code seems to show that the field can have different values for different calling threads, but that’s not the case, since the ThreadStatic attribute is simply ignored on non-static fields.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3005
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3010:
+    Metadata:
+      Category: Major Code Smell
+      Title: Static fields should not be updated in constructors
+      Description: Assigning a value to a static field in a constructor could cause unreliable behavior at runtime since it will change the value for all instances of the class.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3010
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3011:
+    Metadata:
+      Category: Major Code Smell
+      Title: Reflection should not be used to increase accessibility of classes, methods, or fields
+      Description: This rule raises an issue when reflection is used to change the visibility of a class, method or field, and when it is used to directly update a field value. Altering or bypassing the accessibility of classes, methods, or fields violates the encapsulation principle and could lead to run-time errors.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3011
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3052:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Members should not be initialized to default values
+      Description: The compiler automatically initializes class fields, auto-properties and events to their default values before setting them with any initialization values, so there is no need to explicitly set a member to its default value. Further, under the logic that cleaner code is better code, it’s considered poor style to do so.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3052
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1805
+  S3060:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: '"is" should not be used with "this"'
+      Description: There’s no valid reason to test this with is. The only plausible explanation for such a test is that you’re executing code in a parent class conditionally based on the kind of child class this is. But code that’s specific to a child class should be in that child class, not in the parent.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3060
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3168:
+    Metadata:
+      Category: Major Bug
+      Title: '"async" methods should not return "void"'
+      Description: An async method with a void return type is a "fire and forget" method best reserved for event handlers because there’s no way to wait for the method’s execution to complete and respond accordingly. There’s also no way to catch exceptions thrown from the method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3168
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: VSTHRD100
+  S3169:
+    Metadata:
+      Category: Major Code Smell
+      Title: Multiple "OrderBy" calls should not be used
+      Description: There’s no point in chaining multiple OrderBy calls in a LINQ; only the last one will be reflected in the result because each subsequent call completely reorders the list. Thus, calling OrderBy multiple times is a performance issue as well, because all of the sorting will be executed, but only the result of the last sort will be kept.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3169
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3172:
+    Metadata:
+      Category: Major Bug
+      Title: Delegates should not be subtracted
+      Description: In C#, delegates can be added together to chain their execution, and subtracted to remove their execution from the chain.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3172
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3215:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"interface" instances should not be cast to concrete types'
+      Description: Needing to cast from an interface to a concrete type indicates that something is wrong with the abstractions in use, likely that something is missing from the interface. Instead of casting to a discrete type, the missing functionality should be added to the interface. Otherwise there is a risk of runtime exceptions.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3215
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3216:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"ConfigureAwait(false)" should be used'
+      Description: After an awaited Task has executed, you can continue execution in the original, calling thread or any arbitrary thread. Unless the rest of the code needs the context from which the Task was spawned, Task.ConfigureAwait(false) should be used to keep execution in the Task thread to avoid the need for context switching and the possibility of deadlocks.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3216
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2007
+  S3217:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"Explicit" conversions of "foreach" loops should not be used'
+      Description: The foreach statement was introduced in the C# language prior to generics to make it easier to work with the non-generic collections available at that time such as ArrayList. The foreach statements allows you to downcast elements of a collection of Objects to any other type. The problem is that to achieve the cast, the foreach statements silently performs explicit type conversion, which at runtime can result in an InvalidCastException.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3217
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3218:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Inner class members should not shadow outer class "static" or type members
+      Description: It’s possible to name the members of an inner class the same as the static members of its enclosing class - possible, but a bad idea. That’s because maintainers may be confused about which members are being used where. Instead the inner class' members should be renamed and all the references updated.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3218
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3220:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Method calls should not resolve ambiguously to overloads with "params"
+      Description: The rules for method resolution are complex and perhaps not properly understood by all coders. The params keyword can make method declarations overlap in non-obvious ways, so that slight changes in the argument types of an invocation can resolve to different methods.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3220
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3234:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
+      Description: GC.SuppressFinalize asks the Common Language Runtime not to call the finalizer of an object. This is useful when implementing the dispose pattern where object finalization is already handled in IDisposable.Dispose. However, it has no effect if there is no finalizer defined in the object’s type, so using it in such cases is just confusing.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3234
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3235:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Redundant parentheses should not be used
+      Description: Redundant parentheses are simply wasted keystrokes, and should be removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3235
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3236:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Caller information arguments should not be provided explicitly
+      Description: 'Caller information attributes: CallerFilePathAttribute, CallerLineNumberAttribute, and CallerArgumentExpressionAttribute provide a way to get information about the caller of a method through optional parameters. But the arguments for these optional parameters are only generated if they are not explicitly defined in the call. Thus, specifying the argument values defeats the purpose of the attributes.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3236
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3237:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: '"value" parameters should be used'
+      Description: In property and indexer set methods, and in event add and remove methods, the implicit value parameter holds the value the accessor was called with. Not using the value means that the accessor ignores the caller’s intent which could cause unexpected results at runtime.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3237
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3240:
+    Metadata:
+      Category: Minor Code Smell
+      Title: The simplest possible condition syntax should be used
+      Description: In the interests of keeping code clean, the simplest possible conditional syntax should be used. That means
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3240
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0054
+  S3241:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Methods should not return values that are never used
+      Description: Private methods are clearly intended for use only within their own scope. When such methods return values that are never used by any of their callers, then clearly there is no need to actually make the return, and it should be removed in the interests of efficiency and clarity.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3241
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3242:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Method parameters should be declared with base types
+      Description: When a derived type is used as a parameter instead of the base type, it limits the uses of the method. If the additional functionality that is provided in the derived type is not required then that limitation isn’t required, and should be removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3242
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+  S3244:
+    Metadata:
+      Category: Major Bug
+      Title: Anonymous delegates should not be used to unsubscribe from Events
+      Description: 'It is possible to subscribe to events with anonymous delegates, but having done so, it is impossible to unsubscribe from them. That’s because the process of subscribing adds the delegate to a list. The process of unsubscribing essentially says: remove this item from the subscription list. But because an anonymous delegate was used in both cases, the unsubscribe attempt tries to remove a different item from the list than was added. The result: NOOP.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3244
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3246:
+    Metadata:
+      Category: Major Code Smell
+      Title: Generic type parameters should be co/contravariant when possible
+      Description: In the interests of making code as usable as possible, interfaces and delegates with generic parameters should use the out and in modifiers when possible to make the interfaces and delegates covariant and contravariant, respectively.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3246
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3247:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Duplicate casts should not be made
+      Description: Because the is operator performs a cast if the object is not null, using is to check type and then casting the same argument to that type, necessarily performs two casts. The same result can be achieved more efficiently with a single cast using as, followed by a null-check.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3247
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3249:
+    Metadata:
+      Category: Major Bug
+      Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+      Description: Making a base call in an overriding method is generally a good idea, but not in GetHashCode and Equals for classes that directly extend object because those methods are based on the object reference. Meaning that no two objects that use those base methods will ever be equal or have the same hash.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3249
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3251:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Implementations should be provided for "partial" methods
+      Description: partial methods allow an increased degree of flexibility in programming a system. Hooks can be added to generated code by invoking methods that define their signature, but might not have an implementation yet. But if the implementation is still missing when the code makes it to production, the compiler silently removes the call. In the best case scenario, such calls simply represent cruft, but in they worst case they are critical, missing functionality, the loss of which will lead to unexpected results at runtime.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3251
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3253:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Constructor and destructor declarations should not be redundant
+      Description: Since the compiler will automatically invoke the base type’s no-argument constructor, there’s no need to specify its invocation explicitly. Also, when only a single public parameterless constructor is defined in a class, then that constructor can be removed because the compiler would generate it automatically. Similarly, empty static constructors and empty destructors are also wasted keystrokes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3253
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3254:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Default parameter values should not be passed as arguments
+      Description: Specifying the default parameter values in a method call is redundant. Such values should be omitted in the interests of readability.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3254
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3256:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"string.IsNullOrEmpty" should be used'
+      Description: Using string.Equals to determine if a string is empty is significantly slower than using string.IsNullOrEmpty() or checking for string.Length == 0. string.IsNullOrEmpty() is both clear and concise, and therefore preferred to laborious, error-prone, manual null- and emptiness-checking.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3256
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3257:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Declarations and initializations should be as concise as possible
+      Description: Unnecessarily verbose declarations and initializations make it harder to read the code, and should be simplified.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3257
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3261:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Namespaces should not be empty
+      Description: Namespaces with no lines of code clutter a project and should be removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3261
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3262:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"params" should be used on overrides'
+      Description: Overriding methods automatically inherit the params behavior. To ease readability, this modifier should be explicitly used in the overriding method as well.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3262
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3263:
+    Metadata:
+      Category: Major Bug
+      Title: 'Static fields should appear in the order they must be initialized '
+      Description: Static field initializers are executed in the order in which they appear in the class from top to bottom. Thus, placing a static field in a class above the field or fields required for its initialization will yield unexpected results.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3263
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3264:
+    Metadata:
+      Category: Major Code Smell
+      Title: Events should be invoked
+      Description: Events that are not invoked anywhere are dead code, and there’s no good reason to keep them in the source.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3264
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3265:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Non-flags enums should not be used in bitwise operations
+      Description: enums are usually used to identify distinct elements in a set of values. However enums can be treated as bit fields and bitwise operations can be used on them to combine the values. This is a good way of specifying multiple elements of set with a single value. When enums are used this way, it is a best practice to mark the enum with the FlagsAttribute.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3265
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3329:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Cipher Block Chaining IVs should be unpredictable
+      Description: When encrypting data with the Cipher Block Chaining (CBC) mode an Initialization Vector (IV) is used to randomize the encryption, ie under a given key the same plaintext doesn’t always produce the same ciphertext. The IV doesn’t need to be secret but should be unpredictable to avoid "Chosen-Plaintext Attack".
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3329
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Analysis is too slow
+  S3330:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Creating cookies without the "HttpOnly" flag is security-sensitive
+      Description: When a cookie is configured with the HttpOnly attribute set to true, the browser guaranties that no client-side script will be able to read it. In most cases, when a cookie is created, the default value of HttpOnly is false and it’s up to the developer to decide whether or not the content of the cookie can be read by the client-side script. As a majority of Cross-Site Scripting (XSS) attacks target the theft of session-cookies, the HttpOnly attribute can help to reduce their impact as it won’t be possible to exploit the XSS vulnerability to steal session-cookies.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3330
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3343:
+    Metadata:
+      Category: Major Bug
+      Title: Caller information parameters should come at the end of the parameter list
+      Description: 'Caller information attributes (CallerFilePathAttribute, CallerLineNumberAttribute, CallerMemberNameAttribute, and CallerArgumentExpressionAttribute) provide a way to get information about the caller of a method through optional parameters. But they only work right if their values aren’t provided explicitly. So if you define a method with caller info attributes in the middle of the parameter list, you put your callers in a bad position: they are forced to use named arguments if they want to use the method properly.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3343
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3346:
+    Metadata:
+      Category: Major Bug
+      Title: Expressions used in "Debug.Assert" should not produce side effects
+      Description: An assertion is a piece of code that’s used during development when the compilation debug mode is activated. It allows a program to check itself as it runs. When an assertion is true, that means everything is operating as expected.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3346
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3353:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Unchanged local variables should be "const"
+      Description: Marking a variable that is unchanged after initialization const is an indication to future maintainers that "no this isn’t updated, and it’s not supposed to be". const should be used in these situations in the interests of code clarity.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3353
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3358:
+    Metadata:
+      Category: Major Code Smell
+      Title: Ternary operators should not be nested
+      Description: Just because you can do something, doesn’t mean you should, and that’s the case with nested ternary operations. Nesting ternary operators results in the kind of code that may seem clear as day when you write it, but six months later will leave maintainers (or worse - future you) scratching their heads and cursing.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3358
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3366:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"this" should not be exposed from constructors'
+      Description: In single-threaded environments, the use of this in constructors is normal, and expected. But in multi-threaded environments, it could expose partially-constructed objects to other threads, and should be used with caution.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3366
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3376:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Attribute, EventArgs, and Exception type names should end with the type being extended
+      Description: 'Adherence to the standard naming conventions makes your code not only more readable, but more usable. For instance, class FirstAttribute : Attribute can be used simply with First, but you must use the full name for class AttributeOne : Attribute.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3376
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1710
+  S3397:
+    Metadata:
+      Category: Minor Bug
+      Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
+      Description: object.Equals() overrides can be optimized by checking first for reference equality between this and the parameter. This check can be implemented by calling object.ReferenceEquals() or base.Equals(), where base is object. However, using base.Equals() is a maintenance hazard because while it works if you extend Object directly, if you introduce a new base class that overrides Equals, it suddenly stops working.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3397
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3400:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Methods should not return constants
+      Description: There’s no point in forcing the overhead of a method call for a method that always returns the same constant value. Even worse, the fact that a method call must be made will likely mislead developers who call the method thinking that something more is done. Declare a constant instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3400
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3415:
+    Metadata:
+      Category: Major Code Smell
+      Title: Assertion arguments should be passed in the correct order
+      Description: The standard assertions library methods such as AreEqual and AreSame in MSTest and NUnit, or Equal and Same in XUnit, expect the first argument to be the expected value and the second argument to be the actual value. Swap them, and your test will still have the same outcome (succeed/fail when it should) but the error messages will be confusing.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3415
+      CustomTags:
+      - C#
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3427:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: 'Method overloads with default parameter values should not overlap '
+      Description: The rules for method resolution are complex and perhaps not properly understood by all coders. Having overloads with optional parameter values makes the matter even harder to understand.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3427
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3431:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"[ExpectedException]" should not be used'
+      Description: It should be clear to a casual reader what code a test is testing and what results are expected. Unfortunately, that’s not usually the case with the ExpectedException attribute since an exception could be thrown from almost any line in the method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3431
+      CustomTags:
+      - C#
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3433:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Test method signatures should be correct
+      Description: A method is detected as test method if marked with one of the following attributes [TestMethod] or [DataTestMethod] (for mstest), [Fact] or [Theory] (for xunit) or [Test], [TestCase], [TestCaseSource] or [Theory] (for nunit). However, whether or not they have a test attribute, non-public methods are not recognized as tests, and therefore not executed. Neither are async void methods, or methods with generics anywhere in their signatures.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3433
+      CustomTags:
+      - C#
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3440:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Variables should not be checked against the values they're about to be assigned
+      Description: There’s no point in checking a variable against the value you’re about to assign it. Save the cycles and lines of code, and simply perform the assignment.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3440
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3441:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Redundant property names should be omitted in anonymous classes
+      Description: When an anonymous type’s properties are copied from properties or variables with the same names, it yields cleaner code to omit the new type’s property name and the assignment operator.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3441
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3442:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"abstract" classes should not have "public" constructors'
+      Description: Since abstract classes can’t be instantiated, there’s no point in their having public or internal constructors. If there is basic initialization logic that should run when an extending class instance is created, you can by all means put it in a constructor, but make that constructor private, private protected or protected.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3442
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3443:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Type should not be examined on "System.Type" instances
+      Description: If you call GetType() on a Type variable, the return value will always be typeof(System.Type). So there’s no real point in making that call. The same applies to passing a type argument to IsInstanceOfType. In both cases the results are entirely predictable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3443
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3444:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Interfaces should not simply inherit from base interfaces with colliding members
+      Description: When an interface inherits from two interfaces that both define a member with the same name, trying to access that member through the derived interface will result in the compiler error CS0229 Ambiguity between 'IBase1.SomeProperty' and 'IBase2.SomeProperty'.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3444
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3445:
+    Metadata:
+      Category: Major Code Smell
+      Title: Exceptions should not be explicitly rethrown
+      Description: When rethrowing an exception, you should do it by simply calling throw; and not throw exc;, because the stack trace is reset with the second syntax, making debugging a lot harder.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3445
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3447:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"[Optional]" should not be used on "ref" or "out" parameters'
+      Description: The use of ref or out in combination with [Optional] is both confusing and contradictory. [Optional] indicates that the parameter doesn’t have to be provided, while out and ref mean that the parameter will be used to return data to the caller (ref additionally indicates that the parameter may also be used to pass data into the method).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3447
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3449:
+    Metadata:
+      Category: Critical Bug
+      Title: Right operands of shift operators should be integers
+      Description: Numbers can be shifted with the << and >> operators, but the right operand of the operation needs to be an int or a type that has an implicit conversion to int. However, with dynamic, the compiler’s type checking is turned off, so you can pass anything to a shift operator and have it compile. And if the argument can’t be converted to int at runtime, then a RuntimeBinderException will be raised.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3449
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3450:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+      Description: There is no point in providing a default value for a parameter if callers are required to provide a value for it anyway. Thus, [DefaultParameterValue] should always be used in conjunction with [Optional].
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3450
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3451:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
+      Description: The use of [DefaultValue] with [Optional] has no more effect than [Optional] alone. That’s because [DefaultValue] doesn’t actually do anything; it merely indicates the intent for the value. More than likely, [DefaultValue] was used in confusion instead of [DefaultParameterValue].
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3451
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3453:
+    Metadata:
+      Category: Major Bug
+      Title: Classes should not have only "private" constructors
+      Description: A class with only private constructors can’t be instantiated, thus, it seems to be pointless code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3453
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3456:
+    Metadata:
+      Category: Minor Bug
+      Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
+      Description: ToCharArray can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit ToCharArray calls should be omitted.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3456
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3457:
+    Metadata:
+      Category: Major Code Smell
+      Title: Composite format strings should be used correctly
+      Description: Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behaviors or runtime errors. This rule statically validates the good behavior of composite formats when calling the methods of String.Format, StringBuilder.AppendFormat, Console.Write, Console.WriteLine, TextWriter.Write, TextWriter.WriteLine, Debug.WriteLine(String, Object[]), Trace.TraceError(String, Object[]), Trace.TraceInformation(String, Object[]), Trace.TraceWarning(String, Object[]) and TraceSource.TraceInformation(String, Object[]).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3457
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3458:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Empty "case" clauses that fall through to the "default" should be omitted
+      Description: Empty case clauses that fall through to the default are useless. Whether or not such a case is present, the default clause will be invoked. Such cases simply clutter the code, and should be removed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3458
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3459:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Unassigned members should be removed
+      Description: Fields and auto-properties that are never assigned to hold the default values for their types. They are either pointless code or, more likely, mistakes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3459
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3464:
+    Metadata:
+      Category: Blocker Bug
+      Title: Type inheritance should not be recursive
+      Description: Recursion is acceptable in methods, where you can break out of it. But with class types, you end up with code that will compile but not run if you try to instantiate the class.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3464
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3466:
+    Metadata:
+      Category: Major Bug
+      Title: Optional parameters should be passed to "base" calls
+      Description: Generally, writing the least code that will readably do the job is a good thing, so omitting default parameter values seems to make sense. Unfortunately, when you omit them from the base call in an override, you’re not actually getting the job done thoroughly, because you’re ignoring the value the caller passed in. The result will likely not be what the caller expected.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3466
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3532:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Empty "default" clauses should be removed
+      Description: The default clause should take appropriate action. Having an empty default is a waste of keystrokes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3532
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3597:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"ServiceContract" and "OperationContract" attributes should be used together'
+      Description: The ServiceContract attribute specifies that a class or interface defines the communication contract of a Windows Communication Foundation (WCF) service. The service operations of this class or interface are defined by OperationContract attributes added to methods. It doesn’t make sense to define a contract without any service operations; thus, in a ServiceContract class or interface at least one method should be annotated with OperationContract. Similarly, WCF only serves OperationContract methods that are defined inside ServiceContract classes or interfaces; thus, this rule also checks that ServiceContract is added to the containing type of OperationContract methods.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3597
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3598:
+    Metadata:
+      Category: Major Bug
+      Title: One-way "OperationContract" methods should have "void" return type
+      Description: When declaring a Windows Communication Foundation (WCF) OperationContract method one-way, that service method won’t return any result, not even an underlying empty confirmation message. These are fire-and-forget methods that are useful in event-like communication. Specifying a return type therefore does not make sense.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3598
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3600:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"params" should not be introduced on overrides'
+      Description: Adding params to a method override has no effect. The compiler accepts it, but the callers won’t be able to benefit from the added modifier.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3600
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3603:
+    Metadata:
+      Category: Major Bug
+      Title: 'Methods with "Pure" attribute should return a value '
+      Description: Marking a method with the Pure attribute specifies that the method doesn’t make any visible changes; thus, the method should return a result, otherwise the call to the method should be equal to no-operation. So Pure on a void method is either a mistake, or the method doesn’t do any meaningful task.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3603
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3604:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Member initializer values should not be redundant
+      Description: Fields, properties and events can be initialized either inline or in the constructor. Initializing them inline and in the constructor at the same time is redundant; the inline initialization will be overridden.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3604
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3610:
+    Metadata:
+      Category: Major Bug
+      Title: Nullable type comparison should not be redundant
+      Description: Calling GetType() on a nullable object returns the underlying value type. Thus, comparing the returned Type object to typeof(Nullable<SomeType>) doesn’t make sense. The comparison either throws an exception or the result can be known at compile time.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3610
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3626:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Jump statements should not be redundant
+      Description: Jump statements, such as return, yield break, goto, and continue let you change the default flow of program execution, but jump statements that direct the control flow to the original direction are just a waste of keystrokes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3626
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3655:
+    Metadata:
+      Category: Major Bug
+      Title: Empty nullable value should not be accessed
+      Description: Nullable value types can hold either a value or null. The value held in the nullable type can be accessed with the Value property, but .Value throws an InvalidOperationException when the value is null. To avoid the exception, a nullable type should always be tested before .Value is accessed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3655
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3693:
+    Metadata:
+      Category: Blocker Bug
+      Title: Exception constructors should not throw exceptions
+      Description: It may be a good idea to raise an exception in a constructor if you're unable to fully flesh the object in question, but not in an exception constructor. If you do, you'll interfere with the exception that was originally being thrown. Further, it is highly unlikely that an exception raised in the creation of an exception will be properly handled in the calling code, and the unexpected, unhandled exception will lead to program termination.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3693
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3717:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Track use of "NotImplementedException"
+      Description: NotImplementedException is often used to mark methods which must be implemented for the overall functionality to be complete, but which the developer wants to implement later. That’s as opposed to the NotSupportedException which is thrown by methods which are required by base classes or interfaces, but which are not appropriate to the current class.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3717
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3776:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Cognitive Complexity of methods should not be too high
+      Description: Cognitive Complexity is a measure of how hard the control flow of a method is to understand. Methods with high Cognitive Complexity will be difficult to maintain.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3776
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: Code gets complicated
+  S3869:
+    Metadata:
+      Category: Blocker Bug
+      Title: '"SafeHandle.DangerousGetHandle" should not be called'
+      Description: Not surprisingly, the SafeHandle.DangerousGetHandle method is dangerous. That’s because it may not return a valid handle. Using it can lead to leaks and vulnerabilities. While it is possible to use the method successfully, it’s extremely difficult to do correctly, so the method should simply be avoided altogether.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3869
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3871:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Exception types should be "public"
+      Description: The point of having custom exception types is to convey more information than is available in standard types. But custom exception types must be public for that to work.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3871
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1064
+  S3872:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Parameter names should not duplicate the names of their methods
+      Description: The name of a method should communicate what it does, and the names of its parameters should indicate how they’re used. If a method and its parameter have the same name it is an indication that one of these rules of thumb has been broken, if not both. Even if by some trick of language that’s not the case, it is still likely to confuse callers and maintainers.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3872
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3874:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"out" and "ref" parameters should not be used'
+      Description: Passing a parameter by reference, which is what happens when you use the out or ref parameter modifiers, means that the method will receive a pointer to the argument, rather than the argument itself. If the argument was a value type, the method will be able to change the argument’s values. If it was a reference type, then the method receives a pointer to a pointer, which is usually not what was intended. Even when it is what was intended, this is the sort of thing that’s difficult to get right, and should be used with caution.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3874
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1021
+  S3875:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: '"operator==" should not be overloaded on reference types'
+      Description: The use of == to compare two objects is expected to do a reference comparison. That is, it is expected to return true if and only if they are the same object instance. Overloading the operator to do anything else will inevitably lead to the introduction of bugs by callers. On the other hand, overloading it to do exactly that is pointless; that’s what == does by default.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3875
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3876:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Strings or integral types should be used for indexers
+      Description: Strings and integral types are typically used as indexers. When some other type is required, it typically indicates design problems, and potentially a situation where a method should be used instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3876
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3877:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Exceptions should not be thrown from unexpected methods
+      Description: It is expected that some methods should be called with caution, but others, such as ToString, are expected to "just work". Throwing an exception from such a method is likely to break callers' code unexpectedly.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3877
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  S3880:
+    Metadata:
+      Category: Major Code Smell
+      Title: Finalizers should not be empty
+      Description: Finalizers come with a performance cost due to the overhead of tracking the life cycle of objects. An empty one is consequently costly with no benefit or justification.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3880
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3881:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"IDisposable" should be implemented correctly'
+      Description: The IDisposable interface is a mechanism to release unmanaged resources, if not implemented correctly this could result in resource leaks or more severe bugs.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3881
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S3884:
+    Metadata:
+      Category: Blocker Vulnerability
+      Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
+      Description: CoSetProxyBlanket and CoInitializeSecurity both work to set the permissions context in which the process invoked immediately after is executed. Calling them from within that process is useless because it’s too late at that point; the permissions context has already been set.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3884
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3885:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"Assembly.Load" should be used'
+      Description: The parameter to Assembly.Load includes the full specification of the dll to be loaded. Use another method, and you might end up with a dll other than the one you expected.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3885
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3887:
+    Metadata:
+      Category: Minor Bug
+      Title: Mutable, non-private fields should not be "readonly"
+      Description: Using the readonly keyword on a field means that it can’t be changed after initialization. However, when applied to collections or arrays, that’s only partly true. readonly enforces that another instance can’t be assigned to the field, but it cannot keep the contents from being updated. That means that in practice, the field value really can be changed, and the use of readonly on such a field is misleading, and you’re likely to not be getting the behavior you expect.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3887
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3889:
+    Metadata:
+      Category: Blocker Bug
+      Title: Neither "Thread.Resume" nor "Thread.Suspend" should be used
+      Description: Thread.Suspend and Thread.Resume can give unpredictable results, and both methods have been deprecated. Indeed, if Thread.Suspend is not used very carefully, a thread can be suspended while holding a lock, thus leading to a deadlock. Other safer synchronization mechanisms should be used, such as Monitor, Mutex, and Semaphore.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3889
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3897:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+      Description: 'The IEquatable<T> interface has only one method in it: Equals(<T>). If you’ve already written Equals(T), there’s no reason not to explicitly implement IEquatable<T>. Doing so expands the utility of your class by allowing it to be used where an IEquatable is called for.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3897
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3898:
+    Metadata:
+      Category: Major Code Smell
+      Title: Value types should implement "IEquatable<T>"
+      Description: If you’re using a struct, it is likely because you’re interested in performance. But by failing to implement IEquatable<T> you’re loosing performance when comparisons are made because without IEquatable<T>, boxing and reflection are used to make comparisons.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3898
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S3900:
+    Metadata:
+      Category: Major Code Smell
+      Title: Arguments of public methods should be validated against null
+      Description: A publicly accessible method can be called from anywhere, which means you should validate parameters to be within the expected constraints. In general, checking against null is recommended defensive programming.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3900
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1062
+  S3902:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"Assembly.GetExecutingAssembly" should not be called'
+      Description: Using Type.Assembly to get the current assembly is nearly free in terms of performance; it’s a simple property access. On the other hand, Assembly.GetExecutingAssembly() can take up to 30 times as long because it walks up the call stack to find the assembly.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3902
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3903:
+    Metadata:
+      Category: Major Bug
+      Title: Types should be defined in named namespaces
+      Description: Types are declared in namespaces in order to prevent name collisions and as a way to organize them into the object hierarchy. Types that are defined outside any named namespace are in a global namespace that cannot be referenced in code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3903
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Doesn't work with file-scoped namespaces, so disabling for now.
+  S3904:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Assemblies should have version information
+      Description: If no AssemblyVersionAttribute is provided, the same default version will be used for every build. Since the version number is used by The .NET Framework to uniquely identify an assembly this can lead to broken dependencies.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3904
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3906:
+    Metadata:
+      Category: Major Code Smell
+      Title: Event Handlers should have the correct signature
+      Description: 'Delegate event handlers (i.e. delegates used as type of an event) should have a very specific signature:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3906
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3908:
+    Metadata:
+      Category: Major Code Smell
+      Title: Generic event handlers should be used
+      Description: Since .Net Framework version 2.0 it is not necessary to declare a delegate that specifies a class derived from System.EventArgs. The System.EventHandler<TEventArgs> delegate mechanism should be used instead as it allows any class derived from EventArgs to be used with that handler.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3908
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3909:
+    Metadata:
+      Category: Major Code Smell
+      Title: Collections should implement the generic interface
+      Description: The NET Framework 2.0 introduced the generic interface System.Collections.Generic.IEnumerable<T> and it should be preferred over the older, non generic, interfaces.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3909
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1010
+  S3923:
+    Metadata:
+      Category: Major Bug
+      Title: All branches in a conditional structure should not have exactly the same implementation
+      Description: Having all branches in a switch or if chain with the same implementation is an error. Either a copy-paste error was made and something different should be executed, or there shouldn’t be a switch/if chain at all.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3923
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3925:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"ISerializable" should be implemented correctly'
+      Description: The ISerializable interface is the mechanism to control the type serialization process. If not implemented correctly this could result in an invalid serialization and hard to detect bugs.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3925
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: TODO - is ISerializable still relevant?
+  S3926:
+    Metadata:
+      Category: Major Bug
+      Title: Deserialization methods should be provided for "OptionalField" members
+      Description: Fields marked with System.Runtime.Serialization.OptionalFieldAttribute are serialized just like any other field. But such fields are ignored on deserialization, and retain the default values associated with their types. Therefore, deserialization event handlers should be declared to set such fields during the deserialization process.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3926
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3927:
+    Metadata:
+      Category: Major Bug
+      Title: Serialization event handlers should be implemented correctly
+      Description: Serialization event handlers that don’t have the correct signature will simply not be called, thus bypassing any attempts to augment the automated de/serialization.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3927
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3928:
+    Metadata:
+      Category: Major Code Smell
+      Title: 'Parameter names used into ArgumentException constructors should match an existing one '
+      Description: 'Some constructors of the ArgumentException, ArgumentNullException, ArgumentOutOfRangeException and DuplicateWaitObjectException classes must be fed with a valid parameter name. This rule raises an issue in two cases:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3928
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  S3937:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Number patterns should be regular
+      Description: The use of punctuation characters to separate subgroups in a number can make the number more readable. For instance consider 1,000,000,000 versus 1000000000. But when the grouping is irregular, such as 1,000,00,000; it indicates an error.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3937
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3949:
+    Metadata:
+      Category: Major Bug
+      Title: Calculations should not overflow
+      Description: Numbers are infinite, but the types that hold them are not. Each numeric type has hard upper and lower bounds. Try to calculate or assign numbers beyond those bounds, and the result will be a value that has silently wrapped around from the expected positive value to a negative one, or vice versa.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3949
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  S3956:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"Generic.List" instances should not be part of public APIs'
+      Description: 'System.Collections.Generic.List<T> is a generic collection that is designed for performance and not inheritance. For example, it does not contain virtual members that make it easier to change the behavior of an inherited class. That means that future attempts to expand the behavior will be spoiled because the extension points simply aren’t there. Instead, one of the following generic collections should be used:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3956
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1002
+  S3962:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"static readonly" constants should be "const" instead'
+      Description: The value of a static readonly field is computed at runtime while the value of a const field is calculated at compile time, which improves performance.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3962
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1802
+  S3963:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"static" fields should be initialized inline'
+      Description: When a static constructor serves no other purpose that initializing static fields, it comes with an unnecessary performance cost because the compiler generates a check before each static method or instance constructor invocation.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3963
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1810 and CA2207
+  S3966:
+    Metadata:
+      Category: Major Code Smell
+      Title: Objects should not be disposed more than once
+      Description: Disposing an object twice, either with the using keyword or by calling Dispose directly, in the same method is at best confusing and at worst error-prone. The next developer might see only one of the Dispose/using and try to use an already-disposed object.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3966
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3967:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Multidimensional arrays should not be used
+      Description: A jagged array is an array whose elements are arrays. It is recommended over a multidimensional array because the arrays that make up the elements can be of different sizes, which avoids wasting memory space.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3967
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3971:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"GC.SuppressFinalize" should not be called'
+      Description: GC.SuppressFinalize requests that the system not call the finalizer for the specified object. This should only be done when implementing Dispose as part of the Dispose Pattern.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3971
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3972:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Conditionals should start on new lines
+      Description: Code is clearest when each statement has its own line. Nonetheless, it is a common pattern to combine on the same line an if and its resulting then statement. However, when an if is placed on the same line as the closing } from a preceding then, else or else if part, it is either an error - else is missing - or the invitation to a future error as maintainers fail to understand that the two statements are unconnected.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3972
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3973:
+    Metadata:
+      Category: Critical Code Smell
+      Title: A conditionally executed single line should be denoted by indentation
+      Description: In the absence of enclosing curly braces, the line immediately after a conditional is the one that is conditionally executed. By both convention and good practice, such lines are indented. In the absence of both curly braces and indentation the intent of the original programmer is entirely unclear and perhaps not actually what is executed. Additionally, such code is highly likely to be confusing to maintainers.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3973
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3981:
+    Metadata:
+      Category: Major Bug
+      Title: Collection sizes and array length comparisons should make sense
+      Description: The size of a collection and the length of an array are always greater than or equal to zero. So testing that a size or length is greater than or equal to zero doesn’t make sense, since the result is always true. Similarly testing that it is less than zero will always return false. Perhaps the intent was to check the non-emptiness of the collection or array instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3981
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S3984:
+    Metadata:
+      Category: Major Bug
+      Title: Exceptions should not be created without being thrown
+      Description: Creating a new Exception without actually throwing it is useless and is probably due to a mistake.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3984
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3990:
+    Metadata:
+      Category: Major Code Smell
+      Title: Assemblies should be marked as CLS compliant
+      Description: Assemblies should conform with the Common Language Specification (CLS) in order to be usable across programming languages. To be compliant an assembly has to indicate it with System.CLSCompliantAttribute.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3990
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1014
+  S3992:
+    Metadata:
+      Category: Major Code Smell
+      Title: Assemblies should explicitly specify COM visibility
+      Description: Assemblies should explicitly indicate whether they are meant to be COM visible or not. If the ComVisibleAttribute is not present, the default is to make the content of the assembly visible to COM clients.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3992
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1017
+  S3993:
+    Metadata:
+      Category: Major Code Smell
+      Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
+      Description: When defining custom attributes, System.AttributeUsageAttribute must be used to indicate where the attribute can be applied. This will determine its valid locations in the code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3993
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1018
+  S3994:
+    Metadata:
+      Category: Major Code Smell
+      Title: URI Parameters should not be strings
+      Description: String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred. At minimum, an overload of the method taking a System.Uri as a parameter should be provided in each class that contains a method with an apparent Uri passed as a string.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3994
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S3995:
+    Metadata:
+      Category: Major Code Smell
+      Title: URI return values should not be strings
+      Description: String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3995
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3996:
+    Metadata:
+      Category: Major Code Smell
+      Title: URI properties should not be strings
+      Description: String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3996
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S3997:
+    Metadata:
+      Category: Major Code Smell
+      Title: String URI overloads should call "System.Uri" overloads
+      Description: String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3997
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S3998:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Threads should not lock on objects with weak identity
+      Description: 'A thread acquiring a lock on an object that can be accessed across application domain boundaries runs the risk of being blocked by another thread in a different application domain. Objects that can be accessed across application domain boundaries are said to have weak identity. Types with weak identity are:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3998
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4000:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Pointers to unmanaged memory should not be visible
+      Description: Pointer and unmanaged function pointer types such as IntPtr, UIntPtr, int* etc. are used to access unmanaged memory, usually in order to use C or C++ libraries. If such a pointer is not secured by making it private, internal or readonly, it can lead to a vulnerability allowing access to arbitrary locations.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4000
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4002:
+    Metadata:
+      Category: Major Code Smell
+      Title: Disposable types should declare finalizers
+      Description: 'This rule raises an issue when a disposable type contains fields of the following types and does not implement a finalizer:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4002
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4004:
+    Metadata:
+      Category: Major Code Smell
+      Title: Collection properties should be readonly
+      Description: A writable collection property can be replaced by a completely different collection. Making it readonly prevents that while still allowing individual members to be set. If you want to allow the replacement of the whole collection the recommended pattern is to implement a method to remove all the elements (e.g. System.Collections.List<T>.Clear) and a method to populate the collection (e.g. System.Collections.List<T>.AddRange).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4004
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2227
+  S4005:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"System.Uri" arguments should be used instead of strings'
+      Description: String representations of URIs or URLs are prone to parsing and encoding errors which can lead to vulnerabilities. The System.Uri class is a safe alternative and should be preferred.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4005
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2234
+  S4015:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Inherited member visibility should not be decreased
+      Description: Changing an inherited member to private will not prevent access to the base class implementation.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4015
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4016:
+    Metadata:
+      Category: Major Code Smell
+      Title: Enumeration members should not be named "Reserved"
+      Description: If an enum member’s name contains the word "reserved" it implies it is not currently used and will be change in the future. However changing an enum member is a breaking change and can create significant problems. There is no need to reserve an enum member since a new member can be added in the future, and such an addition will usually not be a breaking change.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4016
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4017:
+    Metadata:
+      Category: Major Code Smell
+      Title: Method signatures should not contain nested generic types
+      Description: A nested type is a type argument that is also a generic type. Calling a method with such a nested type argument requires complicated and confusing code. It should be avoided as much as possible.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4017
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S4018:
+    Metadata:
+      Category: Minor Code Smell
+      Title: All type parameters should be used in the parameter list to enable type inference
+      Description: Type inference enables the call of a generic method without explicitly specifying its type arguments. This is not possible when a parameter type is missing from the argument list.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4018
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S4019:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Base class methods should not be hidden
+      Description: When a method in a derived class has the same name as a method in the base class but with a signature that only differs by types that are weakly derived (e.g. object vs string), the result is that the base method becomes hidden.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4019
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4022:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Enumerations should have "Int32" storage
+      Description: By default the storage type of an enum is Int32. In most cases it is not necessary to change this. In particular you will not achieve any performance gain by using a smaller data type (e.g. Byte) and may limit future uses.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4022
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4023:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Interfaces should not be empty
+      Description: Empty interfaces are usually used as a marker or a way to identify groups of types. The preferred way to achieve this is to use custom attributes.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4023
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S4025:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Child class fields should not differ from parent class fields only by capitalization
+      Description: Having a field in a child class with a name that differs from a parent class' field only by capitalization is sure to cause confusion. Such child class fields should be renamed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4025
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4026:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+      Description: It is important to inform the ResourceManager of the language used to display the resources of the neutral culture for an assembly. This improves lookup performance for the first resource loaded.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4026
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S4027:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Exceptions should provide standard constructors
+      Description: 'Exceptions types should provide the following constructors:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4027
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1032
+  S4035:
+    Metadata:
+      Category: Major Code Smell
+      Title: Classes implementing "IEquatable<T>" should be sealed
+      Description: When a class implements the IEquatable<T> interface, it enters a contract that, in effect, states "I know how to compare two instances of type T or any type derived from T for equality.". However if that class is derived, it is very unlikely that the base class will know how to make a meaningful comparison. Therefore that implicit contract is now broken.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4035
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4036:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Searching OS commands in PATH is security-sensitive
+      Description: When executing an OS command and unless you specify the full path to the executable, then the locations in your application’s PATH environment variable will be searched for the executable. That search could leave an opening for an attacker if one of the elements in PATH is a directory under his control.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4036
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4039:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Interface methods should be callable by derived types
+      Description: When a base type explicitly implements a public interface method, that method is only accessible in derived types through a reference to the current instance (namely this). If the derived type explicitly overrides that interface method, the base implementation becomes inaccessible.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4039
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4040:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Strings should be normalized to uppercase
+      Description: Certain characters, once normalized to lowercase, cannot make a round trip. That is, they can not be converted from one locale to another and then accurately restored to their original characters.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4040
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1308
+  S4041:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Type names should not match namespaces
+      Description: When a type name matches the name of a publicly defined namespace, for instance one in the .NET framework class library, it leads to confusion and makes the library that much harder to use.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4041
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4047:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Generics should be used when appropriate
+      Description: When a reference parameter (keyword ref) is used, the passed argument type must exactly match the reference parameter type. This means that to be able to pass a derived type, it must be cast and assigned to a variable of the proper type. Use of generic methods eliminates that cumbersome down casting and should therefore be preferred.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4047
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4049:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Properties should be preferred
+      Description: Properties are accessed like fields which makes them easier to use.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4049
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1024
+  S4050:
+    Metadata:
+      Category: Major Code Smell
+      Title: Operators should be overloaded consistently
+      Description: When implementing operator overloads, it is very important to make sure that all related operators and methods are consistent in their implementation.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4050
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4052:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Types should not extend outdated base types
+      Description: With the advent of .NET framework version 2, certain practices have become obsolete.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4052
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S4055:
+    Metadata:
+      Category: Major Code Smell
+      Title: Literals should not be passed as localized parameters
+      Description: String literals embedded in the source code will not be localized properly.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4055
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S4056:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+      Description: When a System.Globalization.CultureInfo or IFormatProvider object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4056
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1305
+  S4057:
+    Metadata:
+      Category: Major Code Smell
+      Title: Locales should be set for data types
+      Description: When you create a DataTable or DataSet, you should set the locale explicitly. By default, the locale for these types is the current culture. For data that is stored in a database or file and is shared globally, the locale should ordinarily be set to the invariant culture (CultureInfo.InvariantCulture).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4057
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4058:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Overloads with a "StringComparison" parameter should be used
+      Description: Many string operations, the Compare and Equals methods in particular, provide an overload that accepts a StringComparison enumeration value as a parameter. Calling these overloads and explicitly providing this parameter makes your code clearer and easier to maintain.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4058
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1310
+  S4059:
+    Metadata:
+      Category: Major Code Smell
+      Title: Property names should not match get methods
+      Description: Properties and Get method should have names that makes them clearly distinguishable.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4059
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4060:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Non-abstract attributes should be sealed
+      Description: The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the inheritance hierarchy, and can improve performance.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4060
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1813
+  S4061:
+    Metadata:
+      Category: Minor Code Smell
+      Title: '"params" should be used instead of "varargs"'
+      Description: A method using the VarArgs calling convention is not Common Language Specification (CLS) compliant and might not be accessible across programming languages, while the params keyword works the same way and is CLS compliant.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4061
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4069:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Operator overloads should have named alternatives
+      Description: 'Operator overloading is convenient but unfortunately not portable across languages. To be able to access the same functionality from another language you need to provide an alternate named method following the convention:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4069
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2225
+  S4070:
+    Metadata:
+      Category: Major Code Smell
+      Title: Non-flags enums should not be marked with "FlagsAttribute"
+      Description: This rule raises an issue when an externally visible enumeration is marked with FlagsAttribute and one, or more, of its values is not a power of 2 or a combination of the other defined values.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4070
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA2217
+  S4136:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Method overloads should be grouped together
+      Description: For clarity, all overloads of the same method should be grouped together. That lets both users and maintainers quickly understand all the current available options.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4136
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  S4142:
+    Metadata:
+      Category: Major Code Smell
+      Title: Duplicate values should not be passed as arguments
+      Description: There are valid cases for passing a variable multiple times into the same method call, but usually doing so is a mistake, and something else was intended for one of the arguments.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4142
+      CustomTags:
+      - C#
+      - MainSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4143:
+    Metadata:
+      Category: Major Bug
+      Title: Collection elements should not be replaced unconditionally
+      Description: It is highly suspicious when a value is saved for a key or index and then unconditionally overwritten. Such replacements are likely errors.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4143
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4144:
+    Metadata:
+      Category: Major Code Smell
+      Title: Methods should not have identical implementations
+      Description: When two methods have the same implementation, either it was a mistake - something else was intended - or the duplication was intentional, but may be confusing to maintainers. In the latter case, one implementation should invoke the other.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4144
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4158:
+    Metadata:
+      Category: Minor Bug
+      Title: Empty collections should not be accessed or iterated
+      Description: When a collection is empty it makes no sense to access or iterate it. Doing so anyway is surely an error; either population was accidentally omitted or the developer doesn’t understand the situation.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4158
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4159:
+    Metadata:
+      Category: Blocker Bug
+      Title: Classes should implement their "ExportAttribute" interfaces
+      Description: In the Attributed Programming Model, the ExportAttribute declares that a part "exports", or provides to the composition container, an object that fulfills a particular contract. During composition, parts with imports that have matching contracts will have those dependencies filled by the exported object.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4159
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4200:
+    Metadata:
+      Category: Major Code Smell
+      Title: Native methods should be wrapped
+      Description: Native methods are functions that reside in libraries outside the .NET runtime. Calling them is helpful for interoperability with applications and libraries written in other programming languages, mainly when performing platform-specific operations. However, doing so comes with additional risks since it means stepping out of the memory-safety model of the runtime. It is therefore highly recommended to take extra steps, like input validation, when invoking native methods. Making the native method private and providing a wrapper that performs these additional steps is the best way to do so.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4200
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4201:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Null checks should not be used with "is"
+      Description: There’s no need to null test in conjunction with an is test. null is not an instance of anything, so a null check is redundant.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4201
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4210:
+    Metadata:
+      Category: Major Bug
+      Title: Windows Forms entry points should be marked with STAThread
+      Description: When an assembly uses Windows Forms (classes and interfaces from the System.Windows.Forms namespace) its entry point should be marked with the STAThreadAttribute to indicate that the threading model should be "Single-Threaded Apartment" (STA) which is the only one supported by Windows Forms.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4210
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4211:
+    Metadata:
+      Category: Major Vulnerability
+      Title: Members should not have conflicting transparency annotations
+      Description: Transparency attributes, SecurityCriticalAttribute and SecuritySafeCriticalAttribute are used to identify code that performs security-critical operations. The second one indicates that it is safe to call this code from transparent, while the first one does not. Since the transparency attributes of code elements with larger scope take precedence over transparency attributes of code elements that are contained in the first element a class, for instance, with a SecurityCriticalAttribute can not contain a method with a SecuritySafeCriticalAttribute.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4211
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4212:
+    Metadata:
+      Category: Major Vulnerability
+      Title: Serialization constructors should be secured
+      Description: Because serialization constructors allocate and initialize objects, security checks that are present on regular constructors must also be present on a serialization constructor. Failure to do so would allow callers that could not otherwise create an instance to use the serialization constructor to do this.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4212
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4214:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"P/Invoke" methods should not be visible'
+      Description: Methods marked with the System.Runtime.InteropServices.DllImportAttribute attribute use Platform Invocation Services to access unmanaged code and should not be exposed. Keeping them private or internal makes sure that their access is controlled and properly managed.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4214
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4220:
+    Metadata:
+      Category: Major Code Smell
+      Title: Events should have proper arguments
+      Description: 'When raising an event, two arguments are expected by the EventHandler delegate: Sender and event-data. There are three guidelines regarding these parameters:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4220
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4225:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Extension methods should not extend "object"
+      Description: Creating an extension method that extends object is not recommended because it makes the method available on every type. Extensions should be applied at the most specialized level possible, and that is very unlikely to be object.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4225
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4226:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Extensions should be in separate namespaces
+      Description: It makes little sense to create an extension method when it is possible to just add that method to the class itself.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4226
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  S4260:
+    Metadata:
+      Category: Major Bug
+      Title: '"ConstructorArgument" parameters should exist in constructors'
+      Description: When creating a custom Markup Extension that accepts parameters in WPF, the ConstructorArgument markup must be used to identify the discrete properties that match these parameters. However since this is done via a string, the compiler will not notice if there are typos.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4260
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4261:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Methods should be named according to their synchronicities
+      Description: According to the Task-based Asynchronous Pattern (TAP), methods returning either a System.Threading.Tasks.Task or a System.Threading.Tasks.Task<TResult> are considered "asynchronous". Such methods should use the Async suffix. Conversely methods which do not return such Tasks should not have an "Async" suffix in their names.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4261
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S4275:
+    Metadata:
+      Category: Critical Bug
+      Title: Getters and setters should access the expected fields
+      Description: Properties provide a way to enforce encapsulation by providing public, protected or internal methods that give controlled access to private fields. However in classes with multiple fields it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a getter or setter.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4275
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4277:
+    Metadata:
+      Category: Critical Bug
+      Title: '"Shared" parts should not be created with "new"'
+      Description: Marking a class with PartCreationPolicy(CreationPolicy.Shared), which is part of Managed Extensibility Framework (MEF), means that a single, shared instance of the exported object will be created. Therefore it doesn’t make sense to create new instances using the constructor and it will most likely result in unexpected behaviours.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4277
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4423:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Weak SSL/TLS protocols should not be used
+      Description: Older versions of SSL/TLS protocol like "SSLv3" have been proven to be insecure.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4423
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4426:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Cryptographic keys should be robust
+      Description: Most of cryptographic systems require a sufficient key size to be robust against brute-force attacks.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4426
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4428:
+    Metadata:
+      Category: Major Bug
+      Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
+      Description: The PartCreationPolicyAttribute attribute, which is part of the Managed Extensibility Framework (MEF), is used to specify how the exported object will be created. Therefore it doesn’t make sense not to export this a class with this attribute using the ExportAttribute attribute.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4428
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4432:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: AES encryption algorithm should be used with secured mode
+      Description: 'Encryption algorithms can be used with various modes. Some combinations are not secured:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4432
+      CustomTags:
+      - C#
+      - MainSourceScope
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4433:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: LDAP connections should be authenticated
+      Description: An LDAP client authenticates to an LDAP server with a "bind request" which provides, among other, a simple authentication method.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4433
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4456:
+    Metadata:
+      Category: Major Code Smell
+      Title: Parameter validation in yielding methods should be wrapped
+      Description: Because of the way yield methods are rewritten by the compiler (they become lazily evaluated state machines) any exceptions thrown during the parameters check will happen only when the collection is iterated over. That could happen far away from the source of the buggy code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4456
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4457:
+    Metadata:
+      Category: Major Code Smell
+      Title: Parameter validation in "async"/"await" methods should be wrapped
+      Description: Because of the way async/await methods are rewritten by the compiler, any exceptions thrown during the parameters check will happen only when the task is observed. That could happen far away from the source of the buggy code or never happen for fire-and-forget tasks.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4457
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4462:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Calls to "async" methods should not be blocking
+      Description: Making blocking calls to async methods transforms code that was intended to be asynchronous into a blocking operation. Doing so can cause deadlocks and unexpected blocking of context threads.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4462
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: VSTHRD002
+  S4487:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Unread "private" fields should be removed
+      Description: Private fields only used to store values without reading them later is a case of dead store. So changing the value of such field is useless and most probably indicates a serious error in the code.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4487
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      - Unnecessary
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0052
+  S4507:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Delivering code in production with debug features activated is security-sensitive
+      Description: 'Delivering code in production with debug features activated is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4507
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4524:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"default" clauses should be first or last'
+      Description: 'switch can contain a default clause for various reasons: to handle unexpected values, to show that all the cases were properly considered.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4524
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4564:
+    Metadata:
+      Category: Major Vulnerability
+      Title: ASP.NET HTTP request validation feature should not be disabled
+      Description: ASP.Net has a feature to validate HTTP requests to prevent potentially dangerous content to perform a cross-site scripting (XSS) attack. There is no reason to disable this mechanism even if other checks to prevent XXS attacks are in place.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4564
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4581:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"new Guid()" should not be used'
+      Description: 'When the syntax new Guid() (i.e. parameterless instantiation) is used, it must be that one of three things is wanted:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4581
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4583:
+    Metadata:
+      Category: Critical Bug
+      Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+      Description: Calling the BeginInvoke method of a delegate will allocate some resources that are only freed-up when EndInvoke is called. This is why you should always pair BeginInvoke with an EndInvoke to complete your asynchronous call.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4583
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4586:
+    Metadata:
+      Category: Critical Bug
+      Title: Non-async "Task/Task<T>" methods should not return null
+      Description: Returning null from a non-async Task/Task<T> method will cause a NullReferenceException at runtime. This problem can be avoided by returning Task.FromResult<T>(null) instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4586
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4635:
+    Metadata:
+      Category: Critical Code Smell
+      Title: String offset-based methods should be preferred for finding substrings from offsets
+      Description: 'Looking for a given substring starting from a specified offset can be achieved by such code: str.Substring(startIndex).IndexOf(char1). This works well, but it creates a new string for each call to the Substring method. When this is done in a loop, a lot of strings are created for nothing, which can lead to performance problems if str is large.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4635
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4784:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using regular expressions is security-sensitive
+      Description: 'Using regular expressions is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4784
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4787:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Encrypting data is security-sensitive
+      Description: 'Encrypting data is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4787
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4790:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using weak hashing algorithms is security-sensitive
+      Description: Cryptographic hash algorithms such as MD2, MD4, MD5, MD6, HAVAL-128, HMAC-MD5, DSA (which uses SHA-1), RIPEMD, RIPEMD-128, RIPEMD-160, HMACRIPEMD160 and SHA-1 are no longer considered secure, because it is possible to have collisions (little computational effort is enough to find two or more different inputs that produce the same hash).
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4790
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4792:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Configuring loggers is security-sensitive
+      Description: 'Configuring loggers is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4792
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4818:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using Sockets is security-sensitive
+      Description: 'Using sockets is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4818
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4823:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using command line arguments is security-sensitive
+      Description: 'Using command line arguments is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4823
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4829:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Reading the Standard Input is security-sensitive
+      Description: 'Reading Standard Input is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4829
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S4830:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Server certificates should be verified during SSL/TLS connections
+      Description: Validation of X.509 certificates is essential to create secure SSL/TLS sessions not vulnerable to man-in-the-middle attacks.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4830
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA5359
+  S4834:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Controlling permissions is security-sensitive
+      Description: 'The access control of an application must be properly implemented in order to restrict access to resources to authorized entities otherwise this could lead to vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4834
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S5034:
+    Metadata:
+      Category: Critical Code Smell
+      Title: '"ValueTask" should be consumed correctly'
+      Description: ValueTask<TResult> was introduced in .NET Core 2.0 to optimize memory allocation when functions return their results synchronously.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5034
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5042:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Expanding archive files without controlling resource consumption is security-sensitive
+      Description: 'Successful Zip Bomb attacks occur when an application expands untrusted archive files without controlling the size of the expanded data, which can lead to denial of service. A Zip bomb is usually a malicious archive file of a few kilobytes of compressed data but turned into gigabytes of uncompressed data. To achieve this extreme compression ratio, attackers will compress irrelevant data (eg: a long string of repeated bytes).'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5042
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5332:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using clear-text protocols is security-sensitive
+      Description: 'Clear-text protocols such as ftp, telnet, or http lack encryption of transported data, as well as the capability to build an authenticated connection. It means that an attacker able to sniff traffic from the network can read, modify, or corrupt the transported content. These protocols are not secure as they expose applications to an extensive range of risks:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5332
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5542:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Encryption algorithms should be used with secure mode and padding scheme
+      Description: Encryption algorithms should use secure modes and padding schemes where appropriate to guarantee data confidentiality and integrity.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5542
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5547:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Cipher algorithms should be robust
+      Description: Strong cipher algorithms are cryptographic systems resistant to cryptanalysis, they are not vulnerable to well-known attacks like brute force attacks for example.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5547
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5659:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: JWT should be signed and verified with strong cipher algorithms
+      Description: If a JSON Web Token (JWT) is not signed with a strong cipher algorithm (or not signed at all) an attacker can forge it and impersonate user identities.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5659
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5753:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
+      Description: ASP.NET 1.1+ comes with a feature called Request Validation, preventing the server to accept content containing un-encoded HTML. This feature comes as a first protection layer against Cross-Site Scripting (XSS) attacks and act as a simple Web Application Firewall (WAF) rejecting requests potentially containing malicious content.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5753
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5766:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Deserializing objects without performing data validation is security-sensitive
+      Description: Deserialization process extracts data from the serialized representation of an object and reconstruct it directly, without calling constructors. Thus, data validation implemented in constructors can be bypassed if serialized objects are controlled by an attacker.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5766
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5773:
+    Metadata:
+      Category: Major Vulnerability
+      Title: Types allowed to be deserialized should be restricted
+      Description: During the deserialization process, the state of an object will be reconstructed from the serialized data stream which can contain dangerous operations.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5773
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S818:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Literal suffixes should be upper case
+      Description: Using upper case literal suffixes removes the potential ambiguity between "1" (digit 1) and "l" (letter el) for declaring literals.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-818
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S881:
+    Metadata:
+      Category: Major Code Smell
+      Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+      Description: 'The use of increment and decrement operators in method calls or in combination with other arithmetic operators is not recommended, because:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-881
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Suggestion
+  S907:
+    Metadata:
+      Category: Major Code Smell
+      Title: '"goto" statement should not be used'
+      Description: goto is an unstructured control flow statement. It makes code less readable and maintainable. Structured control flow statements such as if, for, while, continue or break should be used instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-907
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S927:
+    Metadata:
+      Category: Critical Code Smell
+      Title: Parameter names should match base declaration and other partial definitions
+      Description: The name of a parameter in an externally visible. This rule raises an issue when method override does not match the name of the parameter in the base declaration of the method, or the name of the parameter in the interface declaration of the method or the name of any other partial definition.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-927
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1725
+  S9999-cpd:
+    Metadata:
+      Category: ''
+      Title: Copy-paste token calculator
+      Description: ''
+      CustomTags:
+      - MainSourceScope
+      - TestSourceScope
+      - Utility
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S9999-metadata:
+    Metadata:
+      Category: ''
+      Title: File metadata generator
+      Description: ''
+      CustomTags:
+      - MainSourceScope
+      - TestSourceScope
+      - Utility
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S9999-metrics:
+    Metadata:
+      Category: ''
+      Title: Metrics calculator
+      Description: ''
+      CustomTags:
+      - MainSourceScope
+      - TestSourceScope
+      - Utility
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S9999-symbolRef:
+    Metadata:
+      Category: ''
+      Title: Symbol reference calculator
+      Description: ''
+      CustomTags:
+      - MainSourceScope
+      - TestSourceScope
+      - Utility
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S9999-token-type:
+    Metadata:
+      Category: ''
+      Title: Token type calculator
+      Description: ''
+      CustomTags:
+      - MainSourceScope
+      - TestSourceScope
+      - Utility
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S2612:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Setting loose file permissions is security-sensitive
+      Description: In Unix, "others" class refers to all users except the owner of the file and the members of the group assigned to this file.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2612
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5443:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Using publicly writable directories is security-sensitive
+      Description: 'Operating systems have global directories where any user has write access. Those folders are mostly used as temporary storage areas like /tmp in Linux based systems. An application manipulating files from these folders is exposed to race conditions on filenames: a malicious user can try to create a file with a predictable name before the application does. A successful attack can result in other files being accessed, modified, corrupted or deleted. This risk is even higher if the application runs with elevated permissions.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5443
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S5693:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Allowing requests with excessive content length is security-sensitive
+      Description: Rejecting requests with significant content length is a good practice to control the network traffic intensity and thus resource consumption in order to prevents DoS attacks.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5693
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - TestSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5445:
+    Metadata:
+      Category: Critical Vulnerability
+      Title: Insecure temporary file creation methods should not be used
+      Description: 'Creating temporary files using insecure methods exposes the application to race conditions on filenames: a malicious user can try to create a file with a predictable name before the application does. A successful attack can result in other files being accessed, modified, corrupted or deleted. This risk is even higher if the application run with elevated permissions.'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5445
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S2115:
+    Metadata:
+      Category: Blocker Vulnerability
+      Title: A secure password should be used when connecting to a database
+      Description: When relying on the password authentication mode for the database connection, a secure password should be chosen.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2115
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S4502:
+    Metadata:
+      Category: Critical Security Hotspot
+      Title: Disabling CSRF protections is security-sensitive
+      Description: A cross-site request forgery (CSRF) attack occurs when a trusted user of a web application can be forced, by an attacker, to perform sensitive actions that he didn’t intend, such as updating his profile or sending a message, more generally anything that can change the state of the application.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-4502
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S5122:
+    Metadata:
+      Category: Minor Security Hotspot
+      Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+      Description: 'Having a permissive Cross-Origin Resource Sharing policy is security-sensitive. It has led in the past to the following vulnerabilities:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-5122
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S9999-log:
+    Metadata:
+      Category: ''
+      Title: Log generator
+      Description: ''
+      CustomTags:
+      - MainSourceScope
+      - TestSourceScope
+      - Utility
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S3267:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Loops should be simplified with "LINQ" expressions
+      Description: When a loop is filtering, selecting or aggregating, those functions can be handled with a clearer, more concise LINQ expression instead.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3267
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  S3260:
+    Metadata:
+      Category: Minor Code Smell
+      Title: Non-derived "private" classes and records should be "sealed"
+      Description: private classes and records aren’t visible outside of their assemblies anyway, so if they’re not extended inside the assemblies, they should be made explicitly non-extensible with the addition of the sealed keyword.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3260
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: R9A013
+  S3059:
+    Metadata:
+      Category: Major Code Smell
+      Title: Types should not have members with visibility set higher than the type's visibility
+      Description: There’s no point in having a public member in a non-public type because objects that can’t access the type will never have the chance to access the member.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-3059
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  S2222:
+    Metadata:
+      Category: Critical Bug
+      Title: Locks should be released on all paths
+      Description: If a lock is held or acquired and then released within a method, it should be released along all execution paths.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-2222
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  S6354:
+    Metadata:
+      Category: Major Code Smell
+      Title: Use a testable date/time provider
+      Description: One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6354
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: R9A022
+  S6422:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Calls to "async" methods should not be blocking in Azure Functions
+      Description: Making blocking calls to async methods transforms code that was intended to be asynchronous into a blocking operation. Doing so inside an Azure Function can lead to thread exhaustion.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6422
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S6421:
+    Metadata:
+      Category: Major Code Smell
+      Title: Azure Functions should use Structured Error Handling
+      Description: The top-most level of an Azure Function code should include a try/catch block to capture and log all errors so you can monitor the health of the application effectively. In case a retry policy has been defined for your Azure Function, you should rethrow any errors that should result in a retry.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6421
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S6423:
+    Metadata:
+      Category: Major Code Smell
+      Title: Azure Functions should log all failures
+      Description: Capturing and logging errors is critical to monitoring the health of your Azure Functions application.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6423
+      CustomTags:
+      - C#
+      - MainSourceScope
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S6420:
+    Metadata:
+      Category: Major Code Smell
+      Title: Client instances should not be recreated on each Azure Function invocation
+      Description: 'To avoid holding more connections than necessary and to avoid potentially exhausting the number of available sockets when using HttpClient, DocumentClient, QueueClient, ConnectionMultiplexer or Azure Storage clients, consider:'
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6420
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S6419:
+    Metadata:
+      Category: Major Code Smell
+      Title: Azure Functions should be stateless
+      Description: An Azure Function should be stateless as there’s no control over where and when function instances are provisioned and de-provisioned. Managing and storing data/state between requests can lead to inconsistencies. If, for any reason, you need to have a stateful function, consider using the Durable Functions extension of Azure Functions.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6419
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S6424:
+    Metadata:
+      Category: Blocker Code Smell
+      Title: Interfaces for durable entities should satisfy the restrictions
+      Description: The recommended way to access Azure Durable Entities is Interfaces via generated proxy objects.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6424
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  S6444:
+    Metadata:
+      Category: Major Security Hotspot
+      Title: Not specifying a timeout for regular expressions is security-sensitive
+      Description: Not specifying a timeout for regular expressions can lead to a Denial-of-Service attack. Pass a timeout when using System.Text.RegularExpressions to process untrusted input because a malicious user might craft a value for which the evaluation lasts excessively long.
+      HelpLinkUri: https://rules.sonarsource.com/csharp/RSPEC-6444
+      CustomTags:
+      - C#
+      - MainSourceScope
+      - SonarWay
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/StyleCop.Analyzers.yml
+++ b/eng/Diags/StyleCop.Analyzers.yml
@@ -1,0 +1,2285 @@
+Origin:
+  AssemblyName: StyleCop.Analyzers
+  Version: 1.2.0.435
+Diagnostics:
+  SA0001:
+    Metadata:
+      Category: StyleCop.CSharp.SpecialRules
+      Title: XML comment analysis disabled
+      Description: XML comment analysis can only be performed when the project is configured to parse documentation comments. To enable this functionality, update the project to produce an XML documentation file as part of the build.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA0002:
+    Metadata:
+      Category: StyleCop.CSharp.SpecialRules
+      Title: Invalid settings file
+      Description: >-
+        Various errors in the stylecop.json file can prevent the file from being loaded by the analyzers. In this case, the default settings are used instead.
+
+
+
+        {0}
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1000:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Keywords should be spaced correctly
+      Description: The spacing around a C# keyword is incorrect.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1001:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Commas should be spaced correctly
+      Description: The spacing around a comma is incorrect, within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1002:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Semicolons should be spaced correctly
+      Description: The spacing around a semicolon is incorrect, within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1003:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Symbols should be spaced correctly
+      Description: The spacing around an operator symbol is incorrect, within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1004:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Documentation lines should begin with single space
+      Description: A line within a documentation header above a C# element does not begin with a single space.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1005:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Single line comments should begin with single space
+      Description: A single-line comment within a C# code file does not begin with a single space.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1006:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Preprocessor keywords should not be preceded by space
+      Description: A C# preprocessor-type keyword is preceded by space.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1007:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Operator keyword should be followed by space
+      Description: The operator keyword within a C# operator overload method is not followed by any whitespace.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1008:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Opening parenthesis should be spaced correctly
+      Description: An opening parenthesis within a C# statement is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1009:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Closing parenthesis should be spaced correctly
+      Description: A closing parenthesis within a C# statement is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1010:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Opening square brackets should be spaced correctly
+      Description: An opening square bracket within a C# statement is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1011:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Closing square brackets should be spaced correctly
+      Description: A closing square bracket within a C# statement is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1012:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Opening braces should be spaced correctly
+      Description: An opening brace within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1013:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Closing braces should be spaced correctly
+      Description: A closing brace within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1014:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Opening generic brackets should be spaced correctly
+      Description: An opening generic bracket within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1015:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Closing generic brackets should be spaced correctly
+      Description: A closing generic bracket within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1016:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Opening attribute brackets should be spaced correctly
+      Description: An opening attribute bracket within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1017:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Closing attribute brackets should be spaced correctly
+      Description: A closing attribute bracket within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1018:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Nullable type symbols should be spaced correctly
+      Description: A nullable type symbol within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1019:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Member access symbols should be spaced correctly
+      Description: The spacing around a member access symbol is incorrect, within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1020:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Increment decrement symbols should be spaced correctly
+      Description: An increment or decrement symbol within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1021:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Negative signs should be spaced correctly
+      Description: A negative sign within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1022:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Positive signs should be spaced correctly
+      Description: A positive sign within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1023:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Dereference and access of symbols should be spaced correctly
+      Description: A dereference symbol or an access-of symbol within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1024:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Colons Should Be Spaced Correctly
+      Description: A colon within a C# element is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1025:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Code should not contain multiple whitespace in a row
+      Description: The code contains multiple whitespace characters in a row.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1026:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+      Description: An implicitly typed array allocation within a C# code file is not spaced correctly.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1027:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Use tabs correctly
+      Description: The code contains a tab or space character which is not consistent with the current project settings.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1028:
+    Metadata:
+      Category: StyleCop.CSharp.SpacingRules
+      Title: Code should not contain trailing whitespace
+      Description: There should not be any whitespace at the end of a line of code.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+      CustomTags:
+      - Unnecessary
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1100:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not prefix calls with base unless local implementation exists
+      Description: A call to a member from an inherited class begins with 'base.', and the local class does not contain an override or implementation of the member.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1101:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Prefix local calls with this
+      Description: A call to an instance member of the local class or a base class is not prefixed with 'this.', within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+      DefaultSeverity: Warning
+    Tier: 99
+    Attributes:
+      general:
+        Severity: None
+  SA1102:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Query clause should follow previous clause
+      Description: A C# query clause does not begin on the same line as the previous clause, or on the next line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1103:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Query clauses should be on separate lines or all on one line
+      Description: The clauses within a C# query expression are not all placed on the same line, and each clause is not placed on its own line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1104:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Query clause should begin on new line when previous clause spans multiple lines
+      Description: A clause within a C# query expression begins on the same line as the previous clause, when the previous clause spans across multiple lines.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1105:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Query clauses spanning multiple lines should begin on own line
+      Description: A clause within a C# query expression spans across multiple lines, and does not begin on its own line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1106:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Code should not contain empty statements
+      Description: The C# code contains an extra semicolon.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+      CustomTags:
+      - Unnecessary
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1107:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Code should not contain multiple statements on one line
+      Description: The C# code contains more than one statement on a single line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE2001
+  SA1108:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Block statements should not contain embedded comments
+      Description: A C# statement contains a comment between the declaration of the statement and the opening brace of the statement.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1109:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Block statements should not contain embedded regions
+      Description: A C# statement contains a region tag between the declaration of the statement and the opening brace of the statement.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1110:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Opening parenthesis or bracket should be on declaration line
+      Description: The opening parenthesis or bracket is not placed on the same line as the method/indexer/attribute/array name.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1111:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Closing parenthesis should be on line of last parameter
+      Description: The closing parenthesis or bracket in a call to or declaration of a C# method/indexer/attribute/array/constructor/delegate is not placed on the same line as the last parameter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1112:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Closing parenthesis should be on line of opening parenthesis
+      Description: The closing parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or indexer, is not placed on the same line as the opening bracket when the element does not take any parameters.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1113:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Comma should be on the same line as previous parameter
+      Description: A comma between two parameters in a call to a C# method or indexer, or in the declaration of a method or indexer, is not placed on the same line as the previous parameter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1114:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Parameter list should follow declaration
+      Description: The start of the parameter list for a method/constructor/indexer/array/operator call or declaration does not begin on the same line as the opening bracket, or on the line after the opening bracket.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1115:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Parameter should follow comma
+      Description: A parameter within a C# method or indexer call or declaration does not begin on the same line as the previous parameter, or on the next line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1116:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Split parameters should start on line after declaration
+      Description: The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1117:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Parameters should be on same line or separate lines
+      Description: The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1118:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Parameter should not span multiple lines
+      Description: A parameter to a C# method/indexer/attribute/array, other than the first parameter, spans across multiple lines. If the parameter is short, place the entire parameter on a single line. Otherwise, save the contents of the parameter in a temporary variable and pass the temporary variable as a parameter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1119:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Statement should not use unnecessary parenthesis
+      Description: A C# statement contains parenthesis which are unnecessary and should be removed.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1119_p:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Statement should not use unnecessary parenthesis
+      Description: A C# statement contains parenthesis which are unnecessary and should be removed.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+      CustomTags:
+      - Unnecessary
+      - NotConfigurable
+      DefaultSeverity: None
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  SA1120:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Comments should contain text
+      Description: The C# comment does not contain any comment text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1121:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use built-in type alias
+      Description: The code uses one of the basic C# types, but does not use the built-in alias for the type.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+      CustomTags:
+      - Unnecessary
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1122:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use string.Empty for empty strings
+      Description: The C# code includes an empty string, written as "".
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  SA1123:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not place regions within elements
+      Description: The C# code contains a region within the body of a code element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1124:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not use regions
+      Description: The C# code contains a region.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+  SA1125:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use shorthand for nullable types
+      Description: The Nullable<T> type has been defined not using the C# shorthand. For example, Nullable<DateTime> has been used instead of the preferred DateTime?
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1126:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Prefix calls correctly
+      Description: A call to a member is not prefixed with the 'this.', 'base.', 'object.' or 'typename.' prefix to indicate the intended method call, within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1127:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Generic type constraints should be on their own line
+      Description: Each type constraint clause for a generic type parameter should be listed on a line of code by itself.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1128:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Put constructor initializers on their own line
+      Description: A constructor initializer, including the colon character, should be on its own line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1129:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not use default value type constructor
+      Description: When creating a new instance of a value type T, the syntax 'default(T)' is functionally equivalent to the syntax 'new T()'. To avoid confusion regarding the behavior of the resulting instance, the first form is preferred.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1130:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use lambda syntax
+      Description: Lambda expressions are more succinct and easier to read than anonymous methods, so they should are preferred whenever the two are functionally equivalent.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1131:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use readable conditions
+      Description: When a comparison is made between a variable and a literal, the variable should be placed on the left-hand-side to maximize readability.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1132:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not combine fields
+      Description: Each field should be declared on its own line, in order to clearly see each field of a type and allow for proper documentation of the behavior of each field.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: S1169 handles fields and variables
+        Redundant: S1169
+  SA1133:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not combine attributes
+      Description: Each attribute usage should be placed in its own set of square brackets for maximum readability.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1134:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Attributes should not share line
+      Description: Each attribute should be placed on its own line of code.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0055
+  SA1135:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Using directives should be qualified
+      Description: All using directives should be qualified.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1136:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Enum values should be on separate lines
+      Description: Enum values should be placed on their own lines for maximum readability.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1137:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Elements should have the same indentation
+      Description: Elements at the same level in the syntax tree should have the same indentation.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Doesn't work with file-scoped namespaces
+  SA1139:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use literal suffix notation instead of casting
+      Description: Use literal suffix notation instead of casting, in order to improve readability, avoid bugs related to illegal casts and ensure that optimal IL is produced.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1200:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Using directives should be placed correctly
+      Description: A C# using directive is placed outside of a namespace element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0065
+  SA1201:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Elements should appear in the correct order
+      Description: An element within a C# code file is out of order in relation to the other elements in the code.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1202:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Elements should be ordered by access
+      Description: An element within a C# code file is out of order in relation to other elements in the code.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      production:
+        Severity: Warning
+  SA1203:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Constants should appear before fields
+      Description: A constant field is placed beneath a non-constant field.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1204:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Static elements should appear before instance elements
+      Description: A static element is positioned beneath an instance element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1205:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Partial elements should declare access
+      Description: The partial element does not have an access modifier defined.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1206:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Declaration keywords should follow order
+      Description: The keywords within the declaration of an element do not follow a standard ordering scheme.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1207:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Protected should come before internal
+      Description: The keyword '{0}' is positioned after the keyword '{1}' within the declaration of a {0} {1} C# element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1208:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: System using directives should be placed before other using directives
+      Description: A using directive which declares a member of the 'System' namespace appears after a using directive which declares a member of a different namespace, within a C# code file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1209:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Using alias directives should be placed after other using directives
+      Description: A using-alias directive is positioned before a regular using directive.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1210:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Using directives should be ordered alphabetically by namespace
+      Description: The using directives within a C# code file are not sorted alphabetically by namespace.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1211:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Using alias directives should be ordered alphabetically by alias name
+      Description: The using-alias directives within a C# code file are not sorted alphabetically by alias name.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1212:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Property accessors should follow order
+      Description: A get accessor appears after a set accessor within a property or indexer.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1213:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Event accessors should follow order
+      Description: An add accessor appears after a remove accessor within an event.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1214:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Readonly fields should appear before non-readonly fields
+      Description: A readonly field is positioned beneath a non-readonly field.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1216:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Using static directives should be placed at the correct location
+      Description: A using static directive is positioned before a regular or after an alias using directive.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1217:
+    Metadata:
+      Category: StyleCop.CSharp.OrderingRules
+      Title: Using static directives should be ordered alphabetically
+      Description: All using static directives should be ordered alphabetically.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1300:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Element should begin with upper-case letter
+      Description: The name of a C# element does not begin with an upper-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1301:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Element should begin with lower-case letter
+      Description: There are currently no situations in which this rule will fire.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1302:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Interface names should begin with I
+      Description: The name of a C# interface does not begin with the capital letter I.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1303:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Const field names should begin with upper-case letter
+      Description: The name of a constant C# field should begin with an upper-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1304:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Non-private readonly fields should begin with upper-case letter
+      Description: The name of a non-private readonly C# field should being with an upper-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1305:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Field names should not use Hungarian notation
+      Description: The name of a field or variable in C# uses Hungarian notation.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1306:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Field names should begin with lower-case letter
+      Description: The name of a field in C# does not begin with a lower-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1307:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Accessible fields should begin with upper-case letter
+      Description: The name of a public or internal field in C# does not begin with an upper-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1308:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Variable names should not be prefixed
+      Description: A field name in C# is prefixed with 'm_', 's_', or 't_'.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1309:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Field names should not begin with underscore
+      Description: A field name in C# begins with an underscore.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1310:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Field names should not contain underscore
+      Description: A field name in C# contains an underscore.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1311:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Static readonly fields should begin with upper-case letter
+      Description: The name of a static readonly field does not begin with an upper-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1312:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Variable names should begin with lower-case letter
+      Description: The name of a variable in C# does not begin with a lower-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1313:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Parameter names should begin with lower-case letter
+      Description: The name of a parameter in C# does not begin with a lower-case letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1314:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Type parameter names should begin with T
+      Description: The name of a C# type parameter does not begin with the capital letter T.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1400:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Access modifier should be declared
+      Description: The access modifier for a C# element has not been explicitly defined.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1401:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Fields should be private
+      Description: A field within a C# class has an access modifier other than private.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CA1051
+  SA1402:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: File may only contain a single type
+      Description: A C# code file contains more than one unique type.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1403:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: File may only contain a single namespace
+      Description: A C# code file contains more than one namespace.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1404:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Code analysis suppression should have justification
+      Description: A Code Analysis SuppressMessage attribute does not include a justification.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1405:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Debug.Assert should provide message text
+      Description: A call to Debug.Assert in C# code does not include a descriptive message.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1406:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Debug.Fail should provide message text
+      Description: A call to Debug.Fail in C# code does not include a descriptive message.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1407:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Arithmetic expressions should declare precedence
+      Description: A C# statement contains a complex arithmetic expression which omits parenthesis around operators.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1408:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Conditional expressions should declare precedence
+      Description: A C# statement contains a complex conditional expression which omits parenthesis around operators.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1409:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Remove unnecessary code
+      Description: A C# file contains code which is unnecessary and can be removed without changing the overall logic of the code.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1410:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Remove delegate parenthesis when possible
+      Description: A call to a C# anonymous method does not contain any method parameters, yet the statement still includes parenthesis.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+      CustomTags:
+      - Unnecessary
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1411:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Attribute constructor should not use unnecessary parenthesis
+      Description: TODO.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+      CustomTags:
+      - Unnecessary
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1412:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Store files as UTF-8 with byte order mark
+      Description: Source files should be saved using the UTF-8 encoding with a byte order mark.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Comment: Pedantic
+  SA1413:
+    Metadata:
+      Category: StyleCop.CSharp.MaintainabilityRules
+      Title: Use trailing comma in multi-line initializers
+      Description: A multi-line initializer in a C# code file should use a comma on the last line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1500:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Braces for multi-line statements should not share line
+      Description: The opening or closing brace within a C# statement, element, or expression is not placed on its own line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1501:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Statement should not be on a single line
+      Description: A C# statement containing opening and closing braces is written completely on a single line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1502:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Element should not be on a single line
+      Description: A C# element containing opening and closing braces is written completely on a single line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1503:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Braces should not be omitted
+      Description: The opening and closing braces for a C# statement have been omitted.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0011
+  SA1504:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: All accessors should be single-line or multi-line
+      Description: Within a C# property, indexer or event, at least one of the child accessors is written on a single line, and at least one of the child accessors is written across multiple lines.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1505:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Opening braces should not be followed by blank line
+      Description: An opening brace within a C# element, statement, or expression is followed by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1506:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Element documentation headers should not be followed by blank line
+      Description: An element documentation header above a C# element is followed by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1507:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Code should not contain multiple blank lines in a row
+      Description: The C# code contains multiple blank lines in a row.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE2000
+  SA1508:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Closing braces should not be preceded by blank line
+      Description: A closing brace within a C# element, statement, or expression is preceded by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE2002
+  SA1509:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Opening braces should not be preceded by blank line
+      Description: An opening brace within a C# element, statement, or expression is preceded by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1510:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Chained statement blocks should not be preceded by blank line
+      Description: Chained C# statements are separated by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1511:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: While-do footer should not be preceded by blank line
+      Description: The while footer at the bottom of a do-while statement is separated from the statement by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1512:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Single-line comments should not be followed by blank line
+      Description: A single-line comment within C# code is followed by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1513:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Closing brace should be followed by blank line
+      Description: A closing brace within a C# element, statement, or expression is not followed by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1514:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Element documentation header should be preceded by blank line
+      Description: An element documentation header above a C# element is not preceded by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1515:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Single-line comment should be preceded by blank line
+      Description: A single-line comment within C# code is not preceded by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1516:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Elements should be separated by blank line
+      Description: Adjacent C# elements are not separated by a blank line.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1517:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Code should not contain blank lines at start of file
+      Description: The code file has blank lines at the start.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1518:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Use line endings correctly at end of file
+      Description: Code should not contain blank lines at the end of the file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1519:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Braces should not be omitted from multi-line child statement
+      Description: The opening and closing braces for a multi-line C# statement have been omitted.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1520:
+    Metadata:
+      Category: StyleCop.CSharp.LayoutRules
+      Title: Use braces consistently
+      Description: The opening and closing braces of a chained if/else if/else construct were included for some clauses, but omitted for others.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1600:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Elements should be documented
+      Description: A C# code element is missing a documentation header.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  SA1601:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Partial elements should be documented
+      Description: A C# partial element is missing a documentation header.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1602:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Enumeration items should be documented
+      Description: An item within a C# enumeration is missing an Xml documentation header.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  SA1603:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation should contain valid XML
+      Description: The XML within a C# element’s document header is badly formed.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1604:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element documentation should have summary
+      Description: The XML header documentation for a C# element is missing a <summary> tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1605:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Partial element documentation should have summary
+      Description: The <summary> or <content> tag within the documentation header for a C# code element is missing or empty.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1606:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element documentation should have summary text
+      Description: The <summary> tag within the documentation header for a C# code element is empty.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1607:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Partial element documentation should have summary text
+      Description: The <summary> or <content> tag within the documentation header for a C# code element is empty.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1608:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element documentation should not have default summary
+      Description: The <summary> tag within an element's XML header documentation contains the default text generated by Visual Studio during the creation of the element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1609:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Property documentation should have value
+      Description: The XML header documentation for a C# property does not contain a <value> tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1610:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Property documentation should have value text
+      Description: The XML header documentation for a C# property contains an empty <value> tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1611:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element parameters should be documented
+      Description: A C# method, constructor, delegate or indexer element is missing documentation for one or more of its parameters.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: CS1573
+  SA1612:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element parameter documentation should match element parameters
+      Description: The documentation describing the parameters to a C# method, constructor, delegate or indexer element does not match the actual parameters on the element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1613:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element parameter documentation should declare parameter name
+      Description: A <param> tag within a C# element's documentation header is missing a name attribute containing the name of the parameter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1614:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element parameter documentation should have text
+      Description: A <param> tag within a C# element's documentation header is empty.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1615:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element return value should be documented
+      Description: A C# element is missing documentation for its return value.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      api:
+        Severity: Warning
+  SA1616:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element return value documentation should have text
+      Description: The <returns> tag within a C# element's documentation header is empty.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1617:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Void return value should not be documented
+      Description: A C# code element does not contain a return value, or returns void, but the documentation header for the element contains a <returns> tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1618:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Generic type parameters should be documented
+      Description: A generic C# element is missing documentation for one or more of its generic type parameters.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1619:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Generic type parameters should be documented partial class
+      Description: A generic, partial C# element is missing documentation for one or more of its generic type parameters, and the documentation for the element contains a <summary> tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1620:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Generic type parameter documentation should match type parameters
+      Description: The <typeparam> tags within the Xml header documentation for a generic C# element do not match the generic type parameters on the element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1621:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Generic type parameter documentation should declare parameter name
+      Description: A <typeparam> tag within the XML header documentation for a generic C# element is missing a name attribute, or contains an empty name attribute.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1622:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Generic type parameter documentation should have text
+      Description: A <typeparam> tag within the Xml header documentation for a generic C# element is empty.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1623:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Property summary documentation should match accessors
+      Description: The documentation text within a C# property’s <summary> tag does not match the accessors within the property.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1624:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Property summary documentation should omit accessor with restricted access
+      Description: The documentation text within a C# property’s <summary> tag takes into account all of the accessors within the property, but one of the accessors has limited access.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1625:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element documentation should not be copied and pasted
+      Description: The Xml documentation for a C# element contains two or more identical entries, indicating that the documentation has been copied and pasted. This can sometimes indicate invalid or poorly written documentation.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1626:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Single-line comments should not use documentation style slashes
+      Description: The C# code contains a single-line comment which begins with three forward slashes in a row.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1627:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation text should not be empty
+      Description: The XML header documentation for a C# code element contains an empty tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1628:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation text should begin with a capital letter
+      Description: A section of the XML header documentation for a C# element does not begin with a capital letter.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1629:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation text should end with a period
+      Description: A section of the XML header documentation for a C# element does not end with a period.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1630:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation text should contain whitespace
+      Description: A section of the XML header documentation for a C# element does not contain any whitespace between words.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1631:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation should meet character percentage
+      Description: A section of the Xml header documentation for a C# element does not contain enough alphabetic characters.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1632:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation text should meet minimum character length
+      Description: A section of the Xml header documentation for a C# element is too short.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SA1633:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File should have header
+      Description: A C# code file is missing a standard file header.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0073
+  SA1634:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header should show copyright
+      Description: The file header at the top of a C# code file is missing a copyright tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1635:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header should have copyright text
+      Description: The file header at the top of a C# code file is missing copyright text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1636:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header copyright text should match
+      Description: The file header at the top of a C# code file does not contain the appropriate copyright text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+  SA1637:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header should contain file name
+      Description: The file header at the top of a C# code file is missing the file name.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1638:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header file name documentation should match file name
+      Description: The file attribute within copyright tag of the file header at the top of a C# code file does not contain the name of the file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1639:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header should have summary
+      Description: The file header at the top of a C# code file does not contain a filled-in summary tag.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1640:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header should have valid company text
+      Description: The file header at the top of a C# code file does not contain company name text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1641:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File header company name text should match
+      Description: The file header at the top of a C# code file does not contain the appropriate company name text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+  SA1642:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Constructor summary documentation should begin with standard text
+      Description: The XML documentation header for a C# constructor does not contain the appropriate summary text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1643:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Destructor summary documentation should begin with standard text
+      Description: The XML documentation header for a C# finalizer does not contain the appropriate summary text.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1644:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Documentation headers should not contain blank lines
+      Description: A section within the XML documentation header for a C# element contains blank lines.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1645:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Included documentation file does not exist
+      Description: An included XML documentation file does not exist.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1646:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Included documentation XPath does not exist
+      Description: An included XML documentation link contains an invalid path.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1647:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Include node does not contain valid file and path
+      Description: An include tag within an XML documentation header does not contain valid file and path attribute.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1648:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: inheritdoc should be used with inheriting class
+      Description: <inheritdoc> has been used on an element that doesn't inherit from a base class or implement an interface.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1649:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: File name should match first type name
+      Description: The file name of a C# code file does not match the first type declared in the file.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SA1650:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Element documentation should be spelled correctly
+      Description: The element documentation for the element contains one or more spelling mistakes or unrecognized words.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+      CustomTags:
+      - NotConfigurable
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+        Comment: Deprecated
+  SA1651:
+    Metadata:
+      Category: StyleCop.CSharp.DocumentationRules
+      Title: Do not use placeholder elements
+      Description: The element documentation contains a <placeholder> element.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning
+  SX1101:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Do not prefix local calls with 'this.'
+      Description: A call to an instance member of the local class or a base class is prefixed with `this.`.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+      CustomTags:
+      - Unnecessary
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: Warning
+  SX1309:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Field names should begin with underscore
+      Description: A field name in C# does not begin with an underscore.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SX1309S:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Static field names should begin with underscore
+      Description: A static field name in C# does not begin with an underscore.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+      DefaultSeverity: Warning
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE1006
+  SA1141:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Use tuple syntax
+      Description: Use tuple syntax instead of the underlying ValueTuple implementation type.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1142:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Refer to tuple fields by name
+      Description: A field of a tuple was referenced by its metadata name when a field name is available.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+        Redundant: IDE0033
+  SA1316:
+    Metadata:
+      Category: StyleCop.CSharp.NamingRules
+      Title: Tuple element names should use correct casing
+      Description: Element names within a tuple type should have the correct casing.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+      DefaultSeverity: Warning
+    Tier: 1
+    Attributes:
+      general:
+        Severity: Warning
+  SA1414:
+    Metadata:
+      Category: StyleCop.CSharp.ReadabilityRules
+      Title: Tuple types in signatures should have element names
+      Description: Tuple types appearing in member declarations should have explicitly named tuple elements.
+      HelpLinkUri: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: Warning

--- a/eng/Diags/xunit.analyzers.yml
+++ b/eng/Diags/xunit.analyzers.yml
@@ -1,0 +1,666 @@
+Origin:
+  AssemblyName: xunit.analyzers
+  Version: 1.0.0
+Diagnostics:
+  xUnit1000:
+    Metadata:
+      Category: Usage
+      Title: Test classes must be public
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1000
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1001:
+    Metadata:
+      Category: Usage
+      Title: Fact methods cannot have parameters
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1001
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1002:
+    Metadata:
+      Category: Usage
+      Title: Test methods cannot have multiple Fact or Theory attributes
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1002
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1003:
+    Metadata:
+      Category: Usage
+      Title: Theory methods must have test data
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1003
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1004:
+    Metadata:
+      Category: Usage
+      Title: Test methods should not be skipped
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1004
+      DefaultSeverity: Suggestion
+    Tier: 3
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Suggestion
+  xUnit1005:
+    Metadata:
+      Category: Usage
+      Title: Fact methods should not have test data
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1005
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1006:
+    Metadata:
+      Category: Usage
+      Title: Theory methods should have parameters
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1006
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit1007:
+    Metadata:
+      Category: Usage
+      Title: ClassData must point at a valid class
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1007
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1008:
+    Metadata:
+      Category: Usage
+      Title: Test data attribute should only be used on a Theory
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1008
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1009:
+    Metadata:
+      Category: Usage
+      Title: InlineData values must match the number of method parameters
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1009
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1010:
+    Metadata:
+      Category: Usage
+      Title: The value is not convertible to the method parameter type
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1010
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1011:
+    Metadata:
+      Category: Usage
+      Title: There is no matching method parameter
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1011
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1012:
+    Metadata:
+      Category: Usage
+      Title: Null should not be used for value type parameters
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1012
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit1013:
+    Metadata:
+      Category: Usage
+      Title: Public method should be marked as test
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1013
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit1014:
+    Metadata:
+      Category: Usage
+      Title: MemberData should use nameof operator for member name
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1014
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit1015:
+    Metadata:
+      Category: Usage
+      Title: MemberData must reference an existing member
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1015
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1016:
+    Metadata:
+      Category: Usage
+      Title: MemberData must reference a public member
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1016
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1017:
+    Metadata:
+      Category: Usage
+      Title: MemberData must reference a static member
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1017
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1018:
+    Metadata:
+      Category: Usage
+      Title: MemberData must reference a valid member kind
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1018
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1019:
+    Metadata:
+      Category: Usage
+      Title: MemberData must reference a member providing a valid data type
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1019
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1020:
+    Metadata:
+      Category: Usage
+      Title: MemberData must reference a property with a public getter
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1020
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1021:
+    Metadata:
+      Category: Usage
+      Title: MemberData should not have parameters if the referenced member is not a method
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1021
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1022:
+    Metadata:
+      Category: Usage
+      Title: Theory methods cannot have a parameter array
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1022
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1023:
+    Metadata:
+      Category: Usage
+      Title: Theory methods cannot have default parameter values
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1023
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1024:
+    Metadata:
+      Category: Usage
+      Title: Test methods cannot have overloads
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1024
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1025:
+    Metadata:
+      Category: Usage
+      Title: InlineData should be unique within the Theory it belongs to
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1025
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit1026:
+    Metadata:
+      Category: Usage
+      Title: Theory methods should use all of their parameters
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1026
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2000:
+    Metadata:
+      Category: Assertions
+      Title: Constants and literals should be the expected argument
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2000
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2001:
+    Metadata:
+      Category: Assertions
+      Title: Do not use invalid equality check
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2001
+      DefaultSeverity: None
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Silent
+  xUnit2002:
+    Metadata:
+      Category: Assertions
+      Title: Do not use null check on value type
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2002
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2003:
+    Metadata:
+      Category: Assertions
+      Title: Do not use equality check to test for null value
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2003
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2004:
+    Metadata:
+      Category: Assertions
+      Title: Do not use equality check to test for boolean conditions
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2004
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2005:
+    Metadata:
+      Category: Assertions
+      Title: Do not use identity check on value type
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2005
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2006:
+    Metadata:
+      Category: Assertions
+      Title: Do not use invalid string equality check
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2006
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2007:
+    Metadata:
+      Category: Assertions
+      Title: Do not use typeof expression to check the type
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2007
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2008:
+    Metadata:
+      Category: Assertions
+      Title: Do not use boolean check to match on regular expressions
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2008
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2009:
+    Metadata:
+      Category: Assertions
+      Title: Do not use boolean check to check for substrings
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2009
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2010:
+    Metadata:
+      Category: Assertions
+      Title: Do not use boolean check to check for string equality
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2010
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2011:
+    Metadata:
+      Category: Assertions
+      Title: Do not use empty collection check
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2011
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2012:
+    Metadata:
+      Category: Assertions
+      Title: Do not use boolean check to check if a value exists in a collection
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2012
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2013:
+    Metadata:
+      Category: Assertions
+      Title: Do not use equality check to check for collection size.
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2013
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2014:
+    Metadata:
+      Category: Assertions
+      Title: Do not use throws check to check for asynchronously thrown exception
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2014
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit2015:
+    Metadata:
+      Category: Assertions
+      Title: Do not use typeof expression to check the exception type
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2015
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2016:
+    Metadata:
+      Category: Assertions
+      Title: Keep precision in the allowed range when asserting equality of doubles or decimals.
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2016
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit2017:
+    Metadata:
+      Category: Assertions
+      Title: Do not use Contains() to check if a value exists in a collection
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2017
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2018:
+    Metadata:
+      Category: Assertions
+      Title: Do not compare an object's exact type to an abstract class or interface
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit2018
+      DefaultSeverity: Warning
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit2019:
+    Metadata:
+      Category: Assertions
+      Title: Do not use obsolete throws check to check for asynchronously thrown exception
+      Description: ''
+      HelpLinkUri: https://xunit.github.io/xunit.analyzers/rules/xUnit2019
+    Tier: 2
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Warning
+  xUnit3000:
+    Metadata:
+      Category: Extensibility
+      Title: Test case classes must derive directly or indirectly from Xunit.LongLivedMarshalByRefObject
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit3000
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit3001:
+    Metadata:
+      Category: Extensibility
+      Title: Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit3001
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1027:
+    Metadata:
+      Category: Usage
+      Title: Collection definition classes must be public
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1027
+      DefaultSeverity: Error
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Error
+  xUnit1033:
+    Metadata:
+      Category: Usage
+      Title: Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
+      Description: ''
+      HelpLinkUri: https://xunit.net/xunit.analyzers/rules/xUnit1033
+      DefaultSeverity: Suggestion
+    Tier: 1
+    Attributes:
+      general:
+        Severity: None
+      test:
+        Severity: Suggestion

--- a/eng/Packages/General.props
+++ b/eng/Packages/General.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.18.3" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.41.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.41.0" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.0.0.7106-preview2" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.28.0-preview"/>
     <PackageVersion Include="Microsoft.Azure.KeyVault.AzureServiceDeploy" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
@@ -36,6 +37,7 @@
     <PackageVersion Include="protobuf-net" Version="3.0.101" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="YamlDotNet" Version="11.1.1" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\General-net462.props" />

--- a/eng/Tools/.editorconfig
+++ b/eng/Tools/.editorconfig
@@ -1,7 +1,7 @@
 # Created by DiagConfig, the diagnostic config generator
 # Generated : 2023-05-23 23:01:34Z
 # Max Tier  : 2147483647
-# Attributes: general, performance
+# Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
 
 [*.cs]
@@ -127,9 +127,7 @@ dotnet_diagnostic.CA1008.severity = none
 # Title    : Generic interface should also be implemented
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
-dotnet_diagnostic.CA1010.severity = warning
-dotnet_code_quality.CA1010.api_surface = all
-dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+dotnet_diagnostic.CA1010.severity = none
 
 # Title    : Abstract types should not have public constructors
 # Category : Design
@@ -423,7 +421,7 @@ dotnet_diagnostic.CA1418.severity = warning
 # Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
-dotnet_diagnostic.CA1419.severity = warning
+dotnet_diagnostic.CA1419.severity = none
 
 # Title    : Property, type, or attribute requires runtime marshalling
 # Category : Interoperability
@@ -587,12 +585,12 @@ dotnet_diagnostic.CA1801.severity = none
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-dotnet_diagnostic.CA1802.severity = warning
+dotnet_diagnostic.CA1802.severity = none
 
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-dotnet_diagnostic.CA1802.severity = warning
+dotnet_diagnostic.CA1802.severity = none
 
 # Title    : Do not initialize unnecessarily
 # Category : Performance
@@ -612,7 +610,7 @@ dotnet_diagnostic.CA1806.severity = warning
 # Title    : Initialize reference type static fields inline
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
-dotnet_diagnostic.CA1810.severity = warning
+dotnet_diagnostic.CA1810.severity = none
 
 # Title    : Avoid uninstantiated internal classes
 # Category : Performance
@@ -624,17 +622,17 @@ dotnet_diagnostic.CA1812.severity = none
 # Title    : Avoid unsealed attributes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
-dotnet_diagnostic.CA1813.severity = warning
+dotnet_diagnostic.CA1813.severity = none
 
 # Title    : Prefer jagged arrays over multidimensional
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
-dotnet_diagnostic.CA1814.severity = warning
+dotnet_diagnostic.CA1814.severity = none
 
 # Title    : Override equals and operator equals on value types
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
-dotnet_diagnostic.CA1815.severity = warning
+dotnet_diagnostic.CA1815.severity = none
 
 # Title    : Dispose methods should call SuppressFinalize
 # Category : Usage
@@ -644,17 +642,17 @@ dotnet_diagnostic.CA1816.severity = warning
 # Title    : Properties should not return arrays
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
-dotnet_diagnostic.CA1819.severity = warning
+dotnet_diagnostic.CA1819.severity = none
 
 # Title    : Test for empty strings using string length
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
-dotnet_diagnostic.CA1820.severity = warning
+dotnet_diagnostic.CA1820.severity = none
 
 # Title    : Remove empty Finalizers
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
-dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1821.severity = none
 
 # Title    : Mark members as static
 # Category : Performance
@@ -670,92 +668,92 @@ dotnet_diagnostic.CA1823.severity = none
 # Title    : Mark assemblies with NeutralResourcesLanguageAttribute
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
-dotnet_diagnostic.CA1824.severity = warning
+dotnet_diagnostic.CA1824.severity = suggestion
 
 # Title    : Avoid zero-length array allocations
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
-dotnet_diagnostic.CA1825.severity = warning
+dotnet_diagnostic.CA1825.severity = none
 
 # Title    : Do not use Enumerable methods on indexable collections
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
-dotnet_diagnostic.CA1826.severity = warning
+dotnet_diagnostic.CA1826.severity = none
 
 # Title    : Do not use Count() or LongCount() when Any() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
-dotnet_diagnostic.CA1827.severity = warning
+dotnet_diagnostic.CA1827.severity = none
 
 # Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
-dotnet_diagnostic.CA1828.severity = warning
+dotnet_diagnostic.CA1828.severity = none
 
 # Title    : Use Length/Count property instead of Count() when available
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
-dotnet_diagnostic.CA1829.severity = warning
+dotnet_diagnostic.CA1829.severity = none
 
 # Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
-dotnet_diagnostic.CA1830.severity = warning
+dotnet_diagnostic.CA1830.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
-dotnet_diagnostic.CA1831.severity = warning
+dotnet_diagnostic.CA1831.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
-dotnet_diagnostic.CA1832.severity = warning
+dotnet_diagnostic.CA1832.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
-dotnet_diagnostic.CA1833.severity = warning
+dotnet_diagnostic.CA1833.severity = none
 
 # Title    : Consider using 'StringBuilder.Append(char)' when applicable
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
-dotnet_diagnostic.CA1834.severity = warning
+dotnet_diagnostic.CA1834.severity = none
 
 # Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
-dotnet_diagnostic.CA1835.severity = warning
+dotnet_diagnostic.CA1835.severity = none
 
 # Title    : Prefer IsEmpty over Count
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
-dotnet_diagnostic.CA1836.severity = warning
+dotnet_diagnostic.CA1836.severity = none
 
 # Title    : Use 'Environment.ProcessId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
-dotnet_diagnostic.CA1837.severity = warning
+dotnet_diagnostic.CA1837.severity = none
 
 # Title    : Avoid 'StringBuilder' parameters for P/Invokes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
-dotnet_diagnostic.CA1838.severity = warning
+dotnet_diagnostic.CA1838.severity = none
 
 # Title    : Use 'Environment.ProcessPath'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
-dotnet_diagnostic.CA1839.severity = warning
+dotnet_diagnostic.CA1839.severity = none
 
 # Title    : Use 'Environment.CurrentManagedThreadId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
-dotnet_diagnostic.CA1840.severity = warning
+dotnet_diagnostic.CA1840.severity = none
 
 # Title    : Prefer Dictionary.Contains methods
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
-dotnet_diagnostic.CA1841.severity = warning
+dotnet_diagnostic.CA1841.severity = none
 
 # Title    : Do not use 'WhenAll' with a single task
 # Category : Performance
@@ -765,27 +763,27 @@ dotnet_diagnostic.CA1842.severity = suggestion
 # Title    : Do not use 'WaitAll' with a single task
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
-dotnet_diagnostic.CA1843.severity = warning
+dotnet_diagnostic.CA1843.severity = none
 
 # Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
-dotnet_diagnostic.CA1844.severity = warning
+dotnet_diagnostic.CA1844.severity = none
 
 # Title    : Use span-based 'string.Concat'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
-dotnet_diagnostic.CA1845.severity = warning
+dotnet_diagnostic.CA1845.severity = none
 
 # Title    : Prefer 'AsSpan' over 'Substring'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
-dotnet_diagnostic.CA1846.severity = warning
+dotnet_diagnostic.CA1846.severity = none
 
 # Title    : Use char literal for a single character lookup
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
-dotnet_diagnostic.CA1847.severity = warning
+dotnet_diagnostic.CA1847.severity = none
 
 # Title    : Use the LoggerMessage delegates
 # Category : Performance
@@ -796,12 +794,12 @@ dotnet_diagnostic.CA1848.severity = none
 # Title    : Call async methods when in an async method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
-dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1849.severity = none
 
 # Title    : Prefer static 'HashData' method over 'ComputeHash'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
-dotnet_diagnostic.CA1850.severity = suggestion
+dotnet_diagnostic.CA1850.severity = none
 
 # Title    : Possible multiple enumerations of 'IEnumerable' collection
 # Category : Performance
@@ -817,17 +815,17 @@ dotnet_diagnostic.CA1852.severity = none
 # Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
-dotnet_diagnostic.CA1853.severity = suggestion
+dotnet_diagnostic.CA1853.severity = none
 
 # Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
-dotnet_diagnostic.CA1854.severity = warning
+dotnet_diagnostic.CA1854.severity = none
 
 # Title    : Prefer 'Clear' over 'Fill'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
-dotnet_diagnostic.CA1855.severity = warning
+dotnet_diagnostic.CA1855.severity = none
 
 # Title    : Incorrect usage of ConstantExpected attribute
 # Category : Performance
@@ -872,7 +870,7 @@ dotnet_diagnostic.CA2002.severity = warning
 # Title    : Consider calling ConfigureAwait on the awaited task
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
-dotnet_diagnostic.CA2007.severity = warning
+dotnet_diagnostic.CA2007.severity = none
 
 # Title    : Do not create tasks without passing a TaskScheduler
 # Category : Reliability
@@ -987,7 +985,7 @@ dotnet_diagnostic.CA2201.severity = warning
 # Title    : Initialize value type static fields inline
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
-dotnet_diagnostic.CA2207.severity = warning
+dotnet_diagnostic.CA2207.severity = none
 
 # Title    : Instantiate argument exceptions correctly
 # Category : Usage
@@ -2670,37 +2668,37 @@ dotnet_diagnostic.IL3056.severity = warning
 # Title    : Use source generated logging methods for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a000
-dotnet_diagnostic.R9A000.severity = warning
+dotnet_diagnostic.R9A000.severity = none
 
 # Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a014
-dotnet_diagnostic.R9A014.severity = warning
+dotnet_diagnostic.R9A014.severity = none
 
 # Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a015
-dotnet_diagnostic.R9A015.severity = warning
+dotnet_diagnostic.R9A015.severity = none
 
 # Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a018
-dotnet_diagnostic.R9A018.severity = warning
+dotnet_diagnostic.R9A018.severity = none
 
 # Title    : Remove unnecessary dictionary lookups
 # Category : Performance
 # Help Link: https://TODO/r9a019
-dotnet_diagnostic.R9A019.severity = warning
+dotnet_diagnostic.R9A019.severity = none
 
 # Title    : Remove unnecessary set lookups
 # Category : Performance
 # Help Link: https://TODO/r9a020
-dotnet_diagnostic.R9A020.severity = warning
+dotnet_diagnostic.R9A020.severity = none
 
 # Title    : Perform message formatting in the body of the logging method
 # Category : Performance
 # Help Link: https://TODO/r9a021
-dotnet_diagnostic.R9A021.severity = warning
+dotnet_diagnostic.R9A021.severity = none
 
 # Title    : Use 'System.TimeProvider' to make the code easier to test
 # Category : Reliability
@@ -2715,12 +2713,12 @@ dotnet_diagnostic.R9A029.severity = none
 # Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
 # Category : Performance
 # Help Link: https://TODO/r9a030
-dotnet_diagnostic.R9A030.severity = warning
+dotnet_diagnostic.R9A030.severity = none
 
 # Title    : Make types declared in an executable internal
 # Category : Performance
 # Help Link: https://TODO/r9a031
-dotnet_diagnostic.R9A031.severity = warning
+dotnet_diagnostic.R9A031.severity = none
 
 # Title    : Consider using an array instead of a collection
 # Category : Performance
@@ -2730,32 +2728,32 @@ dotnet_diagnostic.R9A032.severity = none
 # Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a033
-dotnet_diagnostic.R9A033.severity = warning
+dotnet_diagnostic.R9A033.severity = none
 
 # Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a036
-dotnet_diagnostic.R9A036.severity = warning
+dotnet_diagnostic.R9A036.severity = none
 
 # Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a037
-dotnet_diagnostic.R9A037.severity = warning
+dotnet_diagnostic.R9A037.severity = none
 
 # Title    : Use generic collections instead of legacy collections for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a040
-dotnet_diagnostic.R9A040.severity = warning
+dotnet_diagnostic.R9A040.severity = none
 
 # Title    : Use 'System.MemoryExtensions.Split' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a043
-dotnet_diagnostic.R9A043.severity = warning
+dotnet_diagnostic.R9A043.severity = none
 
 # Title    : Assign array of literal values to a static field for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a044
-dotnet_diagnostic.R9A044.severity = warning
+dotnet_diagnostic.R9A044.severity = none
 
 # Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
@@ -3065,7 +3063,7 @@ dotnet_diagnostic.S1210.severity = none
 # Title    : "GC.Collect" should not be called
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
+dotnet_diagnostic.S1215.severity = none
 
 # Title    : Statements should be on separate lines
 # Category : Major Code Smell
@@ -6045,7 +6043,7 @@ dotnet_diagnostic.VSTHRD102.severity = suggestion
 # Title    : Call async methods when in an async method
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
-dotnet_diagnostic.VSTHRD103.severity = warning
+dotnet_diagnostic.VSTHRD103.severity = none
 
 # Title    : Offer async methods
 # Category : Usage

--- a/eng/Tools/ApiChief/ApiChief.csproj
+++ b/eng/Tools/ApiChief/ApiChief.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>ApiChief</AssemblyName>
+    <RootNamespace>ApiChief</RootNamespace>
+    <Description>Tool to help with .NET API management activities</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);R9A061;R9A044</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" />
+    <PackageReference Include="ICSharpCode.Decompiler" />
+  </ItemGroup>
+</Project>

--- a/eng/Tools/ApiChief/Commands/CheckBreakingChanges.cs
+++ b/eng/Tools/ApiChief/Commands/CheckBreakingChanges.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using ApiChief.Model;
+
+namespace ApiChief.Commands;
+
+internal static class CheckBreakingChanges
+{
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
+    private sealed class CheckBreakingChangesArgs
+    {
+        public FileInfo? AssemblyPath { get; }
+
+        public string BaselinePath { get; } = string.Empty;
+    }
+
+    public static Command Create()
+    {
+        var command = new Command("breaking", "Performs a breaking change check")
+        {
+            new Argument<string>("baseline-path", "Path to the baseline report to use for reference"),
+        };
+
+        command.Handler = CommandHandler.Create<CheckBreakingChangesArgs>(ExecuteAsync);
+
+        return command;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Catching for proper error reporting.")]
+    private static Task<int> ExecuteAsync(CheckBreakingChangesArgs args)
+    {
+        ApiModel current;
+        ApiModel baseline;
+
+        try
+        {
+            current = ApiModel.LoadFromAssembly(args.AssemblyPath!.FullName);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to create the current API baseline report from '{args.AssemblyPath!.FullName}': {ex.Message}");
+
+            return Task.FromResult(-1);
+        }
+
+        try
+        {
+            baseline = ApiModel.LoadFromFile(args.BaselinePath);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load previous API baseline report '{args.BaselinePath}': {ex.Message}");
+
+            return Task.FromResult(-1);
+        }
+
+        baseline.EvaluateDelta(current);
+
+        if (current.Removals != null)
+        {
+            Console.Error.WriteLine($"Detected removed APIs in the current baseline report: {string.Join(';', current.Removals)}");
+
+            return Task.FromResult(-1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/ApiChief/Commands/EmitBaseline.cs
+++ b/eng/Tools/ApiChief/Commands/EmitBaseline.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using ApiChief.Model;
+
+namespace ApiChief.Commands;
+
+internal static class EmitBaseline
+{
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
+    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
+    private sealed class EmitBaselineArgs
+    {
+        public FileInfo? AssemblyPath { get; set; }
+        public string? Output { get; set; }
+    }
+
+    public static Command Create()
+    {
+        var cmd = new Command("baseline", "Creates an API baseline")
+        {
+            new Option<string>(
+                new[] { "-o", "--output" },
+                "Path of the baseline file to produce"),
+        };
+
+        cmd.Handler = CommandHandler.Create<EmitBaselineArgs>(ExecuteAsync);
+        return cmd;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Catching for proper error reporting.")]
+    private static async Task<int> ExecuteAsync(EmitBaselineArgs args)
+    {
+        ApiModel model;
+        try
+        {
+            model = ApiModel.LoadFromAssembly(args.AssemblyPath!.FullName);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to decompile assembly '{args.AssemblyPath!.FullName}': {ex.Message}");
+            return -1;
+        }
+
+        var result = model.ToString();
+
+        if (args.Output == null)
+        {
+            Console.Write(result);
+        }
+        else
+        {
+            try
+            {
+                await File.WriteAllTextAsync(args.Output, result);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Unable to write output baseline report '{args.Output}': {ex.Message}");
+                return -1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/eng/Tools/ApiChief/Commands/EmitDelta.cs
+++ b/eng/Tools/ApiChief/Commands/EmitDelta.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using ApiChief.Model;
+
+namespace ApiChief.Commands;
+
+internal static class EmitDelta
+{
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
+    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
+    private sealed class EmitDeltaArgs
+    {
+        public FileInfo? AssemblyPath { get; set; }
+
+        public string BaselinePath { get; set; } = string.Empty;
+
+        public string? Output { get; set; }
+    }
+
+    public static Command Create()
+    {
+        var command = new Command("delta", "Creates an API delta")
+        {
+            new Argument<string>("baseline-path", "Path to the baseline report to use for reference"),
+
+            new Option<string>(
+                new[] { "-o", "--output" },
+                "Path of the delta file to produce"),
+        };
+
+        command.Handler = CommandHandler.Create<EmitDeltaArgs>(ExecuteAsync);
+        return command;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Catching for proper error reporting.")]
+    private static async Task<int> ExecuteAsync(EmitDeltaArgs args)
+    {
+        ApiModel current;
+        ApiModel baseline;
+
+        try
+        {
+            current = ApiModel.LoadFromAssembly(args.AssemblyPath!.FullName);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to decompile assembly '{args.AssemblyPath!.FullName}': {ex.Message}");
+            return -1;
+        }
+
+        try
+        {
+            baseline = ApiModel.LoadFromFile(args.BaselinePath);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load baseline report '{args.BaselinePath}': {ex.Message}");
+            return -1;
+        }
+
+        baseline.EvaluateDelta(current);
+
+        var result = current.ToString();
+
+        if (args.Output == null)
+        {
+            Console.Write(result);
+        }
+        else
+        {
+            try
+            {
+                await File.WriteAllTextAsync(args.Output, result);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Unable to write output delta report '{args.Output}': {ex.Message}");
+                return -1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/eng/Tools/ApiChief/Commands/EmitReview.cs
+++ b/eng/Tools/ApiChief/Commands/EmitReview.cs
@@ -1,0 +1,247 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ApiChief.Format;
+using ApiChief.Processing;
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ApiChief.Commands;
+
+internal static class EmitReview
+{
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
+    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
+    private sealed class EmitReviewArgs
+    {
+        public FileInfo? AssemblyPath { get; set; }
+        public string? Output { get; set; }
+        public bool GroupByNamespace { get; set; }
+    }
+
+    public static Command Create()
+    {
+        var command = new Command("review", "Produces a folder with files to submit for API reviews")
+        {
+            new Option<string>(
+                new[] { "-o", "--output" },
+                "Path of the directory to receive the API review files"),
+
+            new Option<bool>(
+                new[] { "-n", "--group-by-namespace" },
+                "Group output by namespace rather than assembly"),
+        };
+
+        command.Handler = CommandHandler.Create<EmitReviewArgs>(ExecuteAsync);
+        return command;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Catching for proper error reporting.")]
+    private static async Task<int> ExecuteAsync(EmitReviewArgs args)
+    {
+        // once with XML comments, once without
+#pragma warning disable S109 // Magic numbers should not be used
+        for (int i = 0; i < 2; i++)
+        {
+            var formatting = Formatter.FormattingWithXmlComments;
+            var outputAsmDep = true;
+            var sub = "WithDocs";
+            var omitXmlComments = false;
+
+            if (i == 1)
+            {
+                formatting = Formatter.BaselineFormatting;
+                outputAsmDep = false;
+                sub = "NoDocs";
+                omitXmlComments = true;
+            }
+
+            if (args.GroupByNamespace)
+            {
+                outputAsmDep = false;
+            }
+
+            CSharpDecompiler decompiler;
+            try
+            {
+                var path = args.AssemblyPath!.FullName;
+
+                var decompilerSettings = new DecompilerSettings(LanguageVersion.Latest)
+                {
+                    DecompileMemberBodies = false,
+                    ExpandUsingDeclarations = true,
+                    UsingDeclarations = true,
+                    ShowXmlDocumentation = false,
+                    CSharpFormattingOptions = Formatter.BaselineFormatting,
+                    AsyncAwait = false,
+                    AlwaysShowEnumMemberValues = true,
+                };
+
+                if (!omitXmlComments)
+                {
+                    decompilerSettings.CSharpFormattingOptions = Formatter.FormattingWithXmlComments;
+                    decompilerSettings.ShowXmlDocumentation = true;
+                }
+
+                decompiler = new(path, decompilerSettings);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Unable to decompile assembly '{args.AssemblyPath!.FullName}': {ex.Message}");
+                return -1;
+            }
+
+            var output = args.Output;
+            if (args.GroupByNamespace)
+            {
+                if (output == null)
+                {
+                    output = "API";
+                }
+            }
+            else
+            {
+                if (output == null)
+                {
+                    output = "API." + decompiler.TypeSystem.MainModule.AssemblyName;
+                }
+                else
+                {
+                    output = Path.Combine(output, decompiler.TypeSystem.MainModule.AssemblyName);
+                }
+            }
+
+            if (outputAsmDep)
+            {
+                var sb = new StringBuilder();
+                foreach (var m in decompiler.TypeSystem.ReferencedModules.OrderBy(m => m.AssemblyName))
+                {
+                    sb.AppendLine(m.AssemblyName);
+                }
+
+                try
+                {
+                    Directory.CreateDirectory(output);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Unable to create output directory '{args.Output}': {ex.Message}");
+                    return -1;
+                }
+
+                var asmDepFile = Path.Combine(output, "AssemblyDependencies.txt");
+                try
+                {
+                    await File.WriteAllTextAsync(asmDepFile, sb.ToString());
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Unable to write API dependency file '{asmDepFile}': {ex.Message}");
+                    return -1;
+                }
+            }
+
+            output += "/" + sub;
+
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var type in decompiler.TypeSystem.GetTopLevelTypeDefinitions().OrderBy(t => t.MetadataName))
+            {
+                var acc = type.EffectiveAccessibility();
+                if (acc is not Accessibility.Public and not Accessibility.Protected and not Accessibility.ProtectedOrInternal)
+                {
+                    continue;
+                }
+
+                if (type.ParentModule == null || !type.ParentModule.IsMainModule)
+                {
+                    continue;
+                }
+
+                var syntaxTree = decompiler.DecompileType(type.FullTypeName);
+
+                // remove private stuff from the tree
+                syntaxTree.AcceptVisitor(new PublicFilterVisitor());
+
+                using var writer = new StringWriter();
+
+                writer.WriteLine($"// Assembly '{type.ParentModule.AssemblyName}'");
+                writer.WriteLine();
+
+                var visitor = new CSharpOutputVisitor(writer, formatting);
+                syntaxTree.AcceptVisitor(visitor);
+                var result = writer.ToString();
+
+                var file = type.FullName.Replace("<", "_").Replace(">", "_");
+                var index = file.LastIndexOf(".", StringComparison.OrdinalIgnoreCase);
+                if (index >= 0)
+                {
+                    file = file.Substring(0, index) + "/" + file.Substring(index + 1);
+                }
+
+                var dir = Path.GetDirectoryName(file) ?? string.Empty;
+                var fullDir = Path.Combine(output, dir);
+                var fullFile = Path.Combine(fullDir, Path.GetFileName(file));
+
+                var tmp = fullFile;
+
+                if (names.Contains(tmp))
+                {
+                    if (type.TypeParameters.Count > 0)
+                    {
+                        var sb = new StringBuilder();
+                        foreach (var t in type.TypeParameters)
+                        {
+                            sb.Append('.');
+                            sb.Append(t.Name);
+                        }
+
+                        tmp += sb;
+                    }
+
+                    var count = 2;
+                    while (names.Contains(tmp))
+                    {
+                        tmp = fullFile + "_" + count++;
+                    }
+                }
+
+                names.Add(tmp);
+                fullFile = tmp + ".cs";
+
+                try
+                {
+                    Directory.CreateDirectory(fullDir);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Unable to create output directory '{fullDir}': {ex.Message}");
+                    return -1;
+                }
+
+                try
+                {
+                    await File.WriteAllTextAsync(fullFile, result);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Unable to write output API review file '{fullFile}': {ex.Message}");
+                    return -1;
+                }
+            }
+        }
+#pragma warning restore S109 // Magic numbers should not be used
+
+        return 0;
+    }
+}

--- a/eng/Tools/ApiChief/Commands/EmitSummary.cs
+++ b/eng/Tools/ApiChief/Commands/EmitSummary.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using ApiChief.Format;
+using ApiChief.Processing;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+
+namespace ApiChief.Commands;
+
+internal static class EmitSummary
+{
+    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Written through reflection.")]
+    [SuppressMessage("Major Code Smell", "S1144:Unused private types or members should be removed", Justification = "Written through reflection.")]
+    private sealed class EmitSummaryArgs
+    {
+        public FileInfo? AssemblyPath { get; set; }
+        public string? Output { get; set; }
+        public bool OmitXmlComments { get; set; }
+    }
+
+    public static Command Create()
+    {
+        var command = new Command("summary", "Creates an API summary")
+        {
+            new Option<string>(
+                new[] { "-o", "--output" },
+                "Path of the summary file to produce"),
+
+            new Option<bool>(
+                new[] { "-x", "--omit-xml-comments" },
+                "Omit the XML documentation comments"),
+        };
+
+        command.Handler = CommandHandler.Create<EmitSummaryArgs>(ExecuteAsync);
+        return command;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Catching for proper error reporting.")]
+    private static async Task<int> ExecuteAsync(EmitSummaryArgs args)
+    {
+        var formatting = args.OmitXmlComments ? Formatter.BaselineFormatting : Formatter.FormattingWithXmlComments;
+        CSharpDecompiler decompiler;
+
+        try
+        {
+            var path = args.AssemblyPath!.FullName;
+
+            decompiler = args.OmitXmlComments
+                ? DecompilerFactory.Create(path)
+                : DecompilerFactory.CreateWithXmlComments(path);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to decompile assembly '{args.AssemblyPath!.FullName}': {ex.Message}");
+            return -1;
+        }
+
+        var syntaxTree = decompiler.DecompileWholeModuleAsSingleFile(true);
+
+        // remove private stuff from the tree
+        syntaxTree.AcceptVisitor(new PublicFilterVisitor());
+
+        using var writer = new StringWriter();
+        var visitor = new CSharpOutputVisitor(writer, formatting);
+        syntaxTree.AcceptVisitor(visitor);
+        var result = writer.ToString();
+
+        if (args.Output == null)
+        {
+            Console.Write(result);
+        }
+        else
+        {
+            try
+            {
+                await File.WriteAllTextAsync(args.Output, result);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Unable to write output summary file '{args.Output}': {ex.Message}");
+                return -1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/eng/Tools/ApiChief/Format/DecompilerFactory.cs
+++ b/eng/Tools/ApiChief/Format/DecompilerFactory.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+
+namespace ApiChief.Format;
+
+internal static class DecompilerFactory
+{
+    private static readonly DecompilerSettings _decompilerSettings = new()
+    {
+        DecompileMemberBodies = false,
+        ShowXmlDocumentation = false,
+        ExpandUsingDeclarations = false,
+        UsingDeclarations = false,
+        ReadOnlyMethods = true,
+        AlwaysShowEnumMemberValues = true,
+        FileScopedNamespaces = true,
+        InitAccessors = true,
+        IntroduceRefModifiersOnStructs = true,
+        IntroduceReadonlyAndInModifiers = true,
+        RecordClasses = true,
+        CovariantReturns = true,
+        AutomaticProperties = true,
+        GetterOnlyAutomaticProperties = true,
+        NullPropagation = true,
+        NullableReferenceTypes = true,
+        OptionalArguments = true,
+        OutVariables = true,
+        LiftNullables = true,
+        CSharpFormattingOptions = Formatter.BaselineFormatting
+    };
+
+    public static CSharpDecompiler Create(string path) => new(path, _decompilerSettings);
+
+    public static CSharpDecompiler CreateWithXmlComments(string path)
+    {
+        var xmlCommentsSettings = _decompilerSettings.Clone();
+
+        xmlCommentsSettings.CSharpFormattingOptions = Formatter.FormattingWithXmlComments;
+        xmlCommentsSettings.ShowXmlDocumentation = true;
+
+        return new(path, xmlCommentsSettings);
+    }
+}

--- a/eng/Tools/ApiChief/Format/Formatter.cs
+++ b/eng/Tools/ApiChief/Format/Formatter.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using ApiChief.Processing;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.Output;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ApiChief.Format;
+
+internal static class Formatter
+{
+    private static readonly CSharpAmbience _typeAmbience = new()
+    {
+        ConversionFlags = ConversionFlags.All & ~(ConversionFlags.ShowAccessibility | ConversionFlags.PlaceReturnTypeAfterParameterList)
+    };
+
+    private static readonly CSharpAmbience _fieldAmbience = new()
+    {
+        ConversionFlags =
+                    ConversionFlags.ShowModifiers |
+                    ConversionFlags.ShowParameterDefaultValues |
+                    ConversionFlags.ShowParameterList |
+                    ConversionFlags.ShowParameterModifiers |
+                    ConversionFlags.ShowTypeParameterList |
+                    ConversionFlags.ShowReturnType |
+                    ConversionFlags.SupportInitAccessors |
+                    ConversionFlags.SupportRecordClasses |
+                    ConversionFlags.UseFullyQualifiedEntityNames |
+                    ConversionFlags.UseNullableSpecifierForValueTypes |
+                    ConversionFlags.ShowDeclaringType |
+                    ConversionFlags.UseFullyQualifiedTypeNames
+    };
+
+    private static readonly CSharpAmbience _propertyAmbience = new()
+    {
+        ConversionFlags =
+            ConversionFlags.All
+                & ~(ConversionFlags.PlaceReturnTypeAfterParameterList
+                | ConversionFlags.ShowAccessibility
+                | ConversionFlags.ShowTypeParameterVarianceModifier),
+    };
+
+    private static readonly CSharpAmbience _methodAmbience = new()
+    {
+        ConversionFlags =
+            ConversionFlags.All
+                & ~(ConversionFlags.PlaceReturnTypeAfterParameterList
+                | ConversionFlags.ShowAccessibility
+                | ConversionFlags.ShowTypeParameterVarianceModifier),
+    };
+
+    private static readonly CSharpAmbience _implicitOperatorAmbience = new()
+    {
+        ConversionFlags =
+            ConversionFlags.All
+                    & ~(ConversionFlags.PlaceReturnTypeAfterParameterList
+                    | ConversionFlags.ShowAccessibility
+                    | ConversionFlags.ShowReturnType
+                    | ConversionFlags.ShowTypeParameterVarianceModifier),
+    };
+
+    public static CSharpFormattingOptions BaselineFormatting { get; } = GetBaselineFormatting();
+
+    public static CSharpFormattingOptions FormattingWithXmlComments { get; } = GetFormattingWithXmlComments();
+
+    public static string TypeToString(ITypeDefinition type, CSharpDecompiler decompiler)
+    {
+        if (type.Kind == TypeKind.Delegate)
+        {
+            return _typeAmbience.ConvertSymbol(type).WithSpaceBetweenParameters().Replace(";", string.Empty);
+        }
+
+        var syntaxTree = decompiler.DecompileType(type.FullTypeName);
+
+        using var writer = new StringWriter();
+        var visitor = new FullyQualifiedTypeNameVisitor(writer, BaselineFormatting);
+        syntaxTree.AcceptVisitor(visitor);
+
+        return writer.ToString();
+    }
+
+    public static string NestedTypeToString(ITypeDefinition nested)
+        => _typeAmbience.ConvertSymbol(nested).WithSpaceBetweenParameters();
+
+    public static string PropertyToString(IProperty property)
+    {
+        using var writer = new StringWriter();
+        _propertyAmbience.ConvertSymbol(property, new TextWriterTokenWriter(writer), BaselineFormatting);
+
+        var propertyString = writer.ToString()
+            .WithSpaceBetweenParameters();
+
+        return property.Setter?.Accessibility switch
+        {
+            Accessibility.Private => propertyString.Replace("set;", "private set;"),
+            Accessibility.Protected => propertyString.Replace("set;", "protected set;"),
+            Accessibility.Internal => propertyString.Replace("set;", "internal set;"),
+            Accessibility.ProtectedOrInternal => propertyString.Replace("set;", "protected internal set;"),
+            _ => propertyString
+        };
+    }
+
+    public static string MethodToString(IMethod method)
+    {
+        var ambience = method.IsOperator && (method.Name == "op_Implicit" || method.Name == "op_Explicit")
+            ? _implicitOperatorAmbience
+            : _methodAmbience;
+
+        using var writer = new StringWriter();
+        ambience.ConvertSymbol(method, new TextWriterTokenWriter(writer), BaselineFormatting);
+
+        return writer.ToString()
+             .WithSpaceBetweenParameters()
+             .WithNumbersWithoutLiterals();
+    }
+
+    public static string FieldToString(IField field)
+        => _fieldAmbience.ConvertSymbol(field).WithSpaceBetweenParameters();
+
+    private static CSharpFormattingOptions GetBaselineFormatting()
+    {
+        var formatting = FormattingOptionsFactory.CreateAllman().Clone();
+        formatting.IndentationString = "    ";
+        formatting.MinimumBlankLinesBetweenFields = 0;
+        formatting.MinimumBlankLinesBetweenMembers = 0;
+
+        return formatting;
+    }
+
+    private static CSharpFormattingOptions GetFormattingWithXmlComments()
+    {
+        var formatting = FormattingOptionsFactory.CreateAllman().Clone();
+        formatting.IndentationString = "    ";
+        formatting.MinimumBlankLinesBetweenFields = 1;
+        formatting.MinimumBlankLinesBetweenMembers = 1;
+
+        return formatting;
+    }
+}

--- a/eng/Tools/ApiChief/Format/FormattingExtensions.cs
+++ b/eng/Tools/ApiChief/Format/FormattingExtensions.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ApiChief.Format;
+
+internal static class FormattingExtensions
+{
+    private static readonly HashSet<char> _numberLiterals = new() { 'l', 'L', 'u', 'U', 'f', 'F', 'd', 'D', 'm', 'M' };
+    private static readonly HashSet<char> _secondCharInLiterals = new() { 'l', 'L', 'u', 'U' };
+    private static readonly HashSet<char> _possibleSpecialCharactersInANumber = new() { '.', 'x', 'X', 'b', 'B' };
+
+    /// <summary>
+    /// Ensures a single space between parameters.
+    /// </summary>
+    public static string WithSpaceBetweenParameters(this string signature)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < signature.Length; i++)
+        {
+            var current = signature[i];
+            sb.Append(current);
+
+            if (current == '"')
+            {
+                var index = i + 1;
+                var next = signature[index];
+
+                while (next != '"')
+                {
+                    sb.Append(next);
+                    index++;
+                    next = signature[index];
+                }
+
+                sb.Append(next);
+#pragma warning disable S127 // "for" loop stop conditions should be invariant
+                i = index;
+#pragma warning restore S127 // "for" loop stop conditions should be invariant
+            }
+            else if (current == ',')
+            {
+                if (i + 1 < signature.Length)
+                {
+                    var next = signature[i + 1];
+
+                    if (next != ' ')
+                    {
+                        sb.Append(' ');
+                    }
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Deletes literal letters from the number.
+    /// </summary>
+    public static string WithNumbersWithoutLiterals(this string memberDecl)
+    {
+        var sb = new StringBuilder();
+
+        var inMethod = false;
+        var sawEqualitySign = false;
+
+        for (var i = 0; i < memberDecl.Length; i++)
+        {
+            var current = memberDecl[i];
+
+            if (!inMethod)
+            {
+                if (current == '(')
+                {
+                    inMethod = true;
+                }
+
+                sb.Append(current);
+
+                continue;
+            }
+
+            sb.Append(current);
+
+            if (current == ')')
+            {
+                inMethod = false;
+            }
+            else if (current == '"')
+            {
+                var initial = i + 1;
+                var next = memberDecl[initial];
+
+                while (next != '"')
+                {
+                    sb.Append(next);
+                    initial++;
+                    next = memberDecl[initial];
+                }
+
+                sb.Append(next);
+#pragma warning disable S127 // "for" loop stop conditions should be invariant
+                i = initial;
+#pragma warning restore S127 // "for" loop stop conditions should be invariant
+            }
+#pragma warning disable S2583 // Conditionally executed code should be reachable
+            else if (current == '=')
+            {
+                sawEqualitySign = true;
+            }
+            else if (char.IsDigit(current) && sawEqualitySign)
+            {
+                var initial = i + 1;
+                var next = memberDecl[initial];
+
+#pragma warning disable S1067 // Expressions should not be too complex
+                while (char.IsDigit(next) || (char.IsDigit(memberDecl[initial - 1]) && _possibleSpecialCharactersInANumber.Contains(next)))
+                {
+                    sb.Append(next);
+                    initial++;
+                    next = memberDecl[initial];
+                }
+#pragma warning restore S1067 // Expressions should not be too complex
+
+                if (!_numberLiterals.Contains(next))
+                {
+                    sb.Append(next);
+                }
+                else if (_secondCharInLiterals.Contains(memberDecl[initial + 1]))
+                {
+                    initial++;
+                }
+#pragma warning disable S127 // "for" loop stop conditions should be invariant
+                i = initial;
+#pragma warning restore S127 // "for" loop stop conditions should be invariant
+                sawEqualitySign = false;
+            }
+#pragma warning restore S2583 // Conditionally executed code should be reachable
+
+        }
+
+        return sb.ToString();
+    }
+}

--- a/eng/Tools/ApiChief/Format/ParsedMember.cs
+++ b/eng/Tools/ApiChief/Format/ParsedMember.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using ApiChief.Model;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ApiChief.Format;
+
+/// <remarks>
+/// Represents information retrieved by analyzing annotations of the entity.
+/// </remarks>
+internal class ParsedMember
+{
+    private const string ObsoleteAttribute = "System.ObsoleteAttribute";
+    private const string ExperimentalAttribute = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
+    private const string ReadonlyRefStructMessage = "Types with embedded references are not supported in this version of your compiler.";
+
+    public ApiStage Stage { get; }
+
+    public ParsedMember(IEntity entity, MetadataModule? metadata = null, ApiStage? parentStage = null)
+    {
+        Stage = ExtractStage(entity, metadata, parentStage);
+    }
+
+    /// <remarks>
+    /// C# Compiler is including `ObsoleteAttribute` for readonly ref structs with <see cref="ReadonlyRefStructMessage"/>.
+    /// It is visible only for older compilers if they want to use readonly ref struct before C# 7.3.
+    /// We want to ignore this attribute in ApiChief since it would make all our readonly ref structs marked as deprecated.
+    /// When we will deprecate readonly ref structs, the auto generated attribute will be replaced with the one we wrote, since no longer ignored by the method logic.
+    /// </remarks>
+    private static ApiStage ExtractStage(IEntity entity, MetadataModule? metadata, ApiStage? parentStage)
+    {
+        if (AssemblyIsAnnotatedAsExperimental(metadata))
+        {
+            return ApiStage.Experimental;
+        }
+
+        var type = entity as ITypeDefinition;
+        var isReadonlyRefStruct = type != null && type.Kind == TypeKind.Struct && type.IsReadOnly && type.IsByRefLike;
+
+        foreach (var attribute in entity.GetAttributes())
+        {
+            if (attribute.AttributeType.FullName == ObsoleteAttribute)
+            {
+                var firstAttributeParameter = (string?)attribute.FixedArguments.FirstOrDefault().Value ?? string.Empty;
+                var isGeneratedAttribute = firstAttributeParameter == ReadonlyRefStructMessage;
+
+                if (isReadonlyRefStruct && isGeneratedAttribute)
+                {
+                    continue;
+                }
+
+                return ApiStage.Obsolete;
+            }
+
+            if (attribute.AttributeType.FullName == ExperimentalAttribute)
+            {
+                return ApiStage.Experimental;
+            }
+        }
+
+        if (parentStage != null && parentStage != ApiStage.Stable)
+        {
+            return (ApiStage)parentStage;
+        }
+
+        return ApiStage.Stable;
+
+        static bool AssemblyIsAnnotatedAsExperimental(MetadataModule? metadata)
+            => metadata != null && metadata.GetAssemblyAttributes().Any(x => x.AttributeType.FullName == ExperimentalAttribute);
+    }
+}
+

--- a/eng/Tools/ApiChief/Model/ApiMember.cs
+++ b/eng/Tools/ApiChief/Model/ApiMember.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace ApiChief.Model;
+
+internal sealed class ApiMember : IEquatable<ApiMember>
+{
+    [JsonPropertyOrder(0)]
+    public string Member { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(1)]
+    public ApiStage Stage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a constant value (for constant field) to ensure it doesn't change between releases.
+    /// </summary>
+    [JsonPropertyOrder(2)]
+    public string? Value { get; set; }
+
+    public bool Equals(ApiMember? other) => other != null && Member == other.Member;
+    public override bool Equals(object? obj) => Equals(obj as ApiMember);
+    public override int GetHashCode() => Member.GetHashCode();
+}

--- a/eng/Tools/ApiChief/Model/ApiModel.cs
+++ b/eng/Tools/ApiChief/Model/ApiModel.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ApiChief.Format;
+using ApiChief.Processing;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ApiChief.Model;
+
+internal sealed class ApiModel
+{
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        IncludeFields = true
+    };
+
+    static ApiModel()
+    {
+        _serializerOptions.Converters.Add(new JsonStringEnumConverter());
+    }
+
+    public string Name { get; set; } = string.Empty;
+    public ISet<ApiType> Types { get; set; } = new HashSet<ApiType>();
+    public ISet<ApiType>? Additions { get; set; }
+    public ISet<ApiType>? Removals { get; set; }
+
+    public static ApiModel LoadFromAssembly(string path)
+    {
+        var decompiler = DecompilerFactory.Create(path);
+        var finalApi = new ApiModel { Name = decompiler.TypeSystem.MainModule.FullAssemblyName };
+
+        ApiProcessor.Process(finalApi, decompiler);
+
+        return finalApi;
+    }
+
+    public static ApiModel LoadFromFile(string path)
+    {
+        return JsonSerializer.Deserialize<ApiModel>(File.ReadAllText(path))!;
+    }
+
+    public void EvaluateDelta(ApiModel current)
+    {
+        current.Additions = FindAdditions(this, current);
+        current.Removals = FindAdditions(current, this);
+    }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, _serializerOptions).ReplaceLineEndings("\n");
+    }
+
+    private static ISet<ApiType>? FindAdditions(ApiModel baseline, ApiModel delta)
+    {
+        ISet<ApiType>? result = null;
+
+        foreach (var t in delta.Types)
+        {
+            if (!baseline.Types.Contains(t))
+            {
+                result ??= new HashSet<ApiType>();
+                _ = result.Add(t);
+            }
+            else
+            {
+                var baseType = baseline.Types.First(bt => bt.Equals(t));
+
+                if (t.Methods != null)
+                {
+                    foreach (var m in t.Methods)
+                    {
+                        if (baseType.Methods == null || !baseType.Methods.Contains(m))
+                        {
+                            result ??= new HashSet<ApiType>();
+
+                            var type = result.First(dt => dt.Equals(t));
+                            if (type == null)
+                            {
+                                type = new ApiType
+                                {
+                                    Type = t.Type,
+                                    Stage = t.Stage,
+                                };
+
+                                result.Add(type);
+                            }
+
+                            type.Methods ??= new HashSet<ApiMember>();
+                            _ = type.Methods!.Add(m);
+                        }
+                    }
+                }
+
+                if (t.Fields != null)
+                {
+                    foreach (var f in t.Fields)
+                    {
+                        if (baseType.Fields == null || !baseType.Fields.Contains(f))
+                        {
+                            result ??= new HashSet<ApiType>();
+
+                            var type = result.First(dt => dt.Equals(t));
+                            if (type == null)
+                            {
+                                type = new ApiType
+                                {
+                                    Type = t.Type,
+                                    Stage = t.Stage,
+                                };
+
+                                result.Add(type);
+                            }
+
+                            type.Fields ??= new HashSet<ApiMember>();
+                            _ = type.Fields.Add(f);
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/eng/Tools/ApiChief/Model/ApiStage.cs
+++ b/eng/Tools/ApiChief/Model/ApiStage.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ApiChief.Model;
+
+internal enum ApiStage
+{
+    Experimental,
+    Stable,
+    Obsolete,
+}

--- a/eng/Tools/ApiChief/Model/ApiType.cs
+++ b/eng/Tools/ApiChief/Model/ApiType.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ApiChief.Model;
+
+internal sealed class ApiType : IEquatable<ApiType>
+{
+    [JsonIgnore]
+    public string FullTypeName { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(0)]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(1)]
+    public ApiStage Stage { get; set; }
+
+    [JsonPropertyOrder(2)]
+    public ISet<ApiMember>? Methods;
+
+    [JsonPropertyOrder(3)]
+    public ISet<ApiMember>? Fields;
+
+    [JsonPropertyOrder(4)]
+    public ISet<ApiMember>? Properties;
+
+    public bool Equals(ApiType? other) => other != null && Type == other.Type;
+    public override bool Equals(object? obj) => Equals(obj as ApiType);
+    public override int GetHashCode() => Type.GetHashCode();
+}

--- a/eng/Tools/ApiChief/Processing/ApiProcessor.cs
+++ b/eng/Tools/ApiChief/Processing/ApiProcessor.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using ApiChief.Format;
+using ApiChief.Model;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ApiChief.Processing;
+
+internal class ApiProcessor
+{
+    /// <remarks>
+    /// This function is mutating the state of the passed <paramref name="finalApi"/>.
+    /// </remarks>
+    public static void Process(ApiModel finalApi, CSharpDecompiler decompiler)
+    {
+        var publicTypes = decompiler.TypeSystem.MainModule.TypeDefinitions
+            .Where<ITypeDefinition>(type => FilterPublicTypes(type))
+            .OrderBy(type => type.Name);
+
+        foreach (var currentType in publicTypes)
+        {
+            var typeString = Formatter.TypeToString(currentType, decompiler);
+            var parsedCurrentType = new ParsedMember(currentType, decompiler.TypeSystem.MainModule);
+            var currentTypeModel = new ApiType
+            {
+                Type = typeString,
+                Stage = parsedCurrentType.Stage,
+                FullTypeName = currentType.FullTypeName.Name
+            };
+
+            if (!finalApi.Types.Add(currentTypeModel))
+            {
+                currentTypeModel = finalApi.Types.First(x => x.Type == currentTypeModel.Type);
+
+                var detectedNestedTypeThatWasDecompiledTwice = currentTypeModel.FullTypeName != currentType.FullTypeName.Name;
+
+                if (detectedNestedTypeThatWasDecompiledTwice)
+                {
+                    continue;
+                }
+            }
+
+            if (currentType.Kind == TypeKind.Delegate)
+            {
+                continue;
+            }
+
+            ProcessType(finalApi, currentType, currentTypeModel, parsedCurrentType.Stage);
+        }
+
+        static bool FilterPublicTypes(ITypeDefinition type)
+            => type.EffectiveAccessibility() == Accessibility.Public;
+    }
+
+    private static void ProcessType(ApiModel finalApi, ITypeDefinition type, ApiType finalTypeApi, ApiStage classStage)
+    {
+        ProcessNestedTypes(finalApi, type, classStage);
+        ProcessMethods(type, finalTypeApi, classStage);
+        ProcessProperties(type, finalTypeApi, classStage);
+        ProcessFields(type, finalTypeApi, classStage);
+    }
+
+    private static void ProcessFields(ITypeDefinition type, ApiType finalTypeApi, ApiStage classStage)
+    {
+        var fields = type.Fields
+            .Where(field => FilterFields(field, type))
+            .OrderBy(field => field.Name);
+
+        foreach (var field in fields)
+        {
+            var fieldString = Formatter.FieldToString(field);
+
+            if (fieldString.EndsWith("value__"))
+            {
+                continue;
+            }
+
+            var parsedMember = new ParsedMember(field, parentStage: classStage);
+            var serializationModel = new ApiMember
+            {
+                Member = fieldString,
+                Stage = parsedMember.Stage,
+                Value = field.GetConstantValue()?.ToString(),
+            };
+
+            finalTypeApi.Fields ??= new HashSet<ApiMember>();
+            finalTypeApi.Fields.Add(serializationModel);
+        }
+
+        static bool FilterFields(IField field, ITypeDefinition type)
+            => (field.EffectiveAccessibility() == Accessibility.Public || field.EffectiveAccessibility() == Accessibility.Protected)
+                && field.DeclaringType.Equals(type);
+    }
+
+    private static void ProcessProperties(ITypeDefinition type, ApiType finalTypeApi, ApiStage classStage)
+    {
+        var properties = type.Properties
+            .Where(property => FilterProperties(property, type))
+            .OrderBy(property => property.Name);
+
+        foreach (var property in properties)
+        {
+            var propertyString = Formatter.PropertyToString(property);
+            var parsedMember = new ParsedMember(property, parentStage: classStage);
+            var serializationModel = new ApiMember
+            {
+                Member = propertyString,
+                Stage = parsedMember.Stage,
+            };
+
+            finalTypeApi.Properties ??= new HashSet<ApiMember>();
+            finalTypeApi.Properties.Add(serializationModel);
+        }
+
+        static bool FilterProperties(IProperty property, ITypeDefinition type)
+            => (property.EffectiveAccessibility() == Accessibility.Public || property.EffectiveAccessibility() == Accessibility.Protected)
+                && property.DeclaringType.Equals(type);
+    }
+
+    [SuppressMessage("Critical Code Smell", "S1067:Expressions should not be too complex", Justification = "Cannot reduce it.")]
+    private static void ProcessMethods(ITypeDefinition type, ApiType finalTypeApi, ApiStage classStage)
+    {
+        var methods = type.Methods
+            .Where(method => FilterMethods(method, type))
+            .OrderBy(method => method.Name);
+
+        foreach (var method in methods)
+        {
+            var methodString = Formatter.MethodToString(method);
+            var parsedMember = new ParsedMember(method, parentStage: classStage);
+
+            var serializationModel = new ApiMember
+            {
+                Member = methodString,
+                Stage = parsedMember.Stage,
+            };
+
+            finalTypeApi.Methods ??= new HashSet<ApiMember>();
+            finalTypeApi.Methods.Add(serializationModel);
+        }
+
+        static bool FilterMethods(IMethod method, ITypeDefinition type)
+            => (method.EffectiveAccessibility() == Accessibility.Public || method.EffectiveAccessibility() == Accessibility.Protected)
+                && method.DeclaringType.Equals(type);
+    }
+
+    private static void ProcessNestedTypes(ApiModel finalApi, ITypeDefinition type, ApiStage classStage)
+    {
+        var nestedTypes = type.NestedTypes
+            .Where(nested => FilterNestedTypes(nested))
+            .OrderBy(nested => nested.Name);
+
+        foreach (var nested in nestedTypes)
+        {
+            var nestedString = Formatter.NestedTypeToString(nested);
+            var parsedMember = new ParsedMember(nested, parentStage: classStage);
+            var serializationModel = new ApiType
+            {
+                Type = nestedString,
+                Stage = parsedMember.Stage,
+            };
+
+            ProcessType(finalApi, nested, serializationModel, parsedMember.Stage);
+
+            finalApi.Types.Add(serializationModel);
+        }
+
+        static bool FilterNestedTypes(ITypeDefinition nested)
+            => (nested.EffectiveAccessibility() == Accessibility.Public || nested.EffectiveAccessibility() == Accessibility.Protected)
+                && nested.Kind != TypeKind.Delegate;
+    }
+}

--- a/eng/Tools/ApiChief/Processing/FullyQualifiedTypeNameVisitor.cs
+++ b/eng/Tools/ApiChief/Processing/FullyQualifiedTypeNameVisitor.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+
+namespace ApiChief.Processing;
+
+/// <summary>
+/// Visitor that produces a fully-qualified type signature.
+/// </summary>
+/// <remarks>
+/// This probably doesn't do the right thing for nested types, we'll eventually see...
+/// </remarks>
+internal sealed class FullyQualifiedTypeNameVisitor : CSharpOutputVisitor
+{
+    public FullyQualifiedTypeNameVisitor(TextWriter tw, CSharpFormattingOptions formatting)
+        : base(tw, formatting)
+    {
+    }
+
+    protected override void WriteCommaSeparatedList(IEnumerable<AstNode> list)
+    {
+        bool isFirst = true;
+        foreach (AstNode node in list)
+        {
+            if (isFirst)
+            {
+                isFirst = false;
+            }
+            else
+            {
+                Comma(node);
+                Space();
+            }
+
+            node.AcceptVisitor(this);
+
+            if (node.Role == Roles.TypeParameter)
+            {
+                if (node.ToString().EndsWith('?'))
+                {
+                    WriteToken(ComposedType.NullableRole);
+                }
+            }
+        }
+    }
+
+    protected override void WriteModifiers(IEnumerable<CSharpModifierToken> modifierTokens)
+    {
+        foreach (CSharpModifierToken modifier in modifierTokens)
+        {
+            if (modifier.Modifier == Modifiers.Public)
+            {
+                continue;
+            }
+
+            modifier.AcceptVisitor(this);
+            Space();
+        }
+    }
+
+    public override void VisitNamespaceDeclaration(NamespaceDeclaration namespaceDeclaration)
+    {
+        StartNode(namespaceDeclaration);
+
+        foreach (var member in namespaceDeclaration.Members)
+        {
+            member.AcceptVisitor(this);
+        }
+
+        EndNode(namespaceDeclaration);
+    }
+
+    public override void VisitTypeDeclaration(TypeDeclaration typeDeclaration)
+    {
+        StartNode(typeDeclaration);
+        WriteModifiers(typeDeclaration.ModifierTokens);
+
+        switch (typeDeclaration.ClassType)
+        {
+            case ClassType.Enum:
+                WriteKeyword(Roles.EnumKeyword);
+                break;
+            case ClassType.Interface:
+                WriteKeyword(Roles.InterfaceKeyword);
+                break;
+            case ClassType.Struct:
+                WriteKeyword(Roles.StructKeyword);
+                break;
+            case ClassType.RecordClass:
+                WriteKeyword(Roles.RecordKeyword);
+                break;
+            default:
+                WriteKeyword(Roles.ClassKeyword);
+                break;
+        }
+
+        var @namespace = typeDeclaration.Parent as NamespaceDeclaration;
+
+        if (@namespace != null)
+        {
+            var all = @namespace.Identifiers.Append(typeDeclaration.Name).Select(s => Identifier.Create(s));
+            WriteQualifiedIdentifier(all);
+        }
+        else
+        {
+            WriteIdentifier(typeDeclaration.NameToken);
+        }
+
+        WriteTypeParameters(typeDeclaration.TypeParameters);
+
+        if (typeDeclaration.PrimaryConstructorParameters.Count > 0)
+        {
+            Space(policy.SpaceBeforeMethodDeclarationParentheses);
+            WriteCommaSeparatedListInParenthesis(typeDeclaration.PrimaryConstructorParameters, policy.SpaceWithinMethodDeclarationParentheses);
+        }
+
+        if (typeDeclaration.BaseTypes.Any())
+        {
+            Space();
+            WriteToken(Roles.Colon);
+            Space();
+
+            WriteCommaSeparatedList(typeDeclaration.BaseTypes);
+        }
+
+        foreach (var constraint in typeDeclaration.Constraints)
+        {
+            constraint.AcceptVisitor(this);
+        }
+
+        EndNode(typeDeclaration);
+    }
+}

--- a/eng/Tools/ApiChief/Processing/PublicFilterVisitor.cs
+++ b/eng/Tools/ApiChief/Processing/PublicFilterVisitor.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Linq;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+
+namespace ApiChief.Processing;
+
+/// <summary>
+/// A visitor that removes non-public entities from the AST.
+/// </summary>
+internal sealed class PublicFilterVisitor : CSharpOutputVisitor
+{
+    public PublicFilterVisitor()
+        : base(StringWriter.Null, FormattingOptionsFactory.CreateEmpty())
+    {
+    }
+
+    private static bool RemoveNonPublicEntity(EntityDeclaration entityDeclaration)
+    {
+        if (entityDeclaration.HasModifier(Modifiers.Public)
+            || (entityDeclaration.HasModifier(Modifiers.Protected) && !entityDeclaration.HasModifier(Modifiers.Private)))
+        {
+            return false;
+        }
+
+        RemoveEntity(entityDeclaration);
+        return true;
+    }
+
+    private static void RemoveEntity(EntityDeclaration entityDeclaration)
+    {
+        var node = entityDeclaration.PrevSibling;
+
+        while (node is Attribute attribute)
+        {
+            node = node.PrevSibling;
+            attribute.Remove();
+        }
+
+        while (node is Comment comment)
+        {
+            node = node.PrevSibling;
+
+            if (comment.CommentType == CommentType.Documentation)
+            {
+                comment.Remove();
+            }
+        }
+
+        entityDeclaration.Remove();
+    }
+
+    public override void VisitTypeDeclaration(TypeDeclaration typeDeclaration)
+    {
+        if (!RemoveNonPublicEntity(typeDeclaration))
+        {
+            base.VisitTypeDeclaration(typeDeclaration);
+
+            if (typeDeclaration != typeDeclaration.Parent?.LastChild)
+            {
+                NewLine();
+            }
+        }
+    }
+
+    public override void VisitMethodDeclaration(MethodDeclaration methodDeclaration)
+    {
+        var type = (TypeDeclaration)methodDeclaration.Parent!;
+        if (type.ClassType == ClassType.Interface || !RemoveNonPublicEntity(methodDeclaration))
+        {
+            foreach (var attribute in methodDeclaration.Attributes)
+            {
+                var s = attribute.ToString();
+                if (s.Contains("SkipLocalsInit")
+                    || s.Contains("ExcludeFromCodeCoverage")
+                    || s.Contains("DebuggerStepThrough")
+                    || s.Contains("AsyncStateMachine"))
+                {
+                    attribute.Remove();
+                }
+            }
+
+            base.VisitMethodDeclaration(methodDeclaration);
+        }
+    }
+
+    public override void VisitConstructorDeclaration(ConstructorDeclaration constructorDeclaration)
+    {
+        if (!RemoveNonPublicEntity(constructorDeclaration))
+        {
+            base.VisitConstructorDeclaration(constructorDeclaration);
+        }
+    }
+
+    public override void VisitFieldDeclaration(FieldDeclaration fieldDeclaration)
+    {
+        if (!RemoveNonPublicEntity(fieldDeclaration))
+        {
+            base.VisitFieldDeclaration(fieldDeclaration);
+        }
+    }
+
+    public override void VisitEventDeclaration(EventDeclaration eventDeclaration)
+    {
+        var type = (TypeDeclaration)eventDeclaration.Parent!;
+        if (type.ClassType == ClassType.Interface || !RemoveNonPublicEntity(eventDeclaration))
+        {
+            base.VisitEventDeclaration(eventDeclaration);
+        }
+    }
+
+    public override void VisitPropertyDeclaration(PropertyDeclaration propertyDeclaration)
+    {
+        var type = (TypeDeclaration)propertyDeclaration.Parent!;
+        if (type.ClassType == ClassType.Interface || !RemoveNonPublicEntity(propertyDeclaration))
+        {
+            base.VisitPropertyDeclaration(propertyDeclaration);
+        }
+    }
+
+    public override void VisitAccessor(Accessor accessor)
+    {
+        var type = (TypeDeclaration)accessor.Parent!.Parent!;
+
+        if (accessor.Attributes != null)
+        {
+            foreach (var attributeSection in accessor.Attributes)
+            {
+                foreach (var attribute in attributeSection.Attributes)
+                {
+                    var s = attribute.ToString();
+                    if (s == "CompilerGenerated")
+                    {
+                        attribute.Remove();
+                        break;
+                    }
+                }
+
+                if (attributeSection.Attributes.Count == 0)
+                {
+                    attributeSection.Remove();
+                    break;
+                }
+            }
+        }
+
+        if (type.ClassType == ClassType.Interface || accessor.Modifiers == Modifiers.None)
+        {
+            base.VisitAccessor(accessor);
+        }
+        else
+        {
+            RemoveEntity(accessor);
+        }
+    }
+
+    public override void VisitNamespaceDeclaration(NamespaceDeclaration namespaceDeclaration)
+    {
+        base.VisitNamespaceDeclaration(namespaceDeclaration);
+
+        var count = namespaceDeclaration.Children.Count();
+
+        if (count == 1)
+        {
+            namespaceDeclaration.Remove();
+        }
+    }
+}

--- a/eng/Tools/ApiChief/Program.cs
+++ b/eng/Tools/ApiChief/Program.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.IO;
+using System.Threading.Tasks;
+using ApiChief.Commands;
+
+namespace ApiChief;
+
+internal static class Program
+{
+    public static Task<int> Main(string[] args)
+    {
+        var rootCommand = new RootCommand("Helps with .NET API management activities")
+        {
+            new Argument<FileInfo>("assembly-path", "Path to the assembly to work with.").ExistingOnly(),
+
+            new Command("emit", "Emits a file resulting from processing the assembly")
+            {
+                EmitBaseline.Create(),
+                EmitDelta.Create(),
+                EmitSummary.Create(),
+                EmitReview.Create(),
+            },
+
+            new Command("check", "Performs checks on the assembly")
+            {
+                CheckBreakingChanges.Create(),
+            }
+        };
+
+        return rootCommand.InvokeAsync(args);
+    }
+}

--- a/eng/Tools/ApiChief/README.md
+++ b/eng/Tools/ApiChief/README.md
@@ -1,0 +1,61 @@
+# About This Project
+
+ApiChief is designed to help with API management activities. It provides five features:
+
+* Prints a human-friendly summary of the public API of an assembly.
+
+* Outputs a YAML file representing a fingerprint of the public API of an assembly.
+
+* Outputs a YAML file representing a delta between a previously captured fingerprint and a current assembly.
+
+* Fails if breaking changes are detected in an assembly relative to a previously captured fingerprint.
+
+* Outputs API review files, needed to perform API reviews.
+
+## Summary
+
+You can output a summary of the public API of an assembly with:
+
+```
+ApiChief MyAssembly.dll emit summary
+```
+
+Use the -o option to specify a file where the output should be stored.
+
+## Baseline
+
+You can output a YAML file that represents a fingerprint of the public API of an assembly using:
+
+```
+ApiChief MyAssembly.dll emit baseline
+```
+
+Use the -o option to specify a file where the baseline should be stored.
+
+## Delta
+
+You can output a YAML file that captures the delta between a previously-captured fingerprint and an assembly:
+
+```
+ApiChief MyAssembly.dll delta MyPreviousBaseline.yml
+```
+
+Use the -o option to specify a file where the delta information should be stored.
+
+## Breaking Changes
+
+You can cause the command to return a failure code (useful from scripts) whenever an assembly's API
+contains breaking changes relative to a previous API baseline fingerprint:
+
+```
+ApiChief MyAssembly.dll breaking MyPreviousBaseline.yml
+```
+
+## API Reviews
+
+You can output a folder containing files that capture the public API surface of an
+assembly, in a form suitable for performing API reviews.
+
+```
+ApiChief MyAssembly.dll emit review
+```

--- a/eng/Tools/DiagConfig/ConfigStore/Analyzer.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Analyzer.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace DiagConfig.ConfigStore;
+
+internal sealed class Analyzer
+{
+    public Origin? Origin { get; set; }
+    public IDictionary<string, Diagnostic> Diagnostics { get; set; } = new SortedDictionary<string, Diagnostic>();
+}

--- a/eng/Tools/DiagConfig/ConfigStore/Diagnostic.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Diagnostic.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace DiagConfig.ConfigStore;
+
+internal sealed class Diagnostic
+{
+    public Metadata Metadata { get; set; } = new Metadata();
+    public int Tier { get; set; } = 1;
+    public IDictionary<string, DiagnosticSetting?> Attributes { get; set; } = new Dictionary<string, DiagnosticSetting?>();
+}

--- a/eng/Tools/DiagConfig/ConfigStore/DiagnosticSetting.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/DiagnosticSetting.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace DiagConfig.ConfigStore;
+
+internal sealed class DiagnosticSetting
+{
+    public Severity Severity { get; set; }
+    public string? Comment { get; set; }
+    public string? Redundant { get; set; }
+    public IList<string>? Options { get; set; }
+}

--- a/eng/Tools/DiagConfig/ConfigStore/Metadata.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Metadata.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace DiagConfig.ConfigStore;
+
+internal sealed class Metadata
+{
+    public string Category { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+#pragma warning disable S3996 // URI properties should not be strings
+    public string? HelpLinkUri { get; set; }
+#pragma warning restore S3996 // URI properties should not be strings
+    public IList<string>? CustomTags { get; set; }
+    public Severity DefaultSeverity { get; set; }
+}

--- a/eng/Tools/DiagConfig/ConfigStore/Origin.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Origin.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DiagConfig.ConfigStore;
+
+internal sealed class Origin
+{
+    public string? AssemblyName { get; set; }
+    public string? Version { get; set; }
+}

--- a/eng/Tools/DiagConfig/ConfigStore/Severity.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Severity.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DiagConfig.ConfigStore;
+
+internal enum Severity
+{
+    Default,
+    None,
+    Silent,
+    Suggestion,
+    Warning,
+    Error,
+}

--- a/eng/Tools/DiagConfig/ConfigStore/Store.cs
+++ b/eng/Tools/DiagConfig/ConfigStore/Store.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using YamlDotNet.Serialization;
+
+namespace DiagConfig.ConfigStore;
+
+internal sealed class Store
+{
+    public IDictionary<string, Analyzer> Analyzers { get; set; } = new SortedDictionary<string, Analyzer>();
+
+    public static Store Load(string directory)
+    {
+        var result = new Store();
+        var deser = new Deserializer();
+
+        foreach (var file in Directory.GetFiles(directory, "*.yml"))
+        {
+            var data = File.ReadAllText(file);
+
+            Analyzer a;
+            try
+            {
+                a = deser.Deserialize<Analyzer>(data);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException($"Unable to parse diagnostic config file {file} due to {ex.Message}", ex);
+            }
+
+            result.Analyzers.Add(Path.GetFileNameWithoutExtension(file), a);
+        }
+
+        return result;
+    }
+
+    public void Save(string directory)
+    {
+        foreach (var a in Analyzers.Values)
+        {
+            foreach (var d in a.Diagnostics.Values)
+            {
+                foreach (var s in d.Attributes.Values)
+                {
+                    if (s == null)
+                    {
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(s.Comment))
+                    {
+                        s.Comment = null;
+                    }
+
+                    if (s.Options != null && s.Options.Count == 0)
+                    {
+                        s.Options = null;
+                    }
+                }
+
+                if (d.Metadata.CustomTags != null && d.Metadata.CustomTags.Count == 0)
+                {
+                    d.Metadata.CustomTags = null;
+                }
+
+                if (string.IsNullOrWhiteSpace(d.Metadata.HelpLinkUri))
+                {
+                    d.Metadata.HelpLinkUri = null;
+                }
+            }
+        }
+
+        var ser = new SerializerBuilder()
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+            .Build();
+
+        foreach (var akvp in Analyzers)
+        {
+            var path = Path.Combine(directory, akvp.Key) + ".yml";
+            var data = ser.Serialize(akvp.Value);
+            File.WriteAllText(path, data.ReplaceLineEndings("\n"));
+        }
+    }
+
+    public void Merge(Origin origin, string id, Diagnostic diag)
+    {
+        if (!Analyzers.TryGetValue(origin.AssemblyName!, out var a))
+        {
+            a = new Analyzer();
+            Analyzers.Add(origin.AssemblyName!, a);
+        }
+
+        a.Origin = origin;
+
+        if (a.Diagnostics.TryGetValue(id, out var d))
+        {
+            d.Metadata = diag.Metadata;
+        }
+        else
+        {
+            a.Diagnostics.Add(id, diag);
+        }
+    }
+
+    public void SetSettingForAttribute(string id, string attributeName, DiagnosticSetting setting)
+    {
+        foreach (var akvp in Analyzers)
+        {
+            if (akvp.Value.Diagnostics.ContainsKey(id))
+            {
+                akvp.Value.Diagnostics[id].Attributes[attributeName] = setting;
+            }
+        }
+    }
+
+    public void ExportEditorConfig(IEnumerable<string> attributes, IEnumerable<string> includedAnalyzers, IEnumerable<string> excludedAnalyzers, string file, int maxTier, bool isGlobal)
+    {
+        var sb = new StringBuilder();
+
+        var attrs = attributes.OrderBy(a => a).ToArray();
+
+        var analyzers = (IEnumerable<KeyValuePair<string, Analyzer>>)Analyzers;
+        if (includedAnalyzers.Any())
+        {
+            analyzers = analyzers.Where(a => includedAnalyzers.Contains(a.Key));
+        }
+
+        if (excludedAnalyzers.Any())
+        {
+            analyzers = analyzers.Where(a => !excludedAnalyzers.Contains(a.Key));
+        }
+
+        _ = sb.AppendLine($"# Created by DiagConfig, the diagnostic config generator");
+        _ = sb.AppendLine($"# Generated : {DateTimeOffset.UtcNow:u}");
+        _ = sb.AppendLine($"# Max Tier  : {maxTier}");
+        _ = sb.AppendLine($"# Attributes: {string.Join(", ", attrs)}");
+        _ = sb.AppendLine($"# Analyzers : {string.Join(", ", analyzers.Select(a => a.Key).OrderBy(a => a))}");
+        _ = sb.AppendLine();
+
+        if (isGlobal)
+        {
+            _ = sb.AppendLine("is_global = true");
+            _ = sb.AppendLine("global_level = -1");
+        }
+        else
+        {
+            _ = sb.AppendLine("[*.cs]");
+        }
+
+        _ = sb.AppendLine();
+
+        var diags = from x in analyzers
+                    from y in x.Value.Diagnostics
+                    orderby y.Key
+                    select y;
+
+        foreach (var d in diags)
+        {
+            var id = d.Key;
+            var diag = d.Value;
+            DiagnosticSetting? setting = null;
+
+            if (diag.Tier <= maxTier)
+            {
+                // pick the attribute with the highest severity
+                foreach (var a in attributes)
+                {
+                    if (diag.Attributes.ContainsKey(a))
+                    {
+                        var diagSettings = diag.Attributes[a];
+                        if (setting == null)
+                        {
+                            setting = diagSettings;
+                        }
+                        else if (setting.Severity < diagSettings!.Severity)
+                        {
+                            setting = diagSettings;
+                        }
+                    }
+                }
+            }
+
+            _ = sb.AppendLine($"# Title    : {diag.Metadata.Title}");
+            _ = sb.AppendLine($"# Category : {diag.Metadata.Category}");
+
+            if (!string.IsNullOrWhiteSpace(diag.Metadata.HelpLinkUri))
+            {
+                _ = sb.AppendLine($"# Help Link: {diag.Metadata.HelpLinkUri}");
+            }
+
+            if (setting != null)
+            {
+                if (!string.IsNullOrWhiteSpace(setting.Comment))
+                {
+                    _ = sb.AppendLine($"# Comment  : {setting.Comment}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(setting.Redundant))
+                {
+                    _ = sb.AppendLine($"# Redundant: {setting.Redundant}");
+                }
+
+                var severity = setting.Severity;
+                _ = sb.AppendLine($"dotnet_diagnostic.{id}.severity = {severity.ToString().ToLowerInvariant()}");
+
+                if (setting.Options != null && severity != Severity.None)
+                {
+                    foreach (var o in setting.Options)
+                    {
+                        if (o.StartsWith("dotnet_") || o.StartsWith("csharp_"))
+                        {
+                            _ = sb.AppendLine($"{o}");
+                        }
+                        else
+                        {
+                            _ = sb.AppendLine($"dotnet_code_quality.{id}.{o}");
+                        }
+                    }
+                }
+            }
+            else if (diag.Tier > maxTier)
+            {
+                _ = sb.AppendLine($"dotnet_diagnostic.{id}.severity = none");
+            }
+
+            _ = sb.AppendLine();
+        }
+
+        File.WriteAllText(file, sb.ToString().ReplaceLineEndings("\n"));
+    }
+
+    public IEnumerable<string> GetAttributes()
+    {
+        var attributes = new HashSet<string>();
+
+        foreach (var a in Analyzers)
+        {
+            foreach (var d in a.Value.Diagnostics)
+            {
+                attributes.UnionWith(d.Value.Attributes.Keys);
+            }
+        }
+
+        return attributes;
+    }
+}

--- a/eng/Tools/DiagConfig/DiagConfig.csproj
+++ b/eng/Tools/DiagConfig/DiagConfig.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>DiagConfig</AssemblyName>
+    <RootNamespace>DiagConfig</RootNamespace>
+    <Description>Tool to manipulate diagnostic YAML files and .editorconfig files</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);R9A061;R9A043;R9A022;R9A033</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+</Project>

--- a/eng/Tools/DiagConfig/LoadCSVCmd.cs
+++ b/eng/Tools/DiagConfig/LoadCSVCmd.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DiagConfig.ConfigStore;
+
+namespace DiagConfig;
+
+internal static class LoadCSVCmd
+{
+    private const int AnalyzerNamePart = 0;
+    private const int DiagnosticPart = 1;
+    private const int TierPart = 2;
+
+    private sealed class LoadCSVArgs
+    {
+        public string ConfigDirectory { get; set; } = string.Empty;
+        public string CSVFile { get; set; } = string.Empty;
+    }
+
+    public static Command Create()
+    {
+        var cmd = new Command("load-tiers", "Loads diagnostic tier state from a comma-separated value file")
+        {
+            new Argument<string>("csv-file", "Path to the CSV file to process"),
+        };
+
+        cmd.Handler = CommandHandler.Create<LoadCSVArgs>(ExecuteAsync);
+        return cmd;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We're doing the right thing")]
+    private static Task<int> ExecuteAsync(LoadCSVArgs args)
+    {
+        Store cfg;
+        try
+        {
+            cfg = Store.Load(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(args.CSVFile);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to read CSV file `{args.CSVFile}`: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        int count = 1;
+        foreach (var l in lines.Skip(1))
+        {
+            var parts = l.Split(',', StringSplitOptions.TrimEntries);
+            if (parts.Length < 8)
+            {
+                Console.Error.WriteLine($"Invalid format on line {count}");
+                return Task.FromResult(1);
+            }
+
+            var analyzer = parts[AnalyzerNamePart];
+            var diag = parts[DiagnosticPart];
+
+            if (!int.TryParse(parts[TierPart], NumberStyles.Any, CultureInfo.InvariantCulture, out var tier))
+            {
+                Console.Error.WriteLine($"Invalid format on line {count}");
+                return Task.FromResult(1);
+            }
+
+            if (cfg.Analyzers.TryGetValue(analyzer, out var a)
+                && a.Diagnostics.TryGetValue(diag, out var d))
+            {
+                d.Tier = tier;
+            }
+            else
+            {
+                Console.Error.WriteLine($"Couldn't find diagnostics {diag} from analyzer {analyzer}, skipping");
+            }
+
+            count++;
+        }
+
+        try
+        {
+            cfg.Save(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to save diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/DiagConfig/MergeAnalyzersCmd.cs
+++ b/eng/Tools/DiagConfig/MergeAnalyzersCmd.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using DiagConfig.ConfigStore;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace DiagConfig;
+
+internal static class MergeAnalyzersCmd
+{
+    private sealed class MergeAnalyzersArgs
+    {
+        public string ConfigDirectory { get; set; } = string.Empty;
+        public string[] Analyzers { get; set; } = Array.Empty<string>();
+    }
+
+    public static Command Create()
+    {
+        var cmd = new Command("merge", "Merges diagnostic descriptors from Roslyn analyzer assemblies")
+        {
+            new Argument<string[]>("analyzers", "Paths to analyzer assemblies")
+            {
+                Arity = ArgumentArity.OneOrMore,
+            },
+        };
+
+        cmd.Handler = CommandHandler.Create<MergeAnalyzersArgs>(ExecuteAsync);
+        return cmd;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We're doing the right thing")]
+    private static Task<int> ExecuteAsync(MergeAnalyzersArgs args)
+    {
+        var diag = typeof(DiagnosticAnalyzer);
+        var diagAttr = typeof(DiagnosticAnalyzerAttribute);
+
+        Store cfg;
+        try
+        {
+            cfg = Store.Load(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        foreach (var path in args.Analyzers)
+        {
+            Assembly asm;
+            try
+            {
+#pragma warning disable S3885 // "Assembly.Load" should be used
+                asm = Assembly.LoadFrom(path);
+#pragma warning restore S3885 // "Assembly.Load" should be used
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Unable to load assembly {path}: {ex.Message}");
+                return Task.FromResult(1);
+            }
+
+            var name = asm.GetName().Name!;
+            var types = asm.GetTypes();
+            var analyzers = types.Where(t => t.IsAssignableTo(diag) && t.GetCustomAttribute(diagAttr) != null);
+
+            var origin = new Origin
+            {
+                AssemblyName = name,
+            };
+
+            if (asm.GetCustomAttribute(typeof(AssemblyFileVersionAttribute)) is AssemblyFileVersionAttribute fileVer)
+            {
+                origin.Version = fileVer.Version;
+            }
+
+            int diagCount = 0;
+            foreach (var at in analyzers)
+            {
+                var da = (DiagnosticAnalyzer)at.GetConstructor(Array.Empty<Type>())!.Invoke(null);
+                var diags = da.SupportedDiagnostics;
+                foreach (var d in diags)
+                {
+                    var sev = d.DefaultSeverity switch
+                    {
+                        DiagnosticSeverity.Hidden => Severity.None,
+                        DiagnosticSeverity.Info => Severity.Suggestion,
+                        DiagnosticSeverity.Warning => Severity.Warning,
+                        DiagnosticSeverity.Error => Severity.Error,
+                        _ => Severity.Error
+                    };
+
+                    var meta = new ConfigStore.Metadata
+                    {
+                        Category = d.Category,
+                        Title = d.Title.ToString(CultureInfo.InvariantCulture),
+                        Description = d.Description.ToString(CultureInfo.InvariantCulture),
+                        HelpLinkUri = d.HelpLinkUri,
+                        CustomTags = (d.CustomTags != null && d.CustomTags.Any()) ? new List<string>(d.CustomTags) : null,
+                        DefaultSeverity = sev,
+                    };
+
+                    var dg = new ConfigStore.Diagnostic
+                    {
+                        Metadata = meta,
+                        Attributes =
+                        {
+                            ["general"] = new DiagnosticSetting
+                            {
+                                Severity = sev,
+                            },
+                        },
+                    };
+
+                    cfg.Merge(origin, d.Id, dg);
+                    diagCount++;
+                }
+            }
+
+            Console.WriteLine($"Assembly {name}: {diagCount} diagnostics found");
+        }
+
+        try
+        {
+            cfg.Save(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to save diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/DiagConfig/MergeEditorConfigCmd.cs
+++ b/eng/Tools/DiagConfig/MergeEditorConfigCmd.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using DiagConfig.ConfigStore;
+
+namespace DiagConfig;
+
+internal static class MergeEditorConfigCmd
+{
+    private sealed class MergeEditorConfigArgs
+    {
+        public string ConfigDirectory { get; set; } = string.Empty;
+        public string EditorConfigFile { get; set; } = string.Empty;
+        public string EditorConfigAttribute { get; set; } = string.Empty;
+    }
+
+    private static readonly Regex _diagRegex = new(@"^dotnet_diagnostic\.(.*)\.severity *= *(.*)", RegexOptions.Compiled);
+
+    public static Command Create()
+    {
+        var cmd = new Command("merge", "Merges diagnostic state from a .editorconfig file")
+        {
+            new Argument<string>("editor-config-file", "Path to the .editorconfig file to read"),
+            new Argument<string>("editor-config-attribute", "Attribute for values in the .editorconfig file"),
+        };
+
+        cmd.Handler = CommandHandler.Create<MergeEditorConfigArgs>(ExecuteAsync);
+        return cmd;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We're doing the right thing")]
+    private static Task<int> ExecuteAsync(MergeEditorConfigArgs args)
+    {
+        Store cfg;
+        try
+        {
+            cfg = Store.Load(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        string[] lines;
+
+        try
+        {
+            lines = File.ReadAllLines(args.EditorConfigFile);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load .editorconfig file: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        var count = 0;
+        foreach (var line in lines)
+        {
+            var match = _diagRegex.Match(line);
+            if (match.Success)
+            {
+                var id = match.Groups[1].Value;
+                var severity = match.Groups[2].Value;
+
+                var sev = severity.ToUpperInvariant() switch
+                {
+                    "ERROR" => Severity.Error,
+                    "WARNING" => Severity.Warning,
+                    "INFO" => Severity.Suggestion,
+                    "SUGGESTION" => Severity.Suggestion,
+                    "HIDDEN" => Severity.Silent,
+                    "SILENT" => Severity.Silent,
+                    "NONE" => Severity.None,
+                    "DEFAULT" => Severity.Default,
+                    _ => Severity.Error,
+                };
+
+                cfg.SetSettingForAttribute(id, args.EditorConfigAttribute, new DiagnosticSetting { Severity = sev });
+                count++;
+            }
+        }
+
+        Console.WriteLine($"Found {count} configured diagnostics");
+
+        try
+        {
+            cfg.Save(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to save diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/DiagConfig/Program.cs
+++ b/eng/Tools/DiagConfig/Program.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Threading.Tasks;
+
+namespace DiagConfig;
+
+internal static class Program
+{
+    public static Task<int> Main(string[] args)
+    {
+        var rootCmd = new RootCommand("Manipulates diagnostic config files and .editorconfig files")
+        {
+            new Argument<string>("config-directory", "Path to the directory holding the diagnostic config YAML files."),
+
+            new Command("analyzer", "Interact with Roslyn analyzers")
+            {
+                MergeAnalyzersCmd.Create(),
+            },
+
+            new Command("editorconfig", "Interact with .editorconfig files")
+            {
+                MergeEditorConfigCmd.Create(),
+                SaveEditorConfigCmd.Create()
+            },
+
+            new Command("csv", "Interact with comma-separated value files")
+            {
+                LoadCSVCmd.Create(),
+                SaveCSVCmd.Create()
+            },
+
+            ShowAttributesCmd.Create(),
+        };
+
+        return rootCmd.InvokeAsync(args);
+    }
+}

--- a/eng/Tools/DiagConfig/README.md
+++ b/eng/Tools/DiagConfig/README.md
@@ -1,0 +1,135 @@
+# About this Project
+
+This tool is designed to manipulate diagnostic config files. These are YAML files which each
+provide information for all diagnostic messages that can be produced by a given Roslyn analyzer.
+The information is broken down into two parts:
+
+* Full metadata for each diagnostic including a title, description, category, help URI, and a set of
+custom tags. This metadata is extracted from the analyzer assemblies via this tool and can be automatically
+refreshed as new analyzers are added or existing ones are modified.
+
+* A tier value which includes the relative importance of the diagnostics. Tier numbers start at 1 and go up from there.
+The lower a diagnostic's tier value, the more relatively important the diagnostic is.
+
+* A variable set of named attributes. Each attribute indicates a severity for the diagnostic, along with
+an optional comment. Attributes and their severities are maintained by the R9 team and are used to
+describe how to handle a given diagnostic for a given type of source code. More on attributes below.
+
+Here's an example diagnostic:
+
+```yaml
+Diagnostics:
+  R9A001:
+    Metadata:
+      Category: Performance
+      Title: Switch to `Microsoft.IO.RecyclableMemoryStream` for additional performance.
+      Description: Identifies uses of System.IO.MemoryStream.
+      HelpLinkUri: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis-and-analyzers/analyzer/rules/r9a001
+      CustomTags: []
+    Tier: 1
+    Attributes:
+      baseline:
+        Severity: None
+        Comment:
+      production:
+        Severity: Warning
+        Comment:
+```
+
+## What's the Point?
+
+The purpose of the tool is ultimately to emit `.editorconfig` files that can
+be put in source repositories to control diagnostic messages produced for the source code. Different
+`.editorconfig` files can be produced for different kinds of source code (production code, test code,
+benchmark code, etc.)
+
+## Attributes
+
+Attributes are used to control what is ultimately put into a generated `.editorconfig` file. At the time you
+generate an `.editorconfig` file, you specify the set of attributes to evaluate. For each diagnostic, the
+tool compares the requested attributes with what has been defined in the diagnostic config file.
+The severity value selected is based on the highest severity of any matching attribute.
+
+Although the set of attributes is arbitrary, the currently used set is:
+
+* `general`. Generally useful for any code
+* `production`. The severity to use for production-level code being analyzed.
+* `test`. The severity to use for test-level code being analyzed.
+* `performance`. The severity to use for performance-sensitive code being analyzed.
+* `api`. The severity to use for code that exposes APIs.
+
+### Severity Levels
+
+Attributes indicate a level of severity. The available severities are:
+
+* `Default` - whatever the analyzer specified
+* `None` - the analysis isn't performed
+* `Silent` - ignored when building on the command-line, shown in the lightbulb menu in Visual Studio
+* `Suggestion` - ignored when building on the command-line, shown as a Message in the Visual Studio Error List window
+* `Warning` - shown as a Warning in the Visual Studio Error List window
+* `Error` - shown as an Error in the Visual Studio Error List window
+
+Refer to [this page](https://docs.microsoft.com/visualstudio/code-quality/use-roslyn-analyzers) for more details on these severity levels.
+
+## Using the Tool
+
+The tool has a few different commands described below. All these commands require you to specify the name of a directory where the diagnostic configuration
+YAML files are kept. You start out with an empty directory, which gets populated by the tool, and updated over time by
+the tool or by a human. The `eng/Diags` folder is where all these configuration files are located in the code base.
+
+### Extracting Analyzer Metadata
+
+Use the following to extract diagnostic metadata from a Roslyn analyzer assembly:
+
+```bash
+> DiagConfig <config-directory> analyzer merge <analyzers>...
+```
+
+You specify the name of the config directory, along with file system paths to the analyzer assemblies of interest. The tool will read the assembly
+and then either create or update metadata for the analyzer within the given config directory.
+
+Once you have the analyzer's metadata, you can start editing the YAML files in the config directory in order to
+adjust the severity level of the diagnostics.
+
+> Hint!
+> Check `scripts/MergeAnalyzerMetadata.ps1` to see how it is used in the code base.
+
+### Import Existing Settings From an Editor Config File
+
+If you already have an `.editorconfig` file which contains analyzer settings, you can extract them and insert them into
+the config directory state.
+
+```bash
+> DiagConfig <config-directory> editorconfig merge <editor-config-file> <editor-config-family>
+```
+
+You specify the name of the config directory, the path to an existing `.editorconfig` file, and the family to
+update with the settings from the config file.
+
+### Producing an Editor Config File
+
+You use the following to produce an `.editorconfig` file:
+
+```bash
+> DiagConfig <config-directory> editorconfig save <editor-config-file> [<editor-config-attributes>...]
+```
+
+> Hint!
+> Check `scripts/MakeEditorConfigs.ps1` to see how it is used in the code base.
+
+You specify the name of the config directory, the path of the editor config file to produce, and the set
+of severity attributes to extract. When many families are supplied, for any given diagnostic the highest severity of
+any matching attribute is what will be written to the editor config file being produced.
+
+### Producing an 'All-Off Diagnostics' Config File
+
+When our customers want to adopt static analysis they cannot do it all at once in bigger codebases.
+Adding the analysis NuGet turns on all analyzers by default for given assembly.
+By creating `all of` config file they can turn on analyzers only per specific directory and adopt it gradually.
+
+```bash
+> DiagConfig <config-directory> editorconfig save --all-off <editor-config-file> [<editor-config-attributes>...]
+```
+
+> Hint!
+> Check `MakeEditorConfigs.ps1` to see how it is used in the source base.

--- a/eng/Tools/DiagConfig/SaveCSVCmd.cs
+++ b/eng/Tools/DiagConfig/SaveCSVCmd.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using DiagConfig.ConfigStore;
+
+namespace DiagConfig;
+
+internal static class SaveCSVCmd
+{
+    private sealed class SaveCSVArgs
+    {
+        public string ConfigDirectory { get; set; } = string.Empty;
+        public string CSVFile { get; set; } = string.Empty;
+    }
+
+    public static Command Create()
+    {
+        var cmd = new Command("save", "Saves analyzer state as a comma-separated value file")
+        {
+            new Argument<string>("csv-file", "Path to the CSV file to create"),
+        };
+
+        cmd.Handler = CommandHandler.Create<SaveCSVArgs>(ExecuteAsync);
+        return cmd;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We're doing the right thing")]
+    private static Task<int> ExecuteAsync(SaveCSVArgs args)
+    {
+        Store cfg;
+        try
+        {
+            cfg = Store.Load(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        var sb = new StringBuilder();
+        _ = sb.AppendLine("Analyzer,Diagnostic,Tier,Title,Category,Default Severity,Description");
+        foreach (var kvp in cfg.Analyzers)
+        {
+            var analyzer = kvp.Key;
+            foreach (var d in kvp.Value.Diagnostics)
+            {
+                _ = sb.AppendLine($"{analyzer},"
+                    + $"{d.Key},"
+                    + $"{d.Value.Tier},"
+                    + $"{d.Value.Metadata.Title},"
+                    + $"{d.Value.Metadata.Category},"
+                    + $"{d.Value.Metadata.DefaultSeverity},"
+                    + $"{d.Value.Metadata.Description.Replace(",", "-")}");
+            }
+        }
+
+        try
+        {
+            File.WriteAllText(args.CSVFile, sb.ToString().ReplaceLineEndings("\n"));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to write to file `{args.CSVFile}`: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/DiagConfig/SaveEditorConfigCmd.cs
+++ b/eng/Tools/DiagConfig/SaveEditorConfigCmd.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using DiagConfig.ConfigStore;
+
+namespace DiagConfig;
+
+internal static class SaveEditorConfigCmd
+{
+#pragma warning disable S3459 // Unassigned members should be removed
+#pragma warning disable S1144 // Unused private types or members should be removed
+    private sealed class SaveEditorConfigArgs
+    {
+        public string ConfigDirectory { get; set; } = string.Empty;
+        public string EditorConfigFile { get; set; } = string.Empty;
+        public string EditorConfigAttributes { get; set; } = string.Empty;
+        public string Include { get; set; } = string.Empty;
+        public string Exclude { get; set; } = string.Empty;
+        public bool IsGlobal { get; set; }
+        public int MaxTier { get; set; } = int.MaxValue;
+    }
+#pragma warning restore S1144 // Unused private types or members should be removed
+#pragma warning restore S3459 // Unassigned members should be removed
+
+    public static Command Create()
+    {
+        var cmd = new Command("save", "Saves an editor config file")
+        {
+            new Argument<string>("editor-config-file", "Path to the .editorconfig file to create"),
+            new Argument<string>("editor-config-attributes", "Set of comma-separated attributes to evaluate when creating the .editorconfig file"),
+            new Option<string>("--include", "Set of comma-separated analyzers to explicitly include in the generated .editorconfig file"),
+            new Option<string>("--exclude", "Set of comma-separated analyzers to explicitly exclude in the generated .editorconfig file"),
+            new Option<int>("--max-tier", "Maximum tier of diagnostics to enable (0 disables all diagnostics)."),
+            new Option<bool>("--is-global", "Adds is_global=true to the generated .editorconfig file"),
+        };
+
+        cmd.Handler = CommandHandler.Create<SaveEditorConfigArgs>(ExecuteAsync);
+        return cmd;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We're doing the right thing")]
+    private static Task<int> ExecuteAsync(SaveEditorConfigArgs args)
+    {
+        Store cfg;
+        try
+        {
+            cfg = Store.Load(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        var attrs = args.EditorConfigAttributes.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var included = args.Include.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var excluded = args.Exclude.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        try
+        {
+            cfg.ExportEditorConfig(attrs, included, excluded, args.EditorConfigFile, args.MaxTier, args.IsGlobal);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to save file {args.EditorConfigFile}: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/DiagConfig/ShowAttributesCmd.cs
+++ b/eng/Tools/DiagConfig/ShowAttributesCmd.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using DiagConfig.ConfigStore;
+
+namespace DiagConfig;
+
+internal static class ShowAttributesCmd
+{
+    private sealed class ShowAttributesArgs
+    {
+        public string ConfigDirectory { get; set; } = string.Empty;
+    }
+
+    public static Command Create()
+    {
+        return new Command("attributes", "Show the set of available attributes")
+        {
+            Handler = CommandHandler.Create<ShowAttributesArgs>(ExecuteAsync),
+        };
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We're doing the right thing")]
+    private static Task<int> ExecuteAsync(ShowAttributesArgs args)
+    {
+        Store cfg;
+        try
+        {
+            cfg = Store.Load(args.ConfigDirectory);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unable to load diagnostic configuration state: {ex.Message}");
+            return Task.FromResult(1);
+        }
+
+        var attributes = cfg.GetAttributes();
+
+        foreach (var a in attributes)
+        {
+            Console.WriteLine(a);
+        }
+
+        return Task.FromResult(0);
+    }
+}

--- a/eng/Tools/Directory.Build.props
+++ b/eng/Tools/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(LatestTargetFramework)</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/eng/Tools/Directory.Build.targets
+++ b/eng/Tools/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/scripts/MakeEditorConfigs.ps1
+++ b/scripts/MakeEditorConfigs.ps1
@@ -1,0 +1,47 @@
+#!/usr/bin/env pwsh
+<#
+.DESCRIPTION
+    Builds and invokes the DiagConfig tool to generate the .editorconfig files we use within the source base
+#>
+
+$Project = $PSScriptRoot + "/../eng/Tools/DiagConfig/DiagConfig.csproj"
+$Command = $PSScriptRoot + "/../artifacts/bin/DiagConfig/Debug/net8.0/DiagConfig.exe"
+$Diags = $PSScriptRoot + "/../eng/Diags"
+
+Write-Output "Building DiagConfig tool"
+
+& dotnet build $Project --nologo --verbosity q
+
+Write-Output "Creating .editorconfig files"
+
+# The files we use for this repo
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/.editorconfig       general,api,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers bench/.editorconfig     general,performance
+& $Command $Diags editorconfig save --exclude xunit.analyzers eng/Tools/.editorconfig general
+& $Command $Diags editorconfig save                           test/.editorconfig      general,test
+
+# The files we publish with the M.E.StaticAnalysis package
+
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier1.globalconfig       general,general_externalonly --is-global
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier1.globalconfig       general,general_externalonly,performance,production --is-global
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier1.globalconfig       general,general_externalonly,api,performance,production --is-global
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier1.globalconfig    general,general_externalonly --is-global
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier1.globalconfig    general,general_externalonly,api --is-global
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier1.globalconfig     general,general_externalonly,performance --is-global
+& $Command $Diags editorconfig save --max-tier 1 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle                 src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier1.globalconfig          general,general_externalonly,test --is-global
+
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier2.globalconfig       general,general_externalonly --is-global
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier2.globalconfig       general,general_externalonly,performance,production --is-global
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier2.globalconfig       general,general_externalonly,api,performance,production --is-global
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier2.globalconfig    general,general_externalonly --is-global
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier2.globalconfig    general,general_externalonly,api --is-global
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier2.globalconfig     general,general_externalonly,performance --is-global
+& $Command $Diags editorconfig save --max-tier 2 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle                 src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier2.globalconfig          general,general_externalonly,test --is-global
+
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General.globalconfig       general,general_externalonly --is-global
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe.globalconfig       general,general_externalonly,performance,production --is-global
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib.globalconfig       general,general_externalonly,api,performance,production --is-global
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe.globalconfig    general,general_externalonly --is-global
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib.globalconfig    general,general_externalonly,api --is-global
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle,xunit.analyzers src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark.globalconfig     general,general_externalonly,performance --is-global
+& $Command $Diags editorconfig save --max-tier 3 --exclude StyleCop.Analyzers,Microsoft.CodeAnalysis.CodeStyle,Microsoft.CodeAnalysis.CSharp.CodeStyle                 src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test.globalconfig          general,general_externalonly,test --is-global

--- a/scripts/MergeAnalyzerMetadata.ps1
+++ b/scripts/MergeAnalyzerMetadata.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+<#
+.DESCRIPTION
+    Builds and invokes the DiagConfig tool to extract metadata from analyzers and update our diagnostic config state accordingly.
+#>
+
+$Project = Join-Path -Path $PSScriptRoot -ChildPath "\..\eng\Tools\DiagConfig\DiagConfig.csproj"
+$SlnGen = Join-Path -Path $PSScriptRoot -ChildPath ".\Slngen.ps1"
+
+Write-Output "Building DiagConfig tool"
+& dotnet build $Project --nologo --verbosity q
+
+Write-Output "Creating solution file"
+& $SlnGen -all -folders -nolaunch -quiet
+
+Write-Output "Restoring packages"
+& dotnet restore --nologo --verbosity q
+
+# $DotnetVersion = & dotnet --version
+$DotNetVersion = "8.0.100-preview.5.23262.6"
+
+$Artifacts = Join-Path -Path $PSScriptRoot -ChildPath "\..\artifacts" -Resolve
+$DiagToolPath = "$Artifacts\bin\DiagConfig\Debug\net8.0\*"
+$Command = "$Artifacts\bin\DiagConfig\Debug\net8.0\DiagConfig.exe"
+$Diags = (Resolve-Path $PSScriptRoot).Path + "\..\eng\Diags"
+#$DotnetPath = Split-Path -Path (get-command dotnet.exe).Path -Parent
+$DotnetPath = "C:\Program Files\dotnet"
+$RoslynPath = "$DotnetPath\sdk\$DotnetVersion\Roslyn\bincore"
+$CodeStylePath = "$DotnetPath\sdk\$DotnetVersion\Sdks\Microsoft.NET.Sdk\codestyle\cs"
+$NetAnalyzersPath = "$DotnetPath\sdk\$DotnetVersion\Sdks\Microsoft.NET.Sdk\analyzers"
+$PackagePath = Join-Path -Path $Home -ChildPath ".nuget/packages" -Resolve
+$AspNetCorePath = Join-Path -Path $DotNetPath -ChildPath packs\Microsoft.AspNetCore.App.Ref\7.0.4\analyzers\dotnet\cs
+
+Write-Output "Processing analyzer assemblies"
+
+& $Command $Diags analyzer merge $Artifacts\bin\Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0\Debug\netstandard2.0\Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0.dll
+& $Command $Diags analyzer merge $Artifacts\bin\Microsoft.Extensions.LocalAnalyzers\Debug\netstandard2.0\Microsoft.Extensions.LocalAnalyzers.dll
+& $Command $Diags analyzer merge $PackagePath\stylecop.analyzers.unstable\1.2.0.435\analyzers\dotnet\cs\StyleCop.Analyzers.dll
+& $Command $Diags analyzer merge $PackagePath\sonaranalyzer.csharp\8.52.0.60960\analyzers\SonarAnalyzer.CSharp.dll
+& $Command $Diags analyzer merge $PackagePath\microsoft.visualstudio.threading.analyzers\17.5.22\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll
+& $Command $Diags analyzer merge $PackagePath\microsoft.visualstudio.threading.analyzers\17.5.22\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CSharp.dll
+& $Command $Diags analyzer merge $PackagePath\xunit.analyzers\1.0.0\analyzers\dotnet\cs\xunit.analyzers.dll
+
+# voodoo for Microsoft.CodeAnalysis.* and Microsoft.AspNetCore.*
+
+$tempDir = "$PSScriptRoot\Temp"
+
+if (-not (Test-Path -Path $tempDir)) {
+    New-Item -Path $tempDir -ItemType directory | Out-Null
+}
+
+Push-Location $tempDir
+
+try {
+    Copy-Item -Path (Join-Path -Path $RoslynPath -ChildPath Microsoft.CodeAnalysis.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $RoslynPath -ChildPath Microsoft.CodeAnalysis.CSharp.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $CodeStylePath -ChildPath Microsoft.CodeAnalysis.CodeStyle.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $CodeStylePath -ChildPath Microsoft.CodeAnalysis.CSharp.CodeStyle.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $NetAnalyzersPath -ChildPath Microsoft.CodeAnalysis.NetAnalyzers.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $NetAnalyzersPath -ChildPath Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $NetAnalyzersPath -ChildPath ILlink.RoslynAnalyzer.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $AspNetCorePath -ChildPath Microsoft.AspNetCore.App.Analyzers.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path (Join-Path -Path $AspNetCorePath -ChildPath Microsoft.AspNetCore.Components.Analyzers.dll -Resolve) -Destination $tempDir
+    Copy-Item -Path $DiagToolPath -Destination $tempDir
+
+    & .\DiagConfig.exe $Diags analyzer merge Microsoft.CodeAnalysis.CodeStyle.dll
+    & .\DiagConfig.exe $Diags analyzer merge Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+    & .\DiagConfig.exe $Diags analyzer merge Microsoft.CodeAnalysis.NetAnalyzers.dll
+    & .\DiagConfig.exe $Diags analyzer merge Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+    & .\DiagConfig.exe $Diags analyzer merge ILlink.RoslynAnalyzer.dll
+    & .\DiagConfig.exe $Diags analyzer merge Microsoft.AspNetCore.App.Analyzers.dll
+    & .\DiagConfig.exe $Diags analyzer merge Microsoft.AspNetCore.Components.Analyzers.dll
+} finally {
+    Pop-Location
+    Remove-Item -Path $tempDir -Recurse
+}

--- a/scripts/PrepForAPIReview.ps1
+++ b/scripts/PrepForAPIReview.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+<#
+.DESCRIPTION
+    Builds and invokes the ApiChief tool to generate API review metadata.
+.PARAMETER AssemblyPath
+    Path to the assembly to extract the API from.
+#>
+
+param (
+    [Parameter(Mandatory = $true, HelpMessage="Path to the assemly to extract the API from.", Position = 0, ParameterSetName = "AssemblyPath")]
+    [string]$AssemblyPath
+)
+
+$Project = $PSScriptRoot + "/../eng/Tools/ApiChief/ApiChief.csproj"
+$Command = $PSScriptRoot + "/../artifacts/bin/ApiChief/Debug/net8.0/ApiChief.exe"
+
+Write-Output "Building ApiChief tool"
+
+& dotnet build $Project --nologo --verbosity q
+
+Write-Output "Creating API review artifacts in the API.* folder"
+
+& $Command $AssemblyPath emit review

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,7 +1,8 @@
-# Created by the R9 diagnostic config generator
-# Generated : 2023-02-20 04:52:12Z
-# Attributes: api, general, performance, production, r9internal
-# Analyzers : ILLink.RoslynAnalyzer, Internal.Analyzers, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.CPR.Standard.Analyzers.Basic.R3, Microsoft.R9.Analyzers.Roslyn4.0, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-23 23:01:34Z
+# Max Tier  : 2147483647
+# Attributes: api, general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
 
 [*.cs]
 
@@ -96,48 +97,41 @@ dotnet_diagnostic.BL0007.severity = warning
 # Title    : Do not declare static members on generic types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1000.severity = warning
 dotnet_code_quality.CA1000.api_surface = public
 
 # Title    : Types that own disposable fields should be disposable
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1001.severity = warning
 
 # Title    : Do not expose generic lists
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1002.severity = warning
 dotnet_code_quality.CA1002.api_surface = public
 
 # Title    : Use generic event handler instances
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1003.severity = warning
 dotnet_code_quality.CA1003.api_surface = all
 
 # Title    : Avoid excessive parameters on generic types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1005.severity = warning
 dotnet_code_quality.CA1005.api_surface = public
 
 # Title    : Enums should have zero value
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, RuleNoZero
 dotnet_diagnostic.CA1008.severity = warning
 dotnet_code_quality.CA1008.api_surface = public
 
 # Title    : Generic interface should also be implemented
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1010.severity = warning
 dotnet_code_quality.CA1010.api_surface = public
 dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
@@ -145,218 +139,184 @@ dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Col
 # Title    : Abstract types should not have public constructors
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1012.severity = warning
 dotnet_code_quality.CA1012.api_surface = all
 
 # Title    : Mark assemblies with CLSCompliant
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1014.severity = none
 
 # Title    : Mark assemblies with assembly version
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
-dotnet_diagnostic.CA1016.severity = warning
+dotnet_diagnostic.CA1016.severity = suggestion
 
 # Title    : Mark assemblies with ComVisible
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1017.severity = none
 
 # Title    : Mark attributes with AttributeUsageAttribute
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1018.severity = warning
 
 # Title    : Define accessors for attribute arguments
 # Category : Design
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1019.severity = warning
 
 # Title    : Define accessors for attribute arguments
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1019.severity = warning
 
 # Title    : Avoid out parameters
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1021.severity = none
 
 # Title    : Use properties where appropriate
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1024.severity = warning
 dotnet_code_quality.CA1024.api_surface = public
 
 # Title    : Mark enums with FlagsAttribute
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1027.severity = warning
 dotnet_code_quality.CA1027.api_surface = all
 
 # Title    : Enum Storage should be Int32
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1028.severity = none
 
 # Title    : Use events where appropriate
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1030.severity = warning
 
 # Title    : Do not catch general exception types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1031.severity = warning
 
 # Title    : Implement standard exception constructors
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1032.severity = warning
 
 # Title    : Interface methods should be callable by child types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1033.severity = warning
 
 # Title    : Nested types should not be visible
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1034.severity = warning
 
 # Title    : Override methods on comparable types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1036.severity = warning
 
 # Title    : Avoid empty interfaces
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Reasonably frequent in modern .NET programming
 dotnet_diagnostic.CA1040.severity = none
 
 # Title    : Provide ObsoleteAttribute message
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1041.severity = warning
 dotnet_code_quality.CA1041.api_surface = all
 
 # Title    : Use Integral Or String Argument For Indexers
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1043.severity = warning
 dotnet_code_quality.CA1043.api_surface = public, protected
 
 # Title    : Properties should not be write only
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1044.severity = warning
 
 # Title    : Do not pass types by reference
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1045.severity = suggestion
 dotnet_code_quality.CA1045.api_surface = public
 
 # Title    : Do not overload equality operator on reference types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1046.severity = warning
 dotnet_code_quality.CA1046.api_surface = all
 
 # Title    : Do not declare protected member in sealed type
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1047.severity = warning
 dotnet_code_quality.CA1047.api_surface = all
 
 # Title    : Declare types in namespaces
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1050.severity = warning
 dotnet_code_quality.CA1050.api_surface = public
 
 # Title    : Do not declare visible instance fields
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1051.severity = warning
 dotnet_code_quality.CA1051.api_surface = public
 
 # Title    : Static holder types should be Static or NotInheritable
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1052.severity = warning
 
 # Title    : URI-like parameters should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1054.severity = warning
 
 # Title    : URI-like return values should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1055.severity = warning
 
 # Title    : URI-like properties should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1056.severity = warning
 
 # Title    : Types should not extend certain base types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1058.severity = warning
 dotnet_code_quality.CA1058.api_surface = public
 
 # Title    : Move pinvokes to native methods class
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1060.severity = warning
 
 # Title    : Do not hide base class methods
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1061.severity = warning
 dotnet_code_quality.CA1061.api_surface = all
 
 # Title    : Validate arguments of public methods
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1062.severity = warning
 dotnet_code_quality.CA1062.api_surface = public, protected
 dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
@@ -365,263 +325,242 @@ dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|
 # Title    : Implement IDisposable Correctly
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1063.severity = warning
 
 # Title    : Exceptions should be public
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1064.severity = warning
 
 # Title    : Do not raise exceptions in unexpected locations
 # Category : Design
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1065.severity = warning
 
 # Title    : Do not raise exceptions in unexpected locations
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1065.severity = warning
 
 # Title    : Implement IEquatable when overriding Object.Equals
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1066.severity = warning
 
 # Title    : Override Object.Equals(object) when implementing IEquatable<T>
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1067.severity = warning
 
 # Title    : CancellationToken parameters must come last
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1068.severity = warning
 dotnet_code_quality.CA1068.api_surface = public, protected
 
 # Title    : Enums values should not be duplicated
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1069.severity = warning
 
 # Title    : Do not declare event fields as virtual
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1070.severity = warning
 dotnet_code_quality.CA1070.api_surface = all
 
 # Title    : Avoid using cref tags with a prefix
 # Category : Documentation
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1200.severity = warning
 
 # Title    : Do not pass literals as localized parameters
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1303.severity = warning
 
 # Title    : Specify CultureInfo
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1304.severity = warning
 
 # Title    : Specify IFormatProvider
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1305.severity = warning
 
 # Title    : Specify StringComparison for clarity
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1307.severity = warning
 
 # Title    : Normalize strings to uppercase
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1308.severity = warning
 
 # Title    : Use ordinal string comparison
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1309.severity = warning
 
 # Title    : Specify StringComparison for correctness
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1310.severity = warning
 
 # Title    : Specify a culture or use an invariant version
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1311.severity = warning
 
 # Title    : P/Invokes should not be visible
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1401.severity = warning
 
 # Title    : Validate platform compatibility
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1416.severity = warning
 
 # Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1417.severity = warning
 
 # Title    : Use valid platform string
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1418.severity = warning
 
 # Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1419.severity = warning
 
 # Title    : Property, type, or attribute requires runtime marshalling
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1420.severity = warning
 
 # Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1421.severity = suggestion
 
 # Title    : Validate platform compatibility
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1422.severity = warning
 
 # Title    : Avoid excessive inheritance
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1501.severity = warning
 dotnet_code_quality.CA1501.api_surface = public
 
 # Title    : Avoid excessive complexity
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 # Comment  : Code gets complicated
 dotnet_diagnostic.CA1502.severity = none
 
 # Title    : Avoid unmaintainable code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1505.severity = warning
 
 # Title    : Avoid excessive class coupling
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 # Comment  : Code gets complicated
 dotnet_diagnostic.CA1506.severity = none
 
 # Title    : Use nameof to express symbol names
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1507.severity = warning
 
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1508.severity = warning
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
-# Tags     : Telemetry, CompilationEnd
 dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
 
 # Title    : Do not name enum values 'Reserved'
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1700.severity = warning
 dotnet_code_quality.CA1700.api_surface = public
 
 # Title    : Identifiers should not contain underscores
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : StyleCop handles this
 dotnet_diagnostic.CA1707.severity = none
 
 # Title    : Identifiers should differ by more than case
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1708.severity = warning
 dotnet_code_quality.CA1708.api_surface = public
 
 # Title    : Identifiers should have correct suffix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1710.severity = warning
 dotnet_code_quality.CA1710.api_surface = public
 
 # Title    : Identifiers should not have incorrect suffix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1711.severity = warning
 dotnet_code_quality.CA1711.api_surface = public
 
 # Title    : Do not prefix enum values with type name
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1712.severity = warning
 
 # Title    : Events should not have 'Before' or 'After' prefix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1713.severity = warning
 
 # Title    : Identifiers should have correct prefix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: IDE1006
 dotnet_diagnostic.CA1715.severity = none
 
 # Title    : Identifiers should not match keywords
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1716.severity = warning
 dotnet_code_quality.CA1716.api_surface = all
 dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
@@ -629,1625 +568,1134 @@ dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
 # Title    : Identifier contains type name
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1720.severity = warning
 dotnet_code_quality.CA1720.api_surface = public
 
 # Title    : Property names should not match get methods
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1721.severity = warning
 dotnet_code_quality.CA1721.api_surface = public
 
 # Title    : Type names should not match namespaces
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA1724.severity = warning
 dotnet_code_quality.CA1724.api_surface = public
 
 # Title    : Parameter names should match base declaration
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1725.severity = warning
 
 # Title    : Use PascalCase for named placeholders
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1727.severity = silent
 
 # Title    : Review unused parameters
 # Category : Usage
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: IDE0060
 dotnet_diagnostic.CA1801.severity = none
 
 # Title    : Review unused parameters
 # Category : Usage
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: IDE0060
 dotnet_diagnostic.CA1801.severity = none
 
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1802.severity = warning
 
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1802.severity = warning
 
 # Title    : Do not initialize unnecessarily
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1805.severity = warning
 
 # Title    : Do not initialize unnecessarily
 # Category : Performance
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1805.severity = warning
 
 # Title    : Do not ignore method results
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1806.severity = warning
 
 # Title    : Initialize reference type static fields inline
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1810.severity = warning
 
 # Title    : Avoid uninstantiated internal classes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 # Comment  : S1144 finds more cases and has no false positives
-dotnet_diagnostic.CA1812.severity = warning
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
 
 # Title    : Avoid unsealed attributes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1813.severity = warning
 
 # Title    : Prefer jagged arrays over multidimensional
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1814.severity = warning
 
 # Title    : Override equals and operator equals on value types
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1815.severity = warning
 
 # Title    : Dispose methods should call SuppressFinalize
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1816.severity = warning
 
 # Title    : Properties should not return arrays
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1819.severity = warning
 
 # Title    : Test for empty strings using string length
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1820.severity = warning
 
 # Title    : Remove empty Finalizers
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1821.severity = warning
 
 # Title    : Mark members as static
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1822.severity = warning
 
 # Title    : Avoid unused private fields
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
-dotnet_diagnostic.CA1823.severity = warning
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
 
 # Title    : Mark assemblies with NeutralResourcesLanguageAttribute
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA1824.severity = warning
 
 # Title    : Avoid zero-length array allocations
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1825.severity = warning
 
 # Title    : Do not use Enumerable methods on indexable collections
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1826.severity = warning
 
 # Title    : Do not use Count() or LongCount() when Any() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1827.severity = warning
 
 # Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1828.severity = warning
 
 # Title    : Use Length/Count property instead of Count() when available
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1829.severity = warning
 
 # Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1830.severity = warning
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1831.severity = warning
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1832.severity = warning
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1833.severity = warning
 
 # Title    : Consider using 'StringBuilder.Append(char)' when applicable
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1834.severity = warning
 
 # Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1835.severity = warning
 
 # Title    : Prefer IsEmpty over Count
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1836.severity = warning
 
 # Title    : Use 'Environment.ProcessId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1837.severity = warning
 
 # Title    : Avoid 'StringBuilder' parameters for P/Invokes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1838.severity = warning
 
 # Title    : Use 'Environment.ProcessPath'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1839.severity = warning
 
 # Title    : Use 'Environment.CurrentManagedThreadId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1840.severity = warning
 
 # Title    : Prefer Dictionary.Contains methods
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1841.severity = warning
 
 # Title    : Do not use 'WhenAll' with a single task
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1842.severity = suggestion
 
 # Title    : Do not use 'WaitAll' with a single task
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1843.severity = warning
 
 # Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1844.severity = warning
 
 # Title    : Use span-based 'string.Concat'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1845.severity = warning
 
 # Title    : Prefer 'AsSpan' over 'Substring'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1846.severity = warning
 
 # Title    : Use char literal for a single character lookup
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1847.severity = warning
 
 # Title    : Use the LoggerMessage delegates
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Use R9 logging model instead
 dotnet_diagnostic.CA1848.severity = none
 
 # Title    : Call async methods when in an async method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1849.severity = warning
 
 # Title    : Prefer static 'HashData' method over 'ComputeHash'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1850.severity = suggestion
 
 # Title    : Possible multiple enumerations of 'IEnumerable' collection
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1851.severity = suggestion
 
 # Title    : Seal internal types
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
+# Redundant: R9A013
 dotnet_diagnostic.CA1852.severity = none
 
 # Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1853.severity = suggestion
 
 # Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1854.severity = warning
 
 # Title    : Prefer 'Clear' over 'Fill'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
 
 # Title    : Dispose objects before losing scope
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2000.severity = warning
 
 # Title    : Do not lock on objects with weak identity
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2002.severity = warning
 
 # Title    : Consider calling ConfigureAwait on the awaited task
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2007.severity = warning
 
 # Title    : Do not create tasks without passing a TaskScheduler
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2008.severity = warning
 
 # Title    : Do not call ToImmutableCollection on an ImmutableCollection value
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2009.severity = warning
 
 # Title    : Avoid infinite recursion
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2011.severity = error
 
 # Title    : Use ValueTasks correctly
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2012.severity = warning
 
 # Title    : Do not use ReferenceEquals with value types
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2013.severity = warning
 
 # Title    : Do not use stackalloc in loops
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2014.severity = warning
 
 # Title    : Do not use stackalloc in loops
 # Category : Reliability
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2014.severity = warning
 
 # Title    : Do not define finalizers for types derived from MemoryManager<T>
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2015.severity = warning
 
 # Title    : Forward the 'CancellationToken' parameter to methods
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2016.severity = warning
 
 # Title    : Parameter count mismatch
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2017.severity = warning
 
 # Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2018.severity = warning
 
 # Title    : Improper 'ThreadStatic' field initialization
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2019.severity = warning
 
-# Title    : Prevent from behavioral change
+# Title    : Prevent behavioral change
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
 
 # Title    : Review SQL queries for security vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2100.severity = warning
 
 # Title    : Specify marshaling for P/Invoke string arguments
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2101.severity = warning
 
 # Title    : Review visible event handlers
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2109.severity = warning
 dotnet_code_quality.CA2109.api_surface = public
 
 # Title    : Seal methods that satisfy private interfaces
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2119.severity = warning
 
 # Title    : Do Not Catch Corrupted State Exceptions
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2153.severity = warning
 
 # Title    : Rethrow to preserve stack details
 # Category : Usage
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2200.severity = warning
 
 # Title    : Rethrow to preserve stack details
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2200.severity = warning
 
 # Title    : Do not raise reserved exception types
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2201.severity = warning
 
 # Title    : Initialize value type static fields inline
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2207.severity = warning
 
 # Title    : Instantiate argument exceptions correctly
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2208.severity = warning
 
 # Title    : Non-constant fields should not be visible
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2211.severity = warning
 
 # Title    : Disposable fields should be disposed
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2213.severity = warning
 
 # Title    : Do not call overridable methods in constructors
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2214.severity = warning
 
 # Title    : Dispose methods should call base class dispose
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2215.severity = warning
 
 # Title    : Disposable types should declare finalizer
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2216.severity = warning
 
 # Title    : Do not mark enums with FlagsAttribute
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2217.severity = warning
 dotnet_code_quality.CA2217.api_surface = all
 
 # Title    : Do not raise exceptions in finally clauses
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2219.severity = warning
 
 # Title    : Operator overloads have named alternates
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2225.severity = warning
 dotnet_code_quality.CA2225.api_surface = public
 
 # Title    : Operators should have symmetrical overloads
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: CS0216
 dotnet_diagnostic.CA2226.severity = none
 
 # Title    : Collection properties should be read only
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2227.severity = warning
 
 # Title    : Implement serialization constructors
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Obsolete
 dotnet_diagnostic.CA2229.severity = none
 
 # Title    : Overload operator equals on overriding value type Equals
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2231.severity = error
 
 # Title    : Pass system uri objects instead of strings
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2234.severity = warning
 
 # Title    : Mark all non-serializable fields
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Obsolete
 dotnet_diagnostic.CA2235.severity = none
 
 # Title    : Mark ISerializable types with serializable
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Obsolete
 dotnet_diagnostic.CA2237.severity = none
 
 # Title    : Provide correct arguments to formatting methods
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2241.severity = warning
 
 # Title    : Test for NaN correctly
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2242.severity = warning
 
 # Title    : Attribute string literals should parse correctly
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2243.severity = warning
 
 # Title    : Do not duplicate indexed element initializations
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2244.severity = warning
 
 # Title    : Do not assign a property to itself
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2245.severity = warning
 
 # Title    : Assigning symbol and its member in the same statement
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2246.severity = warning
 
 # Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2247.severity = warning
 
 # Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2248.severity = warning
 
 # Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2249.severity = warning
 
 # Title    : Use 'ThrowIfCancellationRequested'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2250.severity = suggestion
 
 # Title    : Use 'string.Equals'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2251.severity = warning
 
 # Title    : This API requires opting into preview features
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2252.severity = error
 
 # Title    : Named placeholders should not be numeric values
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2253.severity = warning
 
 # Title    : Template should be a static expression
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2254.severity = suggestion
 
 # Title    : The 'ModuleInitializer' attribute should not be used in libraries
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2255.severity = warning
 
 # Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2256.severity = error
 
 # Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2257.severity = warning
 
 # Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2258.severity = warning
 
 # Title    : 'ThreadStatic' only affects static fields
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2259.severity = warning
 
 # Title    : Use correct type parameter
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2260.severity = warning
 
 # Title    : Do not use insecure deserializer BinaryFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2300.severity = warning
 
 # Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2301.severity = warning
 
 # Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2302.severity = warning
 
 # Title    : Do not use insecure deserializer LosFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2305.severity = warning
 
 # Title    : Do not use insecure deserializer NetDataContractSerializer
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2310.severity = warning
 
 # Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2311.severity = warning
 
 # Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2312.severity = warning
 
 # Title    : Do not use insecure deserializer ObjectStateFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2315.severity = warning
 
 # Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2321.severity = warning
 
 # Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2322.severity = warning
 
 # Title    : Do not use TypeNameHandling values other than None
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2326.severity = warning
 
 # Title    : Do not use insecure JsonSerializerSettings
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2327.severity = warning
 
 # Title    : Ensure that JsonSerializerSettings are secure
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2328.severity = warning
 
 # Title    : Do not deserialize with JsonSerializer using an insecure configuration
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2329.severity = warning
 
 # Title    : Ensure that JsonSerializer has a secure configuration when deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2330.severity = warning
 
 # Title    : Do not use DataTable.ReadXml() with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2350.severity = warning
 
 # Title    : Do not use DataSet.ReadXml() with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2351.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2352.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2352.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in serializable type
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2353.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in serializable type
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2353.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2354.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2354.severity = warning
 
 # Title    : Unsafe DataSet or DataTable type found in deserializable object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2355.severity = warning
 
 # Title    : Unsafe DataSet or DataTable type found in deserializable object graph
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2355.severity = warning
 
 # Title    : Unsafe DataSet or DataTable type in web deserializable object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2356.severity = warning
 
 # Title    : Unsafe DataSet or DataTable type in web deserializable object graph
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2356.severity = warning
 
 # Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2361.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2362.severity = warning
 
 # Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2362.severity = warning
 
 # Title    : Review code for SQL injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3001.severity = warning
 
 # Title    : Review code for XSS vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3002.severity = warning
 
 # Title    : Review code for file path injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3003.severity = warning
 
 # Title    : Review code for information disclosure vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3004.severity = warning
 
 # Title    : Review code for LDAP injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3005.severity = warning
 
 # Title    : Review code for process command injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3006.severity = warning
 
 # Title    : Review code for open redirect vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3007.severity = warning
 
 # Title    : Review code for XPath injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3008.severity = warning
 
 # Title    : Review code for XML injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3009.severity = warning
 
 # Title    : Review code for XAML injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3010.severity = warning
 
 # Title    : Review code for DLL injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3011.severity = warning
 
 # Title    : Review code for regex injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3012.severity = warning
 
 # Title    : Do Not Add Schema By URL
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3061.severity = silent
 
 # Title    : Insecure DTD processing in XML
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3075.severity = warning
 
 # Title    : Insecure XSLT script processing.
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3076.severity = warning
 
 # Title    : Insecure XSLT script processing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3076.severity = warning
 
 # Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3077.severity = warning
 
 # Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3077.severity = warning
 
 # Title    : Mark Verb Handlers With Validate Antiforgery Token
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3147.severity = warning
 
 # Title    : Do Not Use Weak Cryptographic Algorithms
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5350.severity = error
 
 # Title    : Do Not Use Broken Cryptographic Algorithms
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5351.severity = error
 
 # Title    : Review cipher mode usage with cryptography experts
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5358.severity = warning
 
 # Title    : Do Not Disable Certificate Validation
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5359.severity = warning
 
 # Title    : Do Not Call Dangerous Methods In Deserialization
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5360.severity = warning
 
 # Title    : Do Not Disable SChannel Use of Strong Crypto
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5361.severity = warning
 
 # Title    : Potential reference cycle in deserialized object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5362.severity = warning
 
 # Title    : Do Not Disable Request Validation
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5363.severity = warning
 
 # Title    : Do Not Use Deprecated Security Protocols
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5364.severity = warning
 
 # Title    : Do Not Disable HTTP Header Checking
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5365.severity = warning
 
 # Title    : Use XmlReader for 'DataSet.ReadXml()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5366.severity = warning
 
 # Title    : Do Not Serialize Types With Pointer Fields
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5367.severity = warning
 
 # Title    : Set ViewStateUserKey For Classes Derived From Page
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5368.severity = warning
 
 # Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5369.severity = warning
 
 # Title    : Use XmlReader for XmlValidatingReader constructor
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5370.severity = warning
 
 # Title    : Use XmlReader for 'XmlSchema.Read()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5371.severity = warning
 
 # Title    : Use XmlReader for XPathDocument constructor
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5372.severity = warning
 
 # Title    : Do not use obsolete key derivation function
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5373.severity = warning
 
 # Title    : Do Not Use XslTransform
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5374.severity = warning
 
 # Title    : Do Not Use Account Shared Access Signature
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5375.severity = warning
 
 # Title    : Use SharedAccessProtocol HttpsOnly
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5376.severity = warning
 
 # Title    : Use Container Level Access Policy
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5377.severity = warning
 
 # Title    : Do not disable ServicePointManagerSecurityProtocols
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5378.severity = warning
 
 # Title    : Ensure Key Derivation Function algorithm is sufficiently strong
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5379.severity = warning
 
 # Title    : Do Not Add Certificates To Root Store
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5380.severity = warning
 
 # Title    : Ensure Certificates Are Not Added To Root Store
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5381.severity = warning
 
 # Title    : Use Secure Cookies In ASP.NET Core
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5382.severity = warning
 
 # Title    : Ensure Use Secure Cookies In ASP.NET Core
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5383.severity = warning
 
 # Title    : Do Not Use Digital Signature Algorithm (DSA)
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5384.severity = warning
 
 # Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5385.severity = warning
 
 # Title    : Avoid hardcoding SecurityProtocolType value
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5386.severity = warning
 
 # Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5387.severity = warning
 
 # Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5388.severity = warning
 
 # Title    : Do Not Add Archive Item's Path To The Target File System Path
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5389.severity = warning
 
 # Title    : Do not hard-code encryption key
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5390.severity = warning
 
 # Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5391.severity = warning
 
 # Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5392.severity = warning
 
 # Title    : Do not use unsafe DllImportSearchPath value
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5393.severity = warning
 
 # Title    : Do not use insecure randomness
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5394.severity = warning
 
 # Title    : Miss HttpVerb attribute for action methods
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5395.severity = warning
 
 # Title    : Set HttpOnly to true for HttpCookie
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5396.severity = warning
 
 # Title    : Do not use deprecated SslProtocols values
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5397.severity = warning
 
 # Title    : Avoid hardcoded SslProtocols values
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5398.severity = warning
 
 # Title    : HttpClients should enable certificate revocation list checks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5399.severity = warning
 
 # Title    : Ensure HttpClient certificate revocation list check is not disabled
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5400.severity = warning
 
 # Title    : Do not use CreateEncryptor with non-default IV
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5401.severity = warning
 
 # Title    : Use CreateEncryptor with the default IV 
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5402.severity = warning
 
 # Title    : Do not hard-code certificate
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5403.severity = warning
 
 # Title    : Do not disable token validation checks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5404.severity = warning
 
 # Title    : Do not always skip token validation in delegates
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5405.severity = warning
 
-# Title    : Avoid single use string builders in frequently called class members.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR1001.severity = warning
-
-# Title    : Use bitwise operations instead of 'Enum.HasFlag'
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Obsolete
-dotnet_diagnostic.CPR101.severity = none
-
-# Title    : Use HashSet.Contains instead of List.Contains
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR102.severity = warning
-
-# Title    : Use Ordinal and OrdinalIgnoreCase instead of InvariantCulture when localization is not required.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR103.severity = warning
-
-# Title    : Use DateTime.UtcNow instead of DateTime.Now when time zone conversion is not applicable.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR105.severity = warning
-
-# Title    : MemoryStream.ToArray() is memory inefficient and can often be avoided.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR107.severity = warning
-
-# Title    : List.AddRange() is memory inefficient.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Obsolete
-dotnet_diagnostic.CPR108.severity = none
-
-# Title    : List.Reverse can cause boxing. Implement your own reverse for better performance.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Obsolete
-dotnet_diagnostic.CPR109.severity = none
-
-# Title    : Specify an initial list size when initializing a list to reduce reallocations.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Too noisy
-dotnet_diagnostic.CPR110.severity = none
-
-# Title    : ImmutableDictionary is memory inefficient. Use IReadOnlyDictionary if readonly collection is needed.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR111.severity = warning
-
-# Title    : ImmutableList is memory inefficient. Use IReadOnlyList if a readonly collection is needed.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR112.severity = warning
-
-# Title    : Avoid Linq as much as possible since much of the functionality is inefficient.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Too noisy
-dotnet_diagnostic.CPR113.severity = none
-
-# Title    : string.StartWith and string.EndsWith can be implemented more efficiently checking characters with the indexer for short strings.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR114.severity = warning
-
-# Title    : string.Contains with string.ToLower() or string.ToUpper() causes allocations which can be avoided with a case insensitive comparison.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR115.severity = warning
-
-# Title    : string.Equals with string.ToLower() or string.ToUpper() causes allocations which can be avoided with a case insensitive comparison.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR116.severity = warning
-
-# Title    : operator== with string.ToLower() or string.ToUpper() causes allocations which can be avoided with a case insensitive comparison.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR117.severity = warning
-
-# Title    : Linq.SequenceEqual is inefficient.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR118.severity = warning
-
-# Title    : Use Debug.WriteLine for debugging instead of Console.WriteLine.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Duplicate
-dotnet_diagnostic.CPR119.severity = none
-
-# Title    : File.ReadAllXXX should be replaced by using a StreamReader to avoid adding objects to the large object heap (LOH).
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR120.severity = warning
-
-# Title    : Specify 'concurrencyLevel' and 'capacity' in the ConcurrentDictionary ctor.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR121.severity = warning
-
-# Title    : ConcurrentDictionary.Keys and ConcurrentDictionary.Values takes a lock defeats the benefits of concurrency.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR122.severity = warning
-
-# Title    : ConcurrentDictionary Count, ToArray(), CopyTo() and Clear() take locks and defeats the benefits of the concurrency.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR123.severity = warning
-
-# Title    : TraceSource.TraceEvent does a lock on each listener and can cause lock contention.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR124.severity = warning
-
-# Title    : String interning can cause lock contention.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR125.severity = warning
-
-# Title    : string.Format and StringBuilder.AppendFormat are not efficient for concatenation.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR126.severity = warning
-
-# Title    : Use a custom implementation of IComparer rather than Nullable.Compare.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR127.severity = warning
-
-# Title    : Process.GetProcessName/Process.GetMachineName does a lot of processing. Use once per process and save the result.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR128.severity = warning
-
-# Title    : string.IndexOf is inefficient when used to check the beginning of string.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR129.severity = warning
-
-# Title    : ArrayList is non-generic.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR130.severity = none
-
-# Title    : Hashtable is non-generic.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR131.severity = none
-
-# Title    : Avoid char.ToString.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR134.severity = warning
-
-# Title    : Stream.CopyTo should be used with buffer size.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR135.severity = warning
-
-# Title    : StreamReader.ReadLine can allocate StringBuilder instances each call if the lines are longer than the buffer size.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR136.severity = warning
-
-# Title    : Random class instances should be shared as statics. Random is not thread safe so locks, ThreadLocal class or [ThreadStatic] attribute should be used for synchronization.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR138.severity = warning
-
-# Title    : Regular expressions should be reused from static fields or properties.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR139.severity = warning
-
-# Title    : TextWriter.WriteLine(string) allocates a char array. Use different overload or make two calls.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR140.severity = warning
-
-# Title    : Reduce delegate allocations by storing them in static fields and properties.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : This rule flags most lambda uses, which makes it extremely verbose and not particularly useful
-dotnet_diagnostic.CPR145.severity = none
-
-# Title    : Extra dictionary access
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR500.severity = warning
-
-# Title    : Avoid repeated type checking.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR501.severity = warning
-
-# Title    : Do not cast multiple times.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR502.severity = warning
-
-# Title    : Extra HashSet access
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR503.severity = warning
-
-# Title    : Do not use banned insecure deserialization APIs
-# Category : Security
-# Help Link: https://aka.ms/ia2989
-dotnet_diagnostic.IA2989.severity = error
-
-# Title    : Do Not Use Banned APIs For Insecure Deserializers
-# Category : Security
-# Help Link: https://aka.ms/ia2992
-dotnet_diagnostic.IA2992.severity = error
-
-# Title    : Do Not Use Banned Constructors For Insecure Deserializers
-# Category : Security
-# Help Link: https://aka.ms/ia2993
-dotnet_diagnostic.IA2993.severity = error
-
-# Title    : Do Not Use ResourceSet Without ResourceReader
-# Category : Security
-# Help Link: https://aka.ms/ia2994
-dotnet_diagnostic.IA2994.severity = error
-
-# Title    : Do Not Use ResourceReader
-# Category : Security
-# Help Link: https://aka.ms/ia2995
-dotnet_diagnostic.IA2995.severity = error
-
-# Title    : Do Not Use ResXResourceReader Without ITypeResolutionService
-# Category : Security
-# Help Link: https://aka.ms/ia2996
-dotnet_diagnostic.IA2996.severity = error
-
-# Title    : Do Not Use TypeNameHandling Other Than None
-# Category : Security
-# Help Link: https://aka.ms/ia2997
-dotnet_diagnostic.IA2997.severity = error
-
-# Title    : Do Not Deserialize With BinaryFormatter Without Binder
-# Category : Security
-# Help Link: https://aka.ms/ia2998
-dotnet_diagnostic.IA2998.severity = error
-
-# Title    : Do Not Set BinaryFormatter.Binder to null
-# Category : Security
-# Help Link: https://aka.ms/ia2999
-dotnet_diagnostic.IA2999.severity = error
-
-# Title    : Do Not Use Weak Cryptographic Algorithms
-# Category : Security
-# Help Link: http://aka.ms/IA5350
-# Tags     : Telemetry
-dotnet_diagnostic.IA5350.severity = error
-
-# Title    : Do Not Use Broken Cryptographic Algorithms
-# Category : Security
-# Help Link: http://aka.ms/IA5351
-# Tags     : Telemetry
-dotnet_diagnostic.IA5351.severity = error
-
-# Title    : Do Not Misuse Cryptographic APIs 
-# Category : Security
-# Help Link: http://aka.ms/IA5352
-# Tags     : Telemetry
-dotnet_diagnostic.IA5352.severity = error
-
-# Title    : Use approved crypto libraries for the supported platform
-# Category : Security
-# Help Link: https://aka.ms/ia5359
-# Tags     : Telemetry
-dotnet_diagnostic.IA5359.severity = error
-
-# Title    : Custom web token handler was found
-# Category : Security
-# Help Link: https://aka.ms/ia6450
-# Tags     : Telemetry
-dotnet_diagnostic.IA6450.severity = error
-
-# Title    : Implement required validations for app asserted actor token
-# Category : Security
-# Help Link: https://aka.ms/ia6451
-# Tags     : Telemetry
-dotnet_diagnostic.IA6451.severity = warning
-
-# Title    : Do not disable {0}
-# Category : Security
-# Help Link: https://aka.ms/ia6452
-# Tags     : Telemetry
-dotnet_diagnostic.IA6452.severity = error
-
-# Title    : Do not disable {0}
-# Category : Security
-# Help Link: https://aka.ms/ia6453
-# Tags     : Telemetry
-dotnet_diagnostic.IA6453.severity = error
-
-# Title    : Do not disable {0}
-# Category : Security
-# Help Link: https://aka.ms/ia6454
-# Tags     : Telemetry
-dotnet_diagnostic.IA6454.severity = error
-
-# Title    : Do Not Use Insecure PowerShell LanguageModes
-# Category : Security
-# Help Link: https://aka.ms/ia6456
-# Tags     : Telemetry
-dotnet_diagnostic.IA6456.severity = error
-
-# Title    : Review PowerShell Execution for PowerShell Injection
-# Category : Security
-# Help Link: https://aka.ms/IA6457
-dotnet_diagnostic.IA6457.severity = warning
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
 
 # Title    : Simplify name
 # Category : Style
@@ -2273,25 +1721,23 @@ dotnet_style_qualification_for_property = false
 
 # Title    : Remove Unnecessary Cast
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
 dotnet_diagnostic.IDE0004.severity = warning
 
 # Title    : Using directive is unnecessary.
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
 dotnet_diagnostic.IDE0005.severity = none
 
 # Title    : Using directive is unnecessary.
 # Category : Style
-# Tags     : Telemetry, EnforceOnBuild_Never, NotConfigurable, Unnecessary
+# Redundant: S1128
 dotnet_diagnostic.IDE0005_gen.severity = none
 
 # Title    : Use implicit type
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
 dotnet_diagnostic.IDE0007.severity = silent
 csharp_style_var_elsewhere = true
 csharp_style_var_for_built_in_types = false
@@ -2299,243 +1745,213 @@ csharp_style_var_when_type_is_apparent = true
 
 # Title    : Use explicit type
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
 dotnet_diagnostic.IDE0008.severity = silent
 
 # Title    : Member access should be qualified.
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
-# Tags     : Telemetry, EnforceOnBuild_Never
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0009.severity = none
 
 # Title    : Add missing cases
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
 dotnet_diagnostic.IDE0010.severity = silent
 
 # Title    : Add braces
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
 dotnet_diagnostic.IDE0011.severity = warning
 csharp_prefer_braces = true
 
 # Title    : Use 'throw' expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
 dotnet_diagnostic.IDE0016.severity = warning
 csharp_style_throw_expression = true
 
 # Title    : Simplify object initialization
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
 dotnet_diagnostic.IDE0017.severity = warning
 dotnet_style_object_initializer = true
 
 # Title    : Inline variable declaration
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
 dotnet_diagnostic.IDE0018.severity = warning
 csharp_style_inlined_variable_declaration = true
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
 dotnet_diagnostic.IDE0019.severity = silent
 csharp_style_pattern_matching_over_is_with_cast_check = true
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
 dotnet_diagnostic.IDE0020.severity = silent
 csharp_style_pattern_matching_over_is_with_cast_check
 
-# Title    : Use expression body for constructors
+# Title    : Use expression body for constructor
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
 dotnet_diagnostic.IDE0021.severity = warning
 csharp_style_expression_bodied_constructors = false
 
-# Title    : Use expression body for methods
+# Title    : Use expression body for method
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
 dotnet_diagnostic.IDE0022.severity = silent
 csharp_style_expression_bodied_methods = when_on_single_line
 
-# Title    : Use expression body for conversion operators
+# Title    : Use expression body for conversion operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
 dotnet_diagnostic.IDE0023.severity = warning
 csharp_style_expression_bodied_operators = false
 
-# Title    : Use expression body for operators
+# Title    : Use expression body for operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
 dotnet_diagnostic.IDE0024.severity = warning
 csharp_style_expression_bodied_operators = false
 
-# Title    : Use expression body for properties
+# Title    : Use expression body for property
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
 dotnet_diagnostic.IDE0025.severity = warning
 csharp_style_expression_bodied_properties = true
 
-# Title    : Use expression body for indexers
+# Title    : Use expression body for indexer
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
 dotnet_diagnostic.IDE0026.severity = warning
 csharp_style_expression_bodied_indexers = true
 
-# Title    : Use expression body for accessors
+# Title    : Use expression body for accessor
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
 dotnet_diagnostic.IDE0027.severity = warning
 csharp_style_expression_bodied_accessors = true
 
 # Title    : Simplify collection initialization
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
 dotnet_diagnostic.IDE0028.severity = warning
 dotnet_style_collection_initializer = true
 
 # Title    : Use coalesce expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
 dotnet_diagnostic.IDE0029.severity = warning
 dotnet_style_coalesce_expression = true
 
 # Title    : Use coalesce expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
 dotnet_diagnostic.IDE0030.severity = warning
 dotnet_style_coalesce_expression = true
 
 # Title    : Use null propagation
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
 dotnet_diagnostic.IDE0031.severity = warning
 dotnet_style_null_propagation = true
 
 # Title    : Use auto property
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
 dotnet_diagnostic.IDE0032.severity = warning
 dotnet_style_prefer_auto_properties = true
 
 # Title    : Use explicitly provided tuple name
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
 dotnet_diagnostic.IDE0033.severity = warning
 dotnet_style_explicit_tuple_names = true
 
 # Title    : Simplify 'default' expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
 dotnet_diagnostic.IDE0034.severity = warning
 csharp_prefer_simple_default_expression = true
 
 # Title    : Unreachable code detected
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
-# Tags     : Telemetry, EnforceOnBuild_Never, NotConfigurable, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0035.severity = warning
 
 # Title    : Order modifiers
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
 dotnet_diagnostic.IDE0036.severity = silent
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
 
 # Title    : Use inferred member name
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
 dotnet_diagnostic.IDE0037.severity = silent
 dotnet_style_prefer_inferred_anonymous_type_member_names = true
 dotnet_style_prefer_inferred_tuple_names = true
 
 # Title    : Use local function
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
 dotnet_diagnostic.IDE0039.severity = silent
 csharp_style_prefer_local_over_anonymous_function = false
 
 # Title    : Add accessibility modifiers
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
 dotnet_diagnostic.IDE0040.severity = warning
 dotnet_style_require_accessibility_modifiers = for_non_interface_members
 
 # Title    : Use 'is null' check
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
 dotnet_diagnostic.IDE0041.severity = warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true
 
 # Title    : Deconstruct variable declaration
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
 dotnet_diagnostic.IDE0042.severity = silent
 csharp_style_deconstructed_variable_declaration = true
 
 # Title    : Invalid format string
 # Category : Compiler
-# Tags     : EnforceOnBuild_HighlyRecommended
 dotnet_diagnostic.IDE0043.severity = warning
 
 # Title    : Add readonly modifier
 # Category : Style
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
 dotnet_diagnostic.IDE0044.severity = warning
 dotnet_style_readonly_field = true:warning
 
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
 # Title    : Convert to conditional expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
 dotnet_diagnostic.IDE0045.severity = silent
 dotnet_style_prefer_conditional_expression_over_assignment = true
 
 # Title    : Convert to conditional expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
 dotnet_diagnostic.IDE0046.severity = silent
 dotnet_style_prefer_conditional_expression_over_return = true
 
 # Title    : Remove unnecessary parentheses
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
 dotnet_diagnostic.IDE0047.severity = silent
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
@@ -2544,8 +1960,7 @@ dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
 
 # Title    : Add parentheses for clarity
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
 dotnet_diagnostic.IDE0048.severity = silent
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
@@ -2562,41 +1977,35 @@ dotnet_diagnostic.IDE0049.severity = none
 
 # Title    : Convert to tuple
 # Category : Style
-# Tags     : Telemetry
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0050.severity = silent
 
 # Title    : Remove unused private members
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
 dotnet_diagnostic.IDE0051.severity = warning
 
 # Title    : Remove unread private members
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
 dotnet_diagnostic.IDE0052.severity = warning
 
-# Title    : Use expression body for lambda expressions
+# Title    : Use block body for lambda expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
 # Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
 dotnet_diagnostic.IDE0053.severity = suggestion
 csharp_style_expression_bodied_lambdas = when_on_single_line
 
 # Title    : Use compound assignment
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
 dotnet_diagnostic.IDE0054.severity = warning
 dotnet_style_prefer_compound_assignment = true
 
 # Title    : Fix formatting
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
 dotnet_diagnostic.IDE0055.severity = warning
 dotnet_style_namespace_match_folder = true
 csharp_new_line_before_catch = true
@@ -2639,69 +2048,60 @@ csharp_preserve_single_line_statements = false
 
 # Title    : Use index operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
 dotnet_diagnostic.IDE0056.severity = silent
 csharp_style_prefer_index_operator = true
 
 # Title    : Use range operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
 dotnet_diagnostic.IDE0057.severity = silent
 csharp_style_prefer_range_operator = true:warning
 
 # Title    : Expression value is never used
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
 dotnet_diagnostic.IDE0058.severity = warning
 csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # Title    : Unnecessary assignment of a value
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
 dotnet_diagnostic.IDE0059.severity = none
 
 # Title    : Remove unused parameter
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
 dotnet_diagnostic.IDE0060.severity = warning
 dotnet_code_quality_unused_parameters = all
 
-# Title    : Use expression body for local functions
+# Title    : Use expression body for local function
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
 dotnet_diagnostic.IDE0061.severity = warning
 csharp_style_expression_bodied_local_functions = true
 
 # Title    : Make local function 'static'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
 dotnet_diagnostic.IDE0062.severity = warning
 csharp_prefer_static_local_function = true
 
 # Title    : Use simple 'using' statement
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
 dotnet_diagnostic.IDE0063.severity = warning
 csharp_prefer_simple_using_statement = true
 
 # Title    : Make readonly fields writable
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
 dotnet_diagnostic.IDE0064.severity = warning
 
 # Title    : Misplaced using directive
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
 dotnet_diagnostic.IDE0065.severity = warning
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
@@ -2709,228 +2109,214 @@ csharp_using_directive_placement = outside_namespace:suggestion
 
 # Title    : Convert switch statement to expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
 dotnet_diagnostic.IDE0066.severity = warning
 csharp_style_prefer_switch_expression = true:warning
 
 # Title    : Use 'System.HashCode'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
 dotnet_diagnostic.IDE0070.severity = warning
 
 # Title    : Simplify interpolation
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
 dotnet_diagnostic.IDE0071.severity = warning
 dotnet_style_prefer_simplified_interpolation = true
 
 # Title    : Add missing cases
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
 dotnet_diagnostic.IDE0072.severity = silent
 
-# Title    : The file header is missing or not located at the top of the file
+# Title    : The file header does not match the required text
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
 dotnet_diagnostic.IDE0073.severity = warning
 
 # Title    : Use compound assignment
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0074.severity = suggestion
 dotnet_style_prefer_compound_assignment = true
 
 # Title    : Simplify conditional expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
 dotnet_diagnostic.IDE0075.severity = warning
 dotnet_style_prefer_simplified_boolean_expressions = true
 
 # Title    : Invalid global 'SuppressMessageAttribute'
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
 dotnet_diagnostic.IDE0076.severity = warning
 
 # Title    : Avoid legacy format target in 'SuppressMessageAttribute'
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
 dotnet_diagnostic.IDE0077.severity = warning
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
 dotnet_diagnostic.IDE0078.severity = silent
 csharp_style_prefer_pattern_matching = true
 
 # Title    : Remove unnecessary suppression
 # Category : Style
-# Tags     : Telemetry
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0079.severity = suggestion
 dotnet_remove_unnecessary_suppression_exclusions = CS0618
 
 # Title    : Remove unnecessary suppression operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
 dotnet_diagnostic.IDE0080.severity = warning
 
 # Title    : 'typeof' can be converted  to 'nameof'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
 dotnet_diagnostic.IDE0082.severity = warning
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
 dotnet_diagnostic.IDE0083.severity = silent
 csharp_style_prefer_not_pattern = true
 
 # Title    : Use 'new(...)'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
 dotnet_diagnostic.IDE0090.severity = warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 
 # Title    : Remove redundant equality
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
 # Comment  : S1125 triggers in more cases
+# Redundant: S1125
 dotnet_diagnostic.IDE0100.severity = none
 
 # Title    : Remove unnecessary discard
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
 dotnet_diagnostic.IDE0110.severity = warning
 
 # Title    : Simplify LINQ expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
 dotnet_diagnostic.IDE0120.severity = silent
 
 # Title    : Namespace does not match folder structure
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
 dotnet_diagnostic.IDE0130.severity = silent
 
 # Title    : Prefer 'null' check over type check
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
 dotnet_diagnostic.IDE0150.severity = warning
 csharp_style_prefer_null_check_over_type_check = true
 
 # Title    : Convert to block scoped namespace
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
 dotnet_diagnostic.IDE0160.severity = silent
 csharp_style_namespace_declarations = file_scoped
 
 # Title    : Convert to file-scoped namespace
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
 dotnet_diagnostic.IDE0161.severity = silent
 csharp_style_namespace_declarations = file_scoped
 
 # Title    : Property pattern can be simplified
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
 dotnet_diagnostic.IDE0170.severity = silent
 csharp_style_prefer_extended_property_pattern = true
 
 # Title    : Use tuple to swap values
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
 dotnet_diagnostic.IDE0180.severity = silent
 csharp_style_prefer_tuple_swap = true
 
 # Title    : Null check can be simplified
 # Category : Style
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
 dotnet_diagnostic.IDE0190.severity = silent
 
 # Title    : Remove unnecessary lambda expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
 dotnet_diagnostic.IDE0200.severity = silent
 
 # Title    : Convert to top-level statements
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
 dotnet_diagnostic.IDE0210.severity = silent
 
 # Title    : Convert to 'Program.Main' style program
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
 dotnet_diagnostic.IDE0211.severity = silent
 
 # Title    : Add explicit cast
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
 dotnet_diagnostic.IDE0220.severity = silent
 
 # Title    : Use UTF-8 string literal
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
 dotnet_diagnostic.IDE0230.severity = silent
 
 # Title    : Remove redundant nullable directive
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
 dotnet_diagnostic.IDE0240.severity = warning
 
 # Title    : Remove unnecessary nullable directive
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
 dotnet_diagnostic.IDE0241.severity = warning
 
 # Title    : Make struct 'readonly'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
 dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
 
 # Title    : Delegate invocation can be simplified.
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
 dotnet_diagnostic.IDE1005.severity = warning
 csharp_style_conditional_delegate_call = true
 
 # Title    : Naming Styles
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
 dotnet_diagnostic.IDE1006.severity = warning
 dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
 dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
@@ -3009,34 +2395,39 @@ dotnet_naming_style.tpascalcase.capitalization = pascal_case
 
 # Title    : Avoid multiple blank lines
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
 dotnet_diagnostic.IDE2000.severity = warning
 dotnet_style_allow_multiple_blank_lines_experimental = false
 
 # Title    : Embedded statements must be on their own line
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
 dotnet_diagnostic.IDE2001.severity = warning
 
 # Title    : Consecutive braces must not have blank line between them
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
 dotnet_diagnostic.IDE2002.severity = warning
 
 # Title    : Blank line required between block and subsequent statement
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
 dotnet_diagnostic.IDE2003.severity = silent
 
 # Title    : Blank line not allowed after constructor initializer colon
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
 dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
 
 # Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 # Category : Trimming
@@ -3265,7 +2656,6 @@ dotnet_diagnostic.IL3000.severity = warning
 # Title    : Avoid using accessing Assembly file path when publishing as a single-file
 # Category : Publish
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.IL3000.severity = warning
 
 # Title    : Avoid accessing Assembly file path when publishing as a single file
@@ -3275,7 +2665,6 @@ dotnet_diagnostic.IL3001.severity = warning
 # Title    : Avoid using accessing Assembly file path when publishing as a single-file
 # Category : Publish
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.IL3001.severity = warning
 
 # Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
@@ -3304,257 +2693,112 @@ dotnet_diagnostic.IL3056.severity = warning
 
 # Title    : Use source generated logging methods for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a000
+# Help Link: https://TODO/r9a000
 dotnet_diagnostic.R9A000.severity = warning
 
-# Title    : Use 'Microsoft.IO.RecyclableMemoryStream' instead of 'System.IO.MemoryStream' for improved performance
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a001
-dotnet_diagnostic.R9A001.severity = warning
-
-# Title    : Use higher performance methods from 'IExtendedDistributedCache'
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a003
-dotnet_diagnostic.R9A003.severity = warning
-
-# Title    : Use the 'Microsoft.R9.Extensions.Caching.Redis' package instead of 'Microsoft.Extensions.Caching.StackExchangeRedis'
-# Category : Resilience
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a005
-dotnet_diagnostic.R9A005.severity = warning
-
-# Title    : Update return type to match metric type
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a006
-dotnet_diagnostic.R9A006.severity = error
-
-# Title    : Remove method body
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a007
-dotnet_diagnostic.R9A007.severity = error
-
-# Title    : Add a parameter of type 'IMeter' to the method declaration
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a008
-dotnet_diagnostic.R9A008.severity = error
-
-# Title    : Update method parameters for dimensions to be string type
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a009
-dotnet_diagnostic.R9A009.severity = error
-
-# Title    : Make method static
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a010
-dotnet_diagnostic.R9A010.severity = error
-
-# Title    : Make method partial
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a011
-dotnet_diagnostic.R9A011.severity = error
-
-# Title    : Make method public
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a012
-dotnet_diagnostic.R9A012.severity = warning
-
-# Title    : Seal non-public classes for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a013
-dotnet_diagnostic.R9A013.severity = warning
-
-# Title    : Use the 'Microsoft.R9.Extensions.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a014
+# Help Link: https://TODO/r9a014
 dotnet_diagnostic.R9A014.severity = warning
 
-# Title    : Use the 'Microsoft.R9.Extensions.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a015
+# Help Link: https://TODO/r9a015
 dotnet_diagnostic.R9A015.severity = warning
 
-# Title    : Use eager options validation
-# Category : Reliability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a016
-dotnet_diagnostic.R9A016.severity = warning
-
-# Title    : Use asynchronous operations instead of legacy thread blocking code
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a017
-dotnet_diagnostic.R9A017.severity = warning
-
-# Title    : Use 'Microsoft.R9.Extensions.Text.CompositeFormat' instead of 'string.Format' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a018
+# Help Link: https://TODO/r9a018
 dotnet_diagnostic.R9A018.severity = warning
 
 # Title    : Remove unnecessary dictionary lookups
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a019
+# Help Link: https://TODO/r9a019
 dotnet_diagnostic.R9A019.severity = warning
 
 # Title    : Remove unnecessary set lookups
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a020
+# Help Link: https://TODO/r9a020
 dotnet_diagnostic.R9A020.severity = warning
 
 # Title    : Perform message formatting in the body of the logging method
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a021
+# Help Link: https://TODO/r9a021
 dotnet_diagnostic.R9A021.severity = warning
 
 # Title    : Use 'System.TimeProvider' to make the code easier to test
 # Category : Reliability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a022
+# Help Link: https://TODO/r9a022
 dotnet_diagnostic.R9A022.severity = warning
-
-# Title    : Use 'Microsoft.R9.Extensions.Time.PerfStopwatch' instead of 'System.Diagnostics.Stopwatch' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a023
-dotnet_diagnostic.R9A023.severity = warning
-
-# Title    : Propagate data classification
-# Category : Privacy
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a024
-dotnet_diagnostic.R9A024.severity = warning
-
-# Title    : Use fixed format for 'System.ObsoleteAttribute' message
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a025
-dotnet_diagnostic.R9A025.severity = warning
-
-# Title    : Minimum deprecation period for an obsolete public API
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a026
-dotnet_diagnostic.R9A026.severity = warning
-
-# Title    : Use fixed API surface format for soft deleted members
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a027
-dotnet_diagnostic.R9A027.severity = warning
-
-# Title    : Argument provided for user input parameter on user data vending API is not from any request context
-# Category : Privacy
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a028
-dotnet_diagnostic.R9A028.severity = warning
 
 # Title    : Using experimental API
 # Category : Reliability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a029
+# Help Link: https://TODO/r9a029
 dotnet_diagnostic.R9A029.severity = none
 
 # Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a030
+# Help Link: https://TODO/r9a030
 dotnet_diagnostic.R9A030.severity = warning
 
 # Title    : Make types declared in an executable internal
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a031
+# Help Link: https://TODO/r9a031
 dotnet_diagnostic.R9A031.severity = warning
 
 # Title    : Consider using an array instead of a collection
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a032
+# Help Link: https://TODO/r9a032
 dotnet_diagnostic.R9A032.severity = none
 
 # Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a033
+# Help Link: https://TODO/r9a033
 dotnet_diagnostic.R9A033.severity = warning
 
-# Title    : Optimize method group use to avoid allocations
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a034
-dotnet_diagnostic.R9A034.severity = warning
-
-# Title    : Make struct readonly
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a035
-dotnet_diagnostic.R9A035.severity = warning
-
-# Title    : Use 'Microsoft.R9.Extensions.Text.NumericExtensions.ToInvariantString' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a036
+# Help Link: https://TODO/r9a036
 dotnet_diagnostic.R9A036.severity = warning
 
 # Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a037
+# Help Link: https://TODO/r9a037
 dotnet_diagnostic.R9A037.severity = warning
-
-# Title    : Use 'Microsoft.R9.Extensions.Pools.PoolFactory' instead for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a038
-dotnet_diagnostic.R9A038.severity = warning
-
-# Title    : Remove superfluous null checks when compiling in a nullable context
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a039
-dotnet_diagnostic.R9A039.severity = none
 
 # Title    : Use generic collections instead of legacy collections for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a040
+# Help Link: https://TODO/r9a040
 dotnet_diagnostic.R9A040.severity = warning
 
-# Title    : Use concrete types when possible for improved performance
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a041
-dotnet_diagnostic.R9A041.severity = warning
-
-# Title    : Annotate all User Data APIs parameters
-# Category : Privacy
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a042
-dotnet_diagnostic.R9A042.severity = warning
-
-# Title    : Use 'Microsoft.R9.Extensions.Text.StringSplitExtensions.TrySplit' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a043
+# Help Link: https://TODO/r9a043
 dotnet_diagnostic.R9A043.severity = warning
 
 # Title    : Assign array of literal values to a static field for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a044
+# Help Link: https://TODO/r9a044
 dotnet_diagnostic.R9A044.severity = warning
 
-# Title    : Use 'Array.Empty<T>' instead of allocating a 0-element array for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a045
-dotnet_diagnostic.R9A045.severity = warning
-
-# Title    : Source generated metrics (fast metrics) should be located in 'Metric' class
-# Category : Readability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a046
-dotnet_diagnostic.R9A046.severity = warning
-
-# Title    : Do not use manual metrics, use fast (source generated) metrics instead for better performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a047
-dotnet_diagnostic.R9A047.severity = warning
-
-# Title    : Use the 'Count' or 'Length' properties instead of the 'Any' method for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a048
-dotnet_diagnostic.R9A048.severity = warning
-
-# Title    : Newly added API must be annotated with experimental attribute
+# Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a049
+# Help Link: https://TODO/r9a049
 dotnet_diagnostic.R9A049.severity = warning
 
-# Title    : An experimental API was marked as obsolete
+# Title    : Experimental symbols cannot be marked as obsolete
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a050
+# Help Link: https://TODO/r9a050
 dotnet_diagnostic.R9A050.severity = warning
 
-# Title    : A stable API was marked as experimental
+# Title    : Published symbols cannot be marked experimental
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a051
+# Help Link: https://TODO/r9a051
 dotnet_diagnostic.R9A051.severity = warning
 
-# Title    : A stable API was deleted outside the deprecation period
+# Title    : Published symbols cannot be deleted to maintain compatibility
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a052
+# Help Link: https://TODO/r9a052
 dotnet_diagnostic.R9A052.severity = warning
 
 # Title    : A deprecated API is not annotated with the obsolete attribute
@@ -3567,2526 +2811,2168 @@ dotnet_diagnostic.R9A053.severity = warning
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
 dotnet_diagnostic.R9A054.severity = warning
 
-# Title    : The signature of a stable API has changed
+# Title    : Published symbols cannot be changed to maintain compatibility
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a055
-dotnet_diagnostic.R9A055.severity = none
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
 
 # Title    : Fire-and-forget async call inside a 'using' block
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a056
+# Help Link: https://TODO/r9a056
 dotnet_diagnostic.R9A056.severity = warning
-
-# Title    : Use consistent versions of R9 assemblies
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a057
-dotnet_diagnostic.R9A057.severity = warning
 
 # Title    : Consider removing unnecessary conditional access operator (?)
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a058
+# Help Link: https://TODO/r9a058
 dotnet_diagnostic.R9A058.severity = suggestion
 
 # Title    : Consider removing unnecessary null coalescing assignment (??=)
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a059
+# Help Link: https://TODO/r9a059
 dotnet_diagnostic.R9A059.severity = suggestion
 
 # Title    : Consider removing unnecessary null coalescing operator (??)
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a060
+# Help Link: https://TODO/r9a060
 dotnet_diagnostic.R9A060.severity = suggestion
 
 # Title    : The async method doesn't support cancellation
 # Category : Resilience
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a061
+# Help Link: https://TODO/r9a061
 dotnet_diagnostic.R9A061.severity = warning
 
 # Title    : 
 # Category : Style
-# Tags     : Telemetry, EnforceOnBuild_Never, NotConfigurable
 dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 
 # Title    : Methods and properties should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: IDE1006
 dotnet_diagnostic.S100.severity = none
 
 # Title    : Method overrides should not change parameter defaults
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE1006
 dotnet_diagnostic.S101.severity = none
 
 # Title    : Lines should not be too long
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S103.severity = warning
 
 # Title    : Files should not have too many lines of code
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S104.severity = warning
 
 # Title    : Destructors should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1065
 dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: SA1027
 dotnet_diagnostic.S105.severity = none
 
 # Title    : Standard outputs should not be used directly to log anything
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S106.severity = warning
 
 # Title    : Collapsible "if" statements should be merged
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1066.severity = none
 
 # Title    : Expressions should not be too complex
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1067.severity = warning
 
 # Title    : Methods should not have too many parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S107.severity = warning
 
 # Title    : URIs should not be hardcoded
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1075.severity = warning
 
 # Title    : Nested blocks of code should not be left empty
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S108.severity = warning
 
 # Title    : Magic numbers should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S109.severity = warning
 
 # Title    : Inheritance tree of classes should not be too deep
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1051
 dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: SA1500
 dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: SA1119
 dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: SA1106
 dotnet_diagnostic.S1116.severity = none
 
 # Title    : Local variables should not shadow class fields
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1052
 dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA2219
 dotnet_diagnostic.S112.severity = none
 
 # Title    : Assignments should not be made from within sub-expressions
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1041
 dotnet_diagnostic.S1123.severity = none
 
 # Title    : Boolean literals should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1125.severity = warning
 
 # Title    : Unused "using" should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1128.severity = warning
 
 # Title    : Files should contain an empty newline at the end
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S113.severity = none
 
 # Title    : Track uses of "FIXME" tags
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1134.severity = warning
 
 # Title    : Track uses of "TODO" tags
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1135.severity = warning
 
 # Title    : Unused private types or members should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay, Unnecessary
 dotnet_diagnostic.S1144.severity = warning
 
 # Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1145.severity = warning
 
 # Title    : Exit methods should not be called
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1147.severity = warning
 
 # Title    : "switch case" clauses should not have too many lines of code
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1151.severity = none
 
 # Title    : "Any()" should be used to test for emptiness
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA2219
 dotnet_diagnostic.S1163.severity = none
 
 # Title    : Empty arrays and collections should be returned instead of null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0060
 dotnet_diagnostic.S1172.severity = none
 
 # Title    : Overriding members should do more than simply call the same member in the base class
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1185.severity = warning
 
 # Title    : Methods should not be empty
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1186.severity = warning
 
 # Title    : String literals should not be duplicated
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1192.severity = suggestion
 
 # Title    : Nested code blocks should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1199.severity = warning
 
 # Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CS0659
 dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: SA1503
 dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1036
 dotnet_diagnostic.S1210.severity = none
 
 # Title    : "GC.Collect" should not be called
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1215.severity = warning
 
 # Title    : Statements should be on separate lines
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S122.severity = none
 
 # Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1226.severity = warning
 
 # Title    : break statements should not be used except for switch cases
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1227.severity = none
 
 # Title    : Floating point numbers should not be tested for equality
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1244.severity = error
 
 # Title    : Sections of code should not be commented out
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S125.severity = warning
 
 # Title    : "if ... else if" constructs should end with "else" clauses
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S126.severity = none
 
 # Title    : A "while" loop should be used instead of a "for" loop
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1264.severity = warning
 
 # Title    : "for" loop stop conditions should be invariant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S127.severity = warning
 
 # Title    : "switch" statements should have at least 3 "case" clauses
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
-# Tags     : C#, MainSourceScope, TestSourceScope
 # Comment  : Suppressions are frequently necessary.
 dotnet_diagnostic.S1309.severity = none
 
 # Title    : "switch/Select" statements should contain a "default/Case Else" clauses
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S131.severity = none
 
 # Title    : Using hardcoded IP addresses is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1313.severity = warning
 
 # Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S134.severity = none
 
 # Title    : Functions should not have too many lines of code
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S138.severity = none
 
 # Title    : Culture should be specified for "string" operations
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1449.severity = warning
 
 # Title    : Private fields only used as local variables in methods should become local variables
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: IDE0073
 dotnet_diagnostic.S1451.severity = none
 
 # Title    : "switch" statements should not have too many "case" clauses
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CS0168
 dotnet_diagnostic.S1481.severity = none
 
 # Title    : Methods and properties should not be too complex
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1541.severity = none
 
 # Title    : Tests should not be ignored
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S1607.severity = warning
 
 # Title    : Strings should not be concatenated using '+' in a loop
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1643.severity = warning
 
 # Title    : Variables should not be self-assigned
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1656.severity = warning
 
 # Title    : Multiple variables should not be declared on the same line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1659.severity = warning
 
 # Title    : An abstract class should have both abstract and concrete methods
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1694.severity = warning
 
 # Title    : NullReferenceException should not be caught
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1696.severity = warning
 
 # Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1697.severity = warning
 
 # Title    : "==" should not be used when "Equals" is overridden
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1698.severity = warning
 
 # Title    : Constructors should only call non-overridable methods
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1699.severity = warning
 
 # Title    : Loops with at most one iteration should be refactored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1751.severity = warning
 
 # Title    : Identical expressions should not be used on both sides of a binary operator
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1764.severity = warning
 
 # Title    : "switch" statements should not be nested
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1821.severity = none
 
 # Title    : Objects should not be created to be dropped immediately without being used
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0059
 dotnet_diagnostic.S1854.severity = none
 
 # Title    : "ToString()" calls should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1858.severity = warning
 
 # Title    : Related "if/else if" statements should not have the same condition
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1862.severity = warning
 
 # Title    : Two branches in a conditional structure should not have exactly the same implementation
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0004
 dotnet_diagnostic.S1905.severity = none
 
 # Title    : Inheritance list should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1939.severity = warning
 
 # Title    : Boolean checks should not be inverted
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1940.severity = warning
 
 # Title    : Inappropriate casts should not be made
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1944.severity = warning
 
 # Title    : "for" loop increment clauses should modify the loops' counters
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : Analysis is too slow
 dotnet_diagnostic.S2053.severity = none
 
 # Title    : Hard-coded credentials are security-sensitive
 # Category : Blocker Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
-# Tags     : C#, MainSourceScope
+# Redundant: CA5350
 dotnet_diagnostic.S2070.severity = none
 
 # Title    : Formatting SQL queries is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2077.severity = warning
 
 # Title    : Creating cookies without the "secure" flag is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2092.severity = warning
 
 # Title    : Collections should not be passed as arguments to their own methods
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2114.severity = warning
 
 # Title    : A secure password should be used when connecting to a database
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2115.severity = warning
 
 # Title    : Values should not be uselessly incremented
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2123.severity = warning
 
 # Title    : Underscores should be used to make large numbers readable
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2148.severity = warning
 
 # Title    : "sealed" classes should not have "protected" members
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2156.severity = warning
 
 # Title    : Short-circuit logic should be used in boolean contexts
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2178.severity = warning
 
 # Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2183.severity = warning
 
 # Title    : Results of integer division should not be assigned to floating point variables
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2184.severity = warning
 
 # Title    : TestCases should contain tests
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S2187.severity = warning
 
 # Title    : Recursion should not be infinite
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2190.severity = warning
 
 # Title    : Modulus results should not be checked for direct equality
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2197.severity = warning
 
 # Title    : Return values from functions without side effects should not be ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1806
 dotnet_diagnostic.S2201.severity = none
 
 # Title    : Runtime type checking should be simplified
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2219.severity = warning
 
 # Title    : "Exception" should not be caught
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2221.severity = none
 
 # Title    : Locks should be released on all paths
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2222.severity = warning
 
 # Title    : Non-constant static fields should not be visible
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2223.severity = warning
 
 # Title    : "ToString()" method should not return null
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2225.severity = warning
 
 # Title    : Console logging should not be used
 # Category : Minor Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2228.severity = warning
 
 # Title    : Parameters should be passed in the correct order
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2234.severity = warning
 
 # Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2245.severity = warning
 
 # Title    : A "for" loop update clause should move the counter in the right direction
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2251.severity = warning
 
 # Title    : For-loop conditions should be true at least once
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2252.severity = warning
 
 # Title    : Writing cookies is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2255.severity = warning
 
 # Title    : Using non-standard cryptographic algorithms is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : Redundant, covered by modern C# compiler
 dotnet_diagnostic.S2259.severity = none
 
 # Title    : Composite format strings should not lead to unexpected behavior at runtime
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2275.severity = warning
 
 # Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2278.severity = warning
 
 # Title    : Field-like events should not be virtual
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2290.severity = warning
 
 # Title    : Overflow checking should not be disabled for "Enumerable.Sum"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0032
 dotnet_diagnostic.S2292.severity = none
 
 # Title    : "nameof" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2302.severity = warning
 
 # Title    : "async" and "await" should not be used as identifiers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1822
 dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 # Comment  : Valid pattern used in a number of places
 dotnet_diagnostic.S2326.severity = none
 
 # Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2327.severity = warning
 
 # Title    : "GetHashCode" should not reference mutable fields
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2328.severity = warning
 
 # Title    : Array covariance should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2330.severity = warning
 
 # Title    : Redundant modifiers should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2333.severity = warning
 
 # Title    : Public constant members should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2339.severity = none
 
 # Title    : Enumeration types should comply with a naming convention
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2342.severity = none
 
 # Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2344.severity = warning
 
 # Title    : Flags enumerations should explicitly initialize all their members
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1008
 dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
-# Tags     : C#, MainSourceScope
+# Redundant: CA1051
 dotnet_diagnostic.S2357.severity = none
 
 # Title    : Optional parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2360.severity = none
 
 # Title    : Properties should not make collection or array copies
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2365.severity = warning
 
 # Title    : Public methods should not have multidimensional array parameters
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2368.severity = warning
 
 # Title    : Exceptions should not be thrown from property getters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2372.severity = warning
 
 # Title    : Write-only properties should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2376.severity = warning
 
 # Title    : Mutable fields should not be "public static"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2386.severity = warning
 
 # Title    : Child class fields should not shadow parent class fields
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
-dotnet_diagnostic.S2436.severity = warning
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
 
 # Title    : Silly bit operations should not be performed
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay, Unnecessary
 dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Whitespace and control characters in string literals should be explicit
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2479.severity = warning
 
 # Title    : Generic exceptions should not be ignored
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2486.severity = warning
 
 # Title    : Shared resources should not be used for locking
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1508
 dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2589.severity = warning
 
 # Title    : Setting loose file permissions is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2612.severity = warning
 
 # Title    : The length returned from a stream read should be checked
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2674.severity = warning
 
 # Title    : Multiline blocks should be enclosed in curly braces
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2681.severity = warning
 
 # Title    : "NaN" should not be used in comparisons
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2688.severity = warning
 
 # Title    : "IndexOf" checks should not be for positive numbers
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2692.severity = warning
 
 # Title    : Instance members should not write to "static" fields
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2696.severity = warning
 
 # Title    : Tests should include assertions
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S2699.severity = warning
 
 # Title    : Literal boolean values should not be used in assertions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-# Tags     : C#, TestSourceScope
 dotnet_diagnostic.S2701.severity = warning
 
 # Title    : "catch" clauses should do more than rethrow
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2737.severity = warning
 
 # Title    : Static fields should not be used in generic types
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2743.severity = none
 
 # Title    : XML parsers should not be vulnerable to XXE attacks
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2755.severity = warning
 
 # Title    : "=+" should not be used instead of "+="
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2757.severity = warning
 
 # Title    : The ternary operator should not return the same value regardless of the condition
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2758.severity = warning
 
 # Title    : Sequential tests should not check the same condition
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2760.severity = warning
 
 # Title    : Doubled prefix operators "!!" and "~~" should not be used
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2761.severity = warning
 
 # Title    : SQL keywords should be delimited by whitespace
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2857.severity = warning
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
-# Comment  : Duplicate, see CA2000
+# Redundant: CA2000
 dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
-# Tags     : C#, MainSourceScope, TestSourceScope
-dotnet_diagnostic.S2931.severity = warning
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0044
 dotnet_diagnostic.S2933.severity = none
 
 # Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2934.severity = warning
 
 # Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2952.severity = warning
 
 # Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2953.severity = warning
 
 # Title    : Generic parameters not constrained to reference types should not be compared to "null"
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2955.severity = warning
 
 # Title    : "IEnumerable" LINQs should be simplified
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2971.severity = warning
 
 # Title    : "Object.ReferenceEquals" should not be used for value types
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2995.severity = warning
 
 # Title    : "ThreadStatic" fields should not be initialized
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2996.severity = warning
 
 # Title    : "IDisposables" created in a "using" statement should not be returned
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2997.severity = warning
 
 # Title    : "ThreadStatic" should not be used on non-static fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3005.severity = warning
 
 # Title    : Static fields should not be updated in constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3010.severity = warning
 
 # Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1805
 dotnet_diagnostic.S3052.severity = none
 
 # Title    : Types should not have members with visibility set higher than the type's visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3059.severity = none
 
 # Title    : "is" should not be used with "this"
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3060.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: VSTHRD100
 dotnet_diagnostic.S3168.severity = none
 
 # Title    : Multiple "OrderBy" calls should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3169.severity = warning
 
 # Title    : Delegates should not be subtracted
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3172.severity = warning
 
 # Title    : "interface" instances should not be cast to concrete types
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
-# Tags     : C#, MainSourceScope
+# Redundant: CA2007
 dotnet_diagnostic.S3216.severity = none
 
 # Title    : "Explicit" conversions of "foreach" loops should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3217.severity = warning
 
 # Title    : Inner class members should not shadow outer class "static" or type members
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3218.severity = warning
 
 # Title    : Method calls should not resolve ambiguously to overloads with "params"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3220.severity = warning
 
 # Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3234.severity = warning
 
 # Title    : Redundant parentheses should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3235.severity = warning
 
 # Title    : Caller information arguments should not be provided explicitly
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3236.severity = warning
 
 # Title    : "value" parameters should be used
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: IDE0054
 dotnet_diagnostic.S3240.severity = none
 
 # Title    : Methods should not return values that are never used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
-# Tags     : C#, MainSourceScope, TestSourceScope
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
 dotnet_diagnostic.S3242.severity = none
 
 # Title    : Anonymous delegates should not be used to unsubscribe from Events
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3244.severity = warning
 
 # Title    : Generic type parameters should be co/contravariant when possible
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3246.severity = warning
 
 # Title    : Duplicate casts should not be made
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3247.severity = warning
 
 # Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3249.severity = warning
 
 # Title    : Implementations should be provided for "partial" methods
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3251.severity = warning
 
 # Title    : Constructor and destructor declarations should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3253.severity = warning
 
 # Title    : Default parameter values should not be passed as arguments
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3254.severity = warning
 
 # Title    : "string.IsNullOrEmpty" should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3257.severity = warning
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: R9A013
 dotnet_diagnostic.S3260.severity = none
 
 # Title    : Namespaces should not be empty
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3261.severity = warning
 
 # Title    : "params" should be used on overrides
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3262.severity = warning
 
 # Title    : Static fields should appear in the order they must be initialized 
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3263.severity = warning
 
 # Title    : Events should be invoked
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3264.severity = warning
 
 # Title    : Non-flags enums should not be used in bitwise operations
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3265.severity = warning
 
 # Title    : Loops should be simplified with "LINQ" expressions
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : Analysis is too slow
 dotnet_diagnostic.S3329.severity = none
 
 # Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3330.severity = warning
 
 # Title    : Caller information parameters should come at the end of the parameter list
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3343.severity = warning
 
 # Title    : Expressions used in "Debug.Assert" should not produce side effects
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3346.severity = warning
 
 # Title    : Unchanged local variables should be "const"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3353.severity = warning
 
 # Title    : Ternary operators should not be nested
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3358.severity = warning
 
 # Title    : "this" should not be exposed from constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1710
 dotnet_diagnostic.S3376.severity = none
 
 # Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3397.severity = warning
 
 # Title    : Methods should not return constants
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3400.severity = warning
 
 # Title    : Assertion arguments should be passed in the correct order
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S3415.severity = warning
 
 # Title    : Method overloads with default parameter values should not overlap 
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3427.severity = warning
 
 # Title    : "[ExpectedException]" should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-# Tags     : C#, TestSourceScope
 dotnet_diagnostic.S3431.severity = warning
 
 # Title    : Test method signatures should be correct
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S3433.severity = warning
 
 # Title    : Variables should not be checked against the values they're about to be assigned
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3440.severity = warning
 
 # Title    : Redundant property names should be omitted in anonymous classes
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3441.severity = warning
 
 # Title    : "abstract" classes should not have "public" constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3442.severity = warning
 
 # Title    : Type should not be examined on "System.Type" instances
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3443.severity = warning
 
 # Title    : Interfaces should not simply inherit from base interfaces with colliding members
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3444.severity = warning
 
 # Title    : Exceptions should not be explicitly rethrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3445.severity = warning
 
 # Title    : "[Optional]" should not be used on "ref" or "out" parameters
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3447.severity = warning
 
 # Title    : Right operands of shift operators should be integers
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3449.severity = warning
 
 # Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3450.severity = warning
 
 # Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3451.severity = warning
 
 # Title    : Classes should not have only "private" constructors
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3453.severity = warning
 
 # Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3456.severity = warning
 
 # Title    : Composite format strings should be used correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3457.severity = warning
 
 # Title    : Empty "case" clauses that fall through to the "default" should be omitted
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3458.severity = warning
 
 # Title    : Unassigned members should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3459.severity = warning
 
 # Title    : Type inheritance should not be recursive
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3464.severity = warning
 
 # Title    : Optional parameters should be passed to "base" calls
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3466.severity = warning
 
 # Title    : Empty "default" clauses should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3532.severity = warning
 
 # Title    : "ServiceContract" and "OperationContract" attributes should be used together
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3597.severity = warning
 
 # Title    : One-way "OperationContract" methods should have "void" return type
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3598.severity = warning
 
 # Title    : "params" should not be introduced on overrides
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3600.severity = warning
 
 # Title    : Methods with "Pure" attribute should return a value 
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3603.severity = warning
 
 # Title    : Member initializer values should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3604.severity = warning
 
 # Title    : Nullable type comparison should not be redundant
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3610.severity = warning
 
 # Title    : Jump statements should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3626.severity = warning
 
 # Title    : Empty nullable value should not be accessed
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3655.severity = warning
 
 # Title    : Exception constructors should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3693.severity = warning
 
 # Title    : Track use of "NotImplementedException"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 # Comment  : Code gets complicated
 dotnet_diagnostic.S3776.severity = none
 
 # Title    : "SafeHandle.DangerousGetHandle" should not be called
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1064
 dotnet_diagnostic.S3871.severity = none
 
 # Title    : Parameter names should not duplicate the names of their methods
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1021
 dotnet_diagnostic.S3874.severity = none
 
 # Title    : "operator==" should not be overloaded on reference types
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3875.severity = warning
 
 # Title    : Strings or integral types should be used for indexers
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3876.severity = warning
 
 # Title    : Exceptions should not be thrown from unexpected methods
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3877.severity = warning
 
 # Title    : Finalizers should not be empty
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3880.severity = warning
 
 # Title    : "IDisposable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3881.severity = none
 
 # Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3884.severity = warning
 
 # Title    : "Assembly.Load" should be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3885.severity = warning
 
 # Title    : Mutable, non-private fields should not be "readonly"
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3887.severity = warning
 
 # Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3889.severity = warning
 
 # Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3897.severity = warning
 
 # Title    : Value types should implement "IEquatable<T>"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1062
 dotnet_diagnostic.S3900.severity = none
 
 # Title    : "Assembly.GetExecutingAssembly" should not be called
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
 dotnet_diagnostic.S3903.severity = none
 
 # Title    : Assemblies should have version information
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3904.severity = warning
 
 # Title    : Event Handlers should have the correct signature
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3906.severity = warning
 
 # Title    : Generic event handlers should be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1010
 dotnet_diagnostic.S3909.severity = none
 
 # Title    : All branches in a conditional structure should not have exactly the same implementation
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : TODO - is ISerializable still relevant?
 dotnet_diagnostic.S3925.severity = none
 
 # Title    : Deserialization methods should be provided for "OptionalField" members
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3926.severity = warning
 
 # Title    : Serialization event handlers should be implemented correctly
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3927.severity = warning
 
 # Title    : Parameter names used into ArgumentException constructors should match an existing one 
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3928.severity = warning
 
 # Title    : Number patterns should be regular
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3937.severity = warning
 
 # Title    : Calculations should not overflow
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-# Tags     : C#, MainSourceScope, TestSourceScope, Unnecessary
 dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
-# Tags     : C#, MainSourceScope
-dotnet_diagnostic.S3956.severity = warning
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1802
 dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1810 and CA2207
 dotnet_diagnostic.S3963.severity = none
 
 # Title    : Objects should not be disposed more than once
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3966.severity = warning
 
 # Title    : Multidimensional arrays should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3967.severity = warning
 
 # Title    : "GC.SuppressFinalize" should not be called
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3971.severity = warning
 
 # Title    : Conditionals should start on new lines
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3972.severity = warning
 
 # Title    : A conditionally executed single line should be denoted by indentation
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3973.severity = warning
 
 # Title    : Collection sizes and array length comparisons should make sense
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3981.severity = warning
 
 # Title    : Exceptions should not be created without being thrown
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1014
 dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1017
 dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1018
 dotnet_diagnostic.S3993.severity = none
 
 # Title    : URI Parameters should not be strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3994.severity = none
 
 # Title    : URI return values should not be strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3995.severity = warning
 
 # Title    : URI properties should not be strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3996.severity = warning
 
 # Title    : String URI overloads should call "System.Uri" overloads
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3997.severity = warning
 
 # Title    : Threads should not lock on objects with weak identity
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3998.severity = warning
 
 # Title    : Pointers to unmanaged memory should not be visible
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4000.severity = warning
 
 # Title    : Disposable types should declare finalizers
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA2227
 dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA2234
 dotnet_diagnostic.S4005.severity = none
 
 # Title    : Inherited member visibility should not be decreased
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4015.severity = warning
 
 # Title    : Enumeration members should not be named "Reserved"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4016.severity = warning
 
 # Title    : Method signatures should not contain nested generic types
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4017.severity = none
 
 # Title    : All type parameters should be used in the parameter list to enable type inference
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4018.severity = none
 
 # Title    : Base class methods should not be hidden
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4019.severity = warning
 
 # Title    : Enumerations should have "Int32" storage
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4022.severity = warning
 
 # Title    : Interfaces should not be empty
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4023.severity = warning
 
 # Title    : Child class fields should not differ from parent class fields only by capitalization
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4025.severity = warning
 
 # Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1032
 dotnet_diagnostic.S4027.severity = none
 
 # Title    : Classes implementing "IEquatable<T>" should be sealed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4035.severity = warning
 
 # Title    : Searching OS commands in PATH is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4036.severity = warning
 
 # Title    : Interface methods should be callable by derived types
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1308
 dotnet_diagnostic.S4040.severity = none
 
 # Title    : Type names should not match namespaces
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4041.severity = warning
 
 # Title    : Generics should be used when appropriate
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
-# Tags     : C#, MainSourceScope
-dotnet_diagnostic.S4049.severity = warning
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
 
 # Title    : Operators should be overloaded consistently
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4050.severity = warning
 
 # Title    : Types should not extend outdated base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4052.severity = warning
 
 # Title    : Literals should not be passed as localized parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
-# Tags     : C#, MainSourceScope, TestSourceScope
-dotnet_diagnostic.S4056.severity = warning
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
 
 # Title    : Locales should be set for data types
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1310
 dotnet_diagnostic.S4058.severity = none
 
 # Title    : Property names should not match get methods
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
-# Tags     : C#, MainSourceScope
+# Redundant: CA1813
 dotnet_diagnostic.S4060.severity = none
 
 # Title    : "params" should be used instead of "varargs"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
-# Tags     : C#, MainSourceScope
+# Redundant: CA2225
 dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA2217
 dotnet_diagnostic.S4070.severity = none
 
 # Title    : Method overloads should be grouped together
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4136.severity = warning
 
 # Title    : Duplicate values should not be passed as arguments
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4142.severity = warning
 
 # Title    : Collection elements should not be replaced unconditionally
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4143.severity = warning
 
 # Title    : Methods should not have identical implementations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4158.severity = warning
 
 # Title    : Classes should implement their "ExportAttribute" interfaces
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4159.severity = warning
 
 # Title    : Native methods should be wrapped
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4200.severity = warning
 
 # Title    : Null checks should not be used with "is"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4201.severity = warning
 
 # Title    : Windows Forms entry points should be marked with STAThread
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4210.severity = warning
 
 # Title    : Members should not have conflicting transparency annotations
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4211.severity = warning
 
 # Title    : Serialization constructors should be secured
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4212.severity = warning
 
 # Title    : "P/Invoke" methods should not be visible
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4214.severity = warning
 
 # Title    : Events should have proper arguments
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4220.severity = warning
 
 # Title    : Extension methods should not extend "object"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4225.severity = warning
 
 # Title    : Extensions should be in separate namespaces
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4226.severity = none
 
 # Title    : "ConstructorArgument" parameters should exist in constructors
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4260.severity = warning
 
 # Title    : Methods should be named according to their synchronicities
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4261.severity = none
 
 # Title    : Getters and setters should access the expected fields
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4275.severity = warning
 
 # Title    : "Shared" parts should not be created with "new"
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4277.severity = warning
 
 # Title    : Weak SSL/TLS protocols should not be used
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4423.severity = warning
 
 # Title    : Cryptographic keys should be robust
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4426.severity = warning
 
 # Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4428.severity = warning
 
 # Title    : AES encryption algorithm should be used with secured mode
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4432.severity = warning
 
 # Title    : LDAP connections should be authenticated
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4433.severity = warning
 
 # Title    : Parameter validation in yielding methods should be wrapped
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4456.severity = warning
 
 # Title    : Parameter validation in "async"/"await" methods should be wrapped
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
-# Tags     : C#, MainSourceScope
+# Redundant: VSTHRD002
 dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay, Unnecessary
+# Redundant: IDE0052
 dotnet_diagnostic.S4487.severity = none
 
 # Title    : Disabling CSRF protections is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4502.severity = warning
 
 # Title    : Delivering code in production with debug features activated is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4507.severity = warning
 
 # Title    : "default" clauses should be first or last
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4524.severity = warning
 
 # Title    : ASP.NET HTTP request validation feature should not be disabled
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4564.severity = warning
 
 # Title    : "new Guid()" should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4581.severity = warning
 
 # Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4583.severity = warning
 
 # Title    : Non-async "Task/Task<T>" methods should not return null
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4586.severity = warning
 
 # Title    : String offset-based methods should be preferred for finding substrings from offsets
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4635.severity = warning
 
 # Title    : Using regular expressions is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4784.severity = warning
 
 # Title    : Encrypting data is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4787.severity = warning
 
 # Title    : Using weak hashing algorithms is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4790.severity = warning
 
 # Title    : Configuring loggers is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4792.severity = warning
 
 # Title    : Using Sockets is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4818.severity = warning
 
 # Title    : Using command line arguments is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4823.severity = warning
 
 # Title    : Reading the Standard Input is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA5359
 dotnet_diagnostic.S4830.severity = none
 
 # Title    : Controlling permissions is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4834.severity = warning
 
 # Title    : "ValueTask" should be consumed correctly
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S5034.severity = warning
 
 # Title    : Expanding archive files without controlling resource consumption is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5042.severity = warning
 
 # Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5122.severity = warning
 
 # Title    : Using clear-text protocols is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5332.severity = warning
 
 # Title    : Using publicly writable directories is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5443.severity = warning
 
 # Title    : Insecure temporary file creation methods should not be used
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5445.severity = warning
 
 # Title    : Encryption algorithms should be used with secure mode and padding scheme
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5542.severity = warning
 
 # Title    : Cipher algorithms should be robust
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5547.severity = warning
 
 # Title    : JWT should be signed and verified with strong cipher algorithms
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5659.severity = warning
 
 # Title    : Allowing requests with excessive content length is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S5693.severity = warning
 
 # Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5753.severity = warning
 
 # Title    : Deserializing objects without performing data validation is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S5766.severity = warning
 
 # Title    : Types allowed to be deserialized should be restricted
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5773.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
-# Tags     : C#, MainSourceScope
+# Redundant: R9A022
 dotnet_diagnostic.S6354.severity = none
 
 # Title    : Azure Functions should be stateless
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6419.severity = warning
 
 # Title    : Client instances should not be recreated on each Azure Function invocation
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6420.severity = warning
 
 # Title    : Azure Functions should use Structured Error Handling
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S6421.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking in Azure Functions
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6422.severity = warning
 
 # Title    : Azure Functions should log all failures
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S6423.severity = warning
 
 # Title    : Interfaces for durable entities should satisfy the restrictions
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6424.severity = warning
 
 # Title    : Not specifying a timeout for regular expressions is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Literal suffixes should be upper case
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S818.severity = warning
 
 # Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S881.severity = suggestion
 
 # Title    : "goto" statement should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1725
 dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-cpd.severity = warning
 
 # Title    : Log generator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-log.severity = none
 
 # Title    : File metadata generator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-metadata.severity = warning
 
 # Title    : Metrics calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-metrics.severity = warning
 
 # Title    : Symbol reference calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-symbolRef.severity = warning
 
 # Title    : Token type calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-token-type.severity = warning
 
 # Title    : XML comment analysis disabled
@@ -6102,21 +4988,25 @@ dotnet_diagnostic.SA0002.severity = warning
 # Title    : Keywords should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1000.severity = none
 
 # Title    : Commas should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1001.severity = none
 
 # Title    : Semicolons should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1002.severity = none
 
 # Title    : Symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1003.severity = none
 
 # Title    : Documentation lines should begin with single space
@@ -6137,101 +5027,121 @@ dotnet_diagnostic.SA1006.severity = warning
 # Title    : Operator keyword should be followed by space
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1007.severity = none
 
 # Title    : Opening parenthesis should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1008.severity = none
 
 # Title    : Closing parenthesis should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1009.severity = none
 
 # Title    : Opening square brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1010.severity = none
 
 # Title    : Closing square brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1011.severity = none
 
 # Title    : Opening braces should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1012.severity = none
 
 # Title    : Closing braces should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1013.severity = none
 
 # Title    : Opening generic brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1014.severity = none
 
 # Title    : Closing generic brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1015.severity = none
 
 # Title    : Opening attribute brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1016.severity = none
 
 # Title    : Closing attribute brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1017.severity = none
 
 # Title    : Nullable type symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1018.severity = none
 
 # Title    : Member access symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1019.severity = none
 
 # Title    : Increment decrement symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1020.severity = none
 
 # Title    : Negative signs should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1021.severity = none
 
 # Title    : Positive signs should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1022.severity = none
 
 # Title    : Dereference and access of symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1023.severity = none
 
 # Title    : Colons Should Be Spaced Correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1024.severity = none
 
 # Title    : Code should not contain multiple whitespace in a row
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1025.severity = none
 
 # Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1026.severity = none
 
 # Title    : Use tabs correctly
@@ -6242,8 +5152,8 @@ dotnet_diagnostic.SA1027.severity = warning
 # Title    : Code should not contain trailing whitespace
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
-# Tags     : Unnecessary
-dotnet_diagnostic.SA1028.severity = warning
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
 
 # Title    : Do not prefix calls with base unless local implementation exists
 # Category : StyleCop.CSharp.ReadabilityRules
@@ -6278,12 +5188,12 @@ dotnet_diagnostic.SA1105.severity = warning
 # Title    : Code should not contain empty statements
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1106.severity = warning
 
 # Title    : Code should not contain multiple statements on one line
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
 dotnet_diagnostic.SA1107.severity = none
 
 # Title    : Block statements should not contain embedded comments
@@ -6294,7 +5204,6 @@ dotnet_diagnostic.SA1108.severity = warning
 # Title    : Block statements should not contain embedded regions
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1109.severity = warning
 
 # Title    : Opening parenthesis or bracket should be on declaration line
@@ -6350,7 +5259,6 @@ dotnet_diagnostic.SA1119.severity = warning
 # Title    : Statement should not use unnecessary parenthesis
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
-# Tags     : Unnecessary, NotConfigurable
 dotnet_diagnostic.SA1119_p.severity = none
 
 # Title    : Comments should contain text
@@ -6361,7 +5269,6 @@ dotnet_diagnostic.SA1120.severity = warning
 # Title    : Use built-in type alias
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1121.severity = warning
 
 # Title    : Use string.Empty for empty strings
@@ -6387,7 +5294,6 @@ dotnet_diagnostic.SA1125.severity = warning
 # Title    : Prefix calls correctly
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1126.severity = none
 
 # Title    : Generic type constraints should be on their own line
@@ -6419,6 +5325,7 @@ dotnet_diagnostic.SA1131.severity = warning
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
 # Comment  : S1169 handles fields and variables
+# Redundant: S1169
 dotnet_diagnostic.SA1132.severity = none
 
 # Title    : Do not combine attributes
@@ -6429,6 +5336,7 @@ dotnet_diagnostic.SA1133.severity = warning
 # Title    : Attributes should not share line
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1134.severity = none
 
 # Title    : Using directives should be qualified
@@ -6460,11 +5368,13 @@ dotnet_diagnostic.SA1141.severity = warning
 # Title    : Refer to tuple fields by name
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
 dotnet_diagnostic.SA1142.severity = none
 
 # Title    : Using directives should be placed correctly
 # Category : StyleCop.CSharp.OrderingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
 dotnet_diagnostic.SA1200.severity = none
 
 # Title    : Elements should appear in the correct order
@@ -6550,52 +5460,61 @@ dotnet_diagnostic.SA1217.severity = warning
 # Title    : Element should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1300.severity = none
 
 # Title    : Element should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
-# Tags     : NotConfigurable
+# Redundant: IDE1006
 dotnet_diagnostic.SA1301.severity = none
 
 # Title    : Interface names should begin with I
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1302.severity = none
 
 # Title    : Const field names should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1303.severity = none
 
 # Title    : Non-private readonly fields should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1304.severity = none
 
 # Title    : Field names should not use Hungarian notation
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1305.severity = none
 
 # Title    : Field names should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1306.severity = none
 
 # Title    : Accessible fields should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1307.severity = none
 
 # Title    : Variable names should not be prefixed
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1308.severity = none
 
 # Title    : Field names should not begin with underscore
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1309.severity = none
 
 # Title    : Field names should not contain underscore
@@ -6606,21 +5525,25 @@ dotnet_diagnostic.SA1310.severity = warning
 # Title    : Static readonly fields should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1311.severity = none
 
 # Title    : Variable names should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1312.severity = none
 
 # Title    : Parameter names should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1313.severity = none
 
 # Title    : Type parameter names should begin with T
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1314.severity = none
 
 # Title    : Tuple element names should use correct casing
@@ -6636,6 +5559,7 @@ dotnet_diagnostic.SA1400.severity = warning
 # Title    : Fields should be private
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
 dotnet_diagnostic.SA1401.severity = none
 
 # Title    : File may only contain a single type
@@ -6676,19 +5600,16 @@ dotnet_diagnostic.SA1408.severity = warning
 # Title    : Remove unnecessary code
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1409.severity = warning
 
 # Title    : Remove delegate parenthesis when possible
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1410.severity = warning
 
 # Title    : Attribute constructor should not use unnecessary parenthesis
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1411.severity = warning
 
 # Title    : Store files as UTF-8 with byte order mark
@@ -6725,6 +5646,7 @@ dotnet_diagnostic.SA1502.severity = warning
 # Title    : Braces should not be omitted
 # Category : StyleCop.CSharp.LayoutRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
 dotnet_diagnostic.SA1503.severity = none
 
 # Title    : All accessors should be single-line or multi-line
@@ -6745,11 +5667,13 @@ dotnet_diagnostic.SA1506.severity = warning
 # Title    : Code should not contain multiple blank lines in a row
 # Category : StyleCop.CSharp.LayoutRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
 dotnet_diagnostic.SA1507.severity = none
 
 # Title    : Closing braces should not be preceded by blank line
 # Category : StyleCop.CSharp.LayoutRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
 dotnet_diagnostic.SA1508.severity = none
 
 # Title    : Opening braces should not be preceded by blank line
@@ -6830,7 +5754,6 @@ dotnet_diagnostic.SA1602.severity = warning
 # Title    : Documentation should contain valid XML
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1603.severity = warning
 
 # Title    : Element documentation should have summary
@@ -6871,6 +5794,7 @@ dotnet_diagnostic.SA1610.severity = none
 # Title    : Element parameters should be documented
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
 dotnet_diagnostic.SA1611.severity = none
 
 # Title    : Element parameter documentation should match element parameters
@@ -6956,7 +5880,6 @@ dotnet_diagnostic.SA1627.severity = warning
 # Title    : Documentation text should begin with a capital letter
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1628.severity = warning
 
 # Title    : Documentation text should end with a period
@@ -6967,24 +5890,22 @@ dotnet_diagnostic.SA1629.severity = warning
 # Title    : Documentation text should contain whitespace
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1630.severity = warning
 
 # Title    : Documentation should meet character percentage
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1631.severity = warning
 
 # Title    : Documentation text should meet minimum character length
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1632.severity = warning
 
 # Title    : File should have header
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
 dotnet_diagnostic.SA1633.severity = none
 
 # Title    : File header should show copyright
@@ -7040,25 +5961,21 @@ dotnet_diagnostic.SA1643.severity = warning
 # Title    : Documentation headers should not contain blank lines
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1644.severity = warning
 
 # Title    : Included documentation file does not exist
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1645.severity = warning
 
 # Title    : Included documentation XPath does not exist
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1646.severity = warning
 
 # Title    : Include node does not contain valid file and path
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1647.severity = warning
 
 # Title    : inheritdoc should be used with inheriting class
@@ -7074,7 +5991,6 @@ dotnet_diagnostic.SA1649.severity = warning
 # Title    : Element documentation should be spelled correctly
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
-# Tags     : NotConfigurable
 # Comment  : Deprecated
 dotnet_diagnostic.SA1650.severity = none
 
@@ -7086,17 +6002,18 @@ dotnet_diagnostic.SA1651.severity = warning
 # Title    : Do not prefix local calls with 'this.'
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SX1101.severity = warning
 
 # Title    : Field names should begin with underscore
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
 dotnet_diagnostic.SX1309.severity = none
 
 # Title    : Static field names should begin with underscore
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
 dotnet_diagnostic.SX1309S.severity = none
 
 # Title    : Avoid legacy thread switching APIs
@@ -7122,7 +6039,6 @@ dotnet_diagnostic.VSTHRD004.severity = error
 # Title    : Invoke single-threaded types on Main thread
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
-# Tags     : CompilationEnd
 dotnet_diagnostic.VSTHRD010.severity = warning
 
 # Title    : Use AsyncLazy<T>
@@ -7188,11 +6104,13 @@ dotnet_diagnostic.VSTHRD109.severity = error
 # Title    : Observe result of async calls
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
 dotnet_diagnostic.VSTHRD110.severity = none
 
 # Title    : Use ConfigureAwait(bool)
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
 dotnet_diagnostic.VSTHRD111.severity = none
 
 # Title    : Implement System.IAsyncDisposable

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,7 +1,8 @@
-# Created by the R9 diagnostic config generator
-# Generated : 2023-02-20 04:52:14Z
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-23 23:01:34Z
+# Max Tier  : 2147483647
 # Attributes: general, test
-# Analyzers : ILLink.RoslynAnalyzer, Internal.Analyzers, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.CPR.Standard.Analyzers.Basic.R3, Microsoft.R9.Analyzers.Roslyn4.0, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers, xunit.analyzers
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers, xunit.analyzers
 
 [*.cs]
 
@@ -96,512 +97,450 @@ dotnet_diagnostic.BL0007.severity = warning
 # Title    : Do not declare static members on generic types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1000.severity = none
 
 # Title    : Types that own disposable fields should be disposable
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1001.severity = warning
 
 # Title    : Do not expose generic lists
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1002.severity = none
 
 # Title    : Use generic event handler instances
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1003.severity = none
 
 # Title    : Avoid excessive parameters on generic types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1005.severity = none
 
 # Title    : Enums should have zero value
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, RuleNoZero
 dotnet_diagnostic.CA1008.severity = none
 
 # Title    : Generic interface should also be implemented
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1010.severity = none
 
 # Title    : Abstract types should not have public constructors
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1012.severity = warning
 dotnet_code_quality.CA1012.api_surface = all
 
 # Title    : Mark assemblies with CLSCompliant
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1014.severity = none
 
 # Title    : Mark assemblies with assembly version
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
-dotnet_diagnostic.CA1016.severity = warning
+dotnet_diagnostic.CA1016.severity = suggestion
 
 # Title    : Mark assemblies with ComVisible
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1017.severity = none
 
 # Title    : Mark attributes with AttributeUsageAttribute
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1018.severity = warning
 
 # Title    : Define accessors for attribute arguments
 # Category : Design
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1019.severity = suggestion
 
 # Title    : Define accessors for attribute arguments
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1019.severity = warning
 
 # Title    : Avoid out parameters
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1021.severity = none
 
 # Title    : Use properties where appropriate
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1024.severity = none
 
 # Title    : Mark enums with FlagsAttribute
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1027.severity = warning
 dotnet_code_quality.CA1027.api_surface = all
 
 # Title    : Enum Storage should be Int32
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1028.severity = none
 
 # Title    : Use events where appropriate
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1030.severity = warning
 
 # Title    : Do not catch general exception types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1031.severity = warning
 
 # Title    : Implement standard exception constructors
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1032.severity = none
 
 # Title    : Interface methods should be callable by child types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1033.severity = warning
 
 # Title    : Nested types should not be visible
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1034.severity = none
 
 # Title    : Override methods on comparable types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1036.severity = none
 
 # Title    : Avoid empty interfaces
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Reasonably frequent in modern .NET programming
 dotnet_diagnostic.CA1040.severity = none
 
 # Title    : Provide ObsoleteAttribute message
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1041.severity = warning
 dotnet_code_quality.CA1041.api_surface = all
 
 # Title    : Use Integral Or String Argument For Indexers
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1043.severity = none
 
 # Title    : Properties should not be write only
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1044.severity = warning
 
 # Title    : Do not pass types by reference
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1045.severity = none
 
 # Title    : Do not overload equality operator on reference types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1046.severity = warning
 dotnet_code_quality.CA1046.api_surface = all
 
 # Title    : Do not declare protected member in sealed type
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1047.severity = warning
 dotnet_code_quality.CA1047.api_surface = all
 
 # Title    : Declare types in namespaces
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1050.severity = none
 
 # Title    : Do not declare visible instance fields
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1051.severity = none
 
 # Title    : Static holder types should be Static or NotInheritable
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1052.severity = warning
 
 # Title    : URI-like parameters should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1054.severity = none
 
 # Title    : URI-like return values should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1055.severity = none
 
 # Title    : URI-like properties should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1056.severity = none
 
 # Title    : Types should not extend certain base types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1058.severity = warning
 dotnet_code_quality.CA1058.api_surface = public
 
 # Title    : Move pinvokes to native methods class
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
-# Tags     : PortedFromFxCop, Telemetry
 dotnet_diagnostic.CA1060.severity = warning
 
 # Title    : Do not hide base class methods
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1061.severity = warning
 dotnet_code_quality.CA1061.api_surface = all
 
 # Title    : Validate arguments of public methods
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1062.severity = none
 
 # Title    : Implement IDisposable Correctly
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1063.severity = warning
 
 # Title    : Exceptions should be public
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1064.severity = none
 
 # Title    : Do not raise exceptions in unexpected locations
 # Category : Design
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1065.severity = warning
 
 # Title    : Do not raise exceptions in unexpected locations
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1065.severity = warning
 
 # Title    : Implement IEquatable when overriding Object.Equals
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1066.severity = warning
 
 # Title    : Override Object.Equals(object) when implementing IEquatable<T>
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1067.severity = warning
 
 # Title    : CancellationToken parameters must come last
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1068.severity = none
 
 # Title    : Enums values should not be duplicated
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1069.severity = warning
 
 # Title    : Do not declare event fields as virtual
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1070.severity = warning
 dotnet_code_quality.CA1070.api_surface = all
 
 # Title    : Avoid using cref tags with a prefix
 # Category : Documentation
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1200.severity = warning
 
 # Title    : Do not pass literals as localized parameters
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1303.severity = none
 
 # Title    : Specify CultureInfo
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1304.severity = none
 
 # Title    : Specify IFormatProvider
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1305.severity = none
 
 # Title    : Specify StringComparison for clarity
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1307.severity = none
 
 # Title    : Normalize strings to uppercase
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1308.severity = none
 
 # Title    : Use ordinal string comparison
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1309.severity = suggestion
 
 # Title    : Specify StringComparison for correctness
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1310.severity = none
 
 # Title    : Specify a culture or use an invariant version
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1311.severity = warning
 
 # Title    : P/Invokes should not be visible
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1401.severity = none
 
 # Title    : Validate platform compatibility
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1416.severity = warning
 
 # Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1417.severity = warning
 
 # Title    : Use valid platform string
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1418.severity = warning
 
 # Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1419.severity = none
 
 # Title    : Property, type, or attribute requires runtime marshalling
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1420.severity = warning
 
 # Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1421.severity = suggestion
 
 # Title    : Validate platform compatibility
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1422.severity = warning
 
 # Title    : Avoid excessive inheritance
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1501.severity = warning
 dotnet_code_quality.CA1501.api_surface = public
 
 # Title    : Avoid excessive complexity
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 # Comment  : Code gets complicated
 dotnet_diagnostic.CA1502.severity = none
 
 # Title    : Avoid unmaintainable code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 dotnet_diagnostic.CA1505.severity = warning
 
 # Title    : Avoid excessive class coupling
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
-# Tags     : PortedFromFxCop, Telemetry, CompilationEnd
 # Comment  : Code gets complicated
 dotnet_diagnostic.CA1506.severity = none
 
 # Title    : Use nameof to express symbol names
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1507.severity = warning
 
 # Title    : Avoid dead conditional code
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1508.severity = warning
 
 # Title    : Invalid entry in code metrics rule specification file
 # Category : Maintainability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
-# Tags     : Telemetry, CompilationEnd
 dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
 
 # Title    : Do not name enum values 'Reserved'
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1700.severity = none
 
 # Title    : Identifiers should not contain underscores
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : StyleCop handles this
 dotnet_diagnostic.CA1707.severity = none
 
 # Title    : Identifiers should differ by more than case
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1708.severity = silent
 
 # Title    : Identifiers should have correct suffix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1710.severity = silent
 
 # Title    : Identifiers should not have incorrect suffix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1711.severity = silent
 
 # Title    : Do not prefix enum values with type name
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1712.severity = warning
 
 # Title    : Events should not have 'Before' or 'After' prefix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1713.severity = warning
 
 # Title    : Identifiers should have correct prefix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: IDE1006
 dotnet_diagnostic.CA1715.severity = none
 
 # Title    : Identifiers should not match keywords
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1716.severity = warning
 dotnet_code_quality.CA1716.api_surface = all
 dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
@@ -609,1619 +548,1129 @@ dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
 # Title    : Identifier contains type name
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1720.severity = silent
 
 # Title    : Property names should not match get methods
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1721.severity = none
 
 # Title    : Type names should not match namespaces
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA1724.severity = none
 
 # Title    : Parameter names should match base declaration
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1725.severity = warning
 
 # Title    : Use PascalCase for named placeholders
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1727.severity = silent
 
 # Title    : Review unused parameters
 # Category : Usage
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: IDE0060
 dotnet_diagnostic.CA1801.severity = none
 
 # Title    : Review unused parameters
 # Category : Usage
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: IDE0060
 dotnet_diagnostic.CA1801.severity = none
 
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1802.severity = none
 
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1802.severity = none
 
 # Title    : Do not initialize unnecessarily
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1805.severity = warning
 
 # Title    : Do not initialize unnecessarily
 # Category : Performance
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1805.severity = warning
 
 # Title    : Do not ignore method results
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1806.severity = warning
 
 # Title    : Initialize reference type static fields inline
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1810.severity = none
 
 # Title    : Avoid uninstantiated internal classes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 # Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
 dotnet_diagnostic.CA1812.severity = none
 
 # Title    : Avoid unsealed attributes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1813.severity = none
 
 # Title    : Prefer jagged arrays over multidimensional
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1814.severity = none
 
 # Title    : Override equals and operator equals on value types
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1815.severity = none
 
 # Title    : Dispose methods should call SuppressFinalize
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1816.severity = warning
 
 # Title    : Properties should not return arrays
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1819.severity = none
 
 # Title    : Test for empty strings using string length
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1820.severity = none
 
 # Title    : Remove empty Finalizers
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1821.severity = none
 
 # Title    : Mark members as static
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1822.severity = warning
 
 # Title    : Avoid unused private fields
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: S1144
 dotnet_diagnostic.CA1823.severity = none
 
 # Title    : Mark assemblies with NeutralResourcesLanguageAttribute
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA1824.severity = suggestion
 
 # Title    : Avoid zero-length array allocations
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1825.severity = none
 
 # Title    : Do not use Enumerable methods on indexable collections
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1826.severity = none
 
 # Title    : Do not use Count() or LongCount() when Any() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1827.severity = none
 
 # Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1828.severity = none
 
 # Title    : Use Length/Count property instead of Count() when available
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1829.severity = none
 
 # Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1830.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1831.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1832.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1833.severity = none
 
 # Title    : Consider using 'StringBuilder.Append(char)' when applicable
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1834.severity = none
 
 # Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1835.severity = none
 
 # Title    : Prefer IsEmpty over Count
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1836.severity = none
 
 # Title    : Use 'Environment.ProcessId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1837.severity = none
 
 # Title    : Avoid 'StringBuilder' parameters for P/Invokes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1838.severity = none
 
 # Title    : Use 'Environment.ProcessPath'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1839.severity = none
 
 # Title    : Use 'Environment.CurrentManagedThreadId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1840.severity = none
 
 # Title    : Prefer Dictionary.Contains methods
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1841.severity = none
 
 # Title    : Do not use 'WhenAll' with a single task
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1842.severity = suggestion
 
 # Title    : Do not use 'WaitAll' with a single task
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1843.severity = none
 
 # Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1844.severity = none
 
 # Title    : Use span-based 'string.Concat'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1845.severity = none
 
 # Title    : Prefer 'AsSpan' over 'Substring'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1846.severity = none
 
 # Title    : Use char literal for a single character lookup
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1847.severity = none
 
 # Title    : Use the LoggerMessage delegates
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Use R9 logging model instead
 dotnet_diagnostic.CA1848.severity = none
 
 # Title    : Call async methods when in an async method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1849.severity = none
 
 # Title    : Prefer static 'HashData' method over 'ComputeHash'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1850.severity = none
 
 # Title    : Possible multiple enumerations of 'IEnumerable' collection
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1851.severity = suggestion
 
 # Title    : Seal internal types
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
+# Redundant: R9A013
 dotnet_diagnostic.CA1852.severity = none
 
 # Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1853.severity = none
 
 # Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA1854.severity = none
 
 # Title    : Prefer 'Clear' over 'Fill'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
 
 # Title    : Dispose objects before losing scope
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2000.severity = warning
 
 # Title    : Do not lock on objects with weak identity
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2002.severity = warning
 
 # Title    : Consider calling ConfigureAwait on the awaited task
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2007.severity = none
 
 # Title    : Do not create tasks without passing a TaskScheduler
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2008.severity = warning
 
 # Title    : Do not call ToImmutableCollection on an ImmutableCollection value
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2009.severity = warning
 
 # Title    : Avoid infinite recursion
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2011.severity = error
 
 # Title    : Use ValueTasks correctly
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2012.severity = warning
 
 # Title    : Do not use ReferenceEquals with value types
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2013.severity = warning
 
 # Title    : Do not use stackalloc in loops
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2014.severity = warning
 
 # Title    : Do not use stackalloc in loops
 # Category : Reliability
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2014.severity = warning
 
 # Title    : Do not define finalizers for types derived from MemoryManager<T>
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2015.severity = warning
 
 # Title    : Forward the 'CancellationToken' parameter to methods
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2016.severity = warning
 
 # Title    : Parameter count mismatch
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2017.severity = warning
 
 # Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2018.severity = warning
 
 # Title    : Improper 'ThreadStatic' field initialization
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2019.severity = warning
 
-# Title    : Prevent from behavioral change
+# Title    : Prevent behavioral change
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
 
 # Title    : Review SQL queries for security vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2100.severity = none
 
 # Title    : Specify marshaling for P/Invoke string arguments
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2101.severity = warning
 
 # Title    : Review visible event handlers
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2109.severity = none
 
 # Title    : Seal methods that satisfy private interfaces
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2119.severity = warning
 
 # Title    : Do Not Catch Corrupted State Exceptions
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2153.severity = warning
 
 # Title    : Rethrow to preserve stack details
 # Category : Usage
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2200.severity = warning
 
 # Title    : Rethrow to preserve stack details
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2200.severity = warning
 
 # Title    : Do not raise reserved exception types
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2201.severity = warning
 
 # Title    : Initialize value type static fields inline
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2207.severity = none
 
 # Title    : Instantiate argument exceptions correctly
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2208.severity = warning
 
 # Title    : Non-constant fields should not be visible
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2211.severity = none
 
 # Title    : Disposable fields should be disposed
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
-# Tags     : PortedFromFxCop, Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2213.severity = warning
 
 # Title    : Do not call overridable methods in constructors
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2214.severity = warning
 
 # Title    : Dispose methods should call base class dispose
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2215.severity = warning
 
 # Title    : Disposable types should declare finalizer
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2216.severity = warning
 
 # Title    : Do not mark enums with FlagsAttribute
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2217.severity = warning
 dotnet_code_quality.CA2217.api_surface = all
 
 # Title    : Do not raise exceptions in finally clauses
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2219.severity = warning
 
 # Title    : Operator overloads have named alternates
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2225.severity = none
 
 # Title    : Operators should have symmetrical overloads
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
+# Redundant: CS0216
 dotnet_diagnostic.CA2226.severity = none
 
 # Title    : Collection properties should be read only
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2227.severity = none
 
 # Title    : Implement serialization constructors
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Obsolete
 dotnet_diagnostic.CA2229.severity = none
 
 # Title    : Overload operator equals on overriding value type Equals
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2231.severity = error
 
 # Title    : Pass system uri objects instead of strings
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2234.severity = none
 
 # Title    : Mark all non-serializable fields
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Obsolete
 dotnet_diagnostic.CA2235.severity = none
 
 # Title    : Mark ISerializable types with serializable
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 # Comment  : Obsolete
 dotnet_diagnostic.CA2237.severity = none
 
 # Title    : Provide correct arguments to formatting methods
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2241.severity = warning
 
 # Title    : Test for NaN correctly
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2242.severity = warning
 
 # Title    : Attribute string literals should parse correctly
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
-# Tags     : PortedFromFxCop, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2243.severity = warning
 
 # Title    : Do not duplicate indexed element initializations
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2244.severity = warning
 
 # Title    : Do not assign a property to itself
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2245.severity = warning
 
 # Title    : Assigning symbol and its member in the same statement
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2246.severity = warning
 
 # Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2247.severity = warning
 
 # Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2248.severity = warning
 
 # Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2249.severity = warning
 
 # Title    : Use 'ThrowIfCancellationRequested'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2250.severity = suggestion
 
 # Title    : Use 'string.Equals'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2251.severity = warning
 
 # Title    : This API requires opting into preview features
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2252.severity = error
 
 # Title    : Named placeholders should not be numeric values
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2253.severity = warning
 
 # Title    : Template should be a static expression
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2254.severity = none
 
 # Title    : The 'ModuleInitializer' attribute should not be used in libraries
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2255.severity = warning
 
 # Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2256.severity = error
 
 # Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2257.severity = warning
 
 # Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2258.severity = warning
 
 # Title    : 'ThreadStatic' only affects static fields
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2259.severity = warning
 
 # Title    : Use correct type parameter
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2260.severity = warning
 
 # Title    : Do not use insecure deserializer BinaryFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2300.severity = none
 
 # Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2301.severity = none
 
 # Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2302.severity = none
 
 # Title    : Do not use insecure deserializer LosFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2305.severity = none
 
 # Title    : Do not use insecure deserializer NetDataContractSerializer
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2310.severity = none
 
 # Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2311.severity = none
 
 # Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2312.severity = none
 
 # Title    : Do not use insecure deserializer ObjectStateFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2315.severity = none
 
 # Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2321.severity = none
 
 # Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2322.severity = none
 
 # Title    : Do not use TypeNameHandling values other than None
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2326.severity = none
 
 # Title    : Do not use insecure JsonSerializerSettings
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2327.severity = none
 
 # Title    : Ensure that JsonSerializerSettings are secure
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2328.severity = none
 
 # Title    : Do not deserialize with JsonSerializer using an insecure configuration
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2329.severity = none
 
 # Title    : Ensure that JsonSerializer has a secure configuration when deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA2330.severity = none
 
 # Title    : Do not use DataTable.ReadXml() with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2350.severity = none
 
 # Title    : Do not use DataSet.ReadXml() with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2351.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2352.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2352.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2353.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2353.severity = none
 
 # Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2354.severity = none
 
 # Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2354.severity = none
 
 # Title    : Unsafe DataSet or DataTable type found in deserializable object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2355.severity = none
 
 # Title    : Unsafe DataSet or DataTable type found in deserializable object graph
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2355.severity = none
 
 # Title    : Unsafe DataSet or DataTable type in web deserializable object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2356.severity = none
 
 # Title    : Unsafe DataSet or DataTable type in web deserializable object graph
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2356.severity = none
 
 # Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2361.severity = none
 
 # Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2362.severity = none
 
 # Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA2362.severity = none
 
 # Title    : Review code for SQL injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3001.severity = none
 
 # Title    : Review code for XSS vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3002.severity = none
 
 # Title    : Review code for file path injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3003.severity = none
 
 # Title    : Review code for information disclosure vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3004.severity = none
 
 # Title    : Review code for LDAP injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3005.severity = none
 
 # Title    : Review code for process command injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3006.severity = none
 
 # Title    : Review code for open redirect vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3007.severity = none
 
 # Title    : Review code for XPath injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3008.severity = none
 
 # Title    : Review code for XML injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3009.severity = none
 
 # Title    : Review code for XAML injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3010.severity = none
 
 # Title    : Review code for DLL injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3011.severity = none
 
 # Title    : Review code for regex injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3012.severity = none
 
 # Title    : Do Not Add Schema By URL
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3061.severity = none
 
 # Title    : Insecure DTD processing in XML
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3075.severity = none
 
 # Title    : Insecure XSLT script processing.
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3076.severity = none
 
 # Title    : Insecure XSLT script processing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3076.severity = none
 
 # Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3077.severity = none
 
 # Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3077.severity = none
 
 # Title    : Mark Verb Handlers With Validate Antiforgery Token
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA3147.severity = none
 
 # Title    : Do Not Use Weak Cryptographic Algorithms
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5350.severity = none
 
 # Title    : Do Not Use Broken Cryptographic Algorithms
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5351.severity = none
 
 # Title    : Review cipher mode usage with cryptography experts
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5358.severity = none
 
 # Title    : Do Not Disable Certificate Validation
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5359.severity = none
 
 # Title    : Do Not Call Dangerous Methods In Deserialization
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5360.severity = none
 
 # Title    : Do Not Disable SChannel Use of Strong Crypto
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5361.severity = none
 
 # Title    : Potential reference cycle in deserialized object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5362.severity = none
 
 # Title    : Do Not Disable Request Validation
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5363.severity = none
 
 # Title    : Do Not Use Deprecated Security Protocols
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5364.severity = none
 
 # Title    : Do Not Disable HTTP Header Checking
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5365.severity = none
 
 # Title    : Use XmlReader for 'DataSet.ReadXml()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5366.severity = none
 
 # Title    : Do Not Serialize Types With Pointer Fields
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5367.severity = none
 
 # Title    : Set ViewStateUserKey For Classes Derived From Page
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5368.severity = none
 
 # Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5369.severity = none
 
 # Title    : Use XmlReader for XmlValidatingReader constructor
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5370.severity = none
 
 # Title    : Use XmlReader for 'XmlSchema.Read()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5371.severity = none
 
 # Title    : Use XmlReader for XPathDocument constructor
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5372.severity = none
 
 # Title    : Do not use obsolete key derivation function
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5373.severity = none
 
 # Title    : Do Not Use XslTransform
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5374.severity = none
 
 # Title    : Do Not Use Account Shared Access Signature
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5375.severity = none
 
 # Title    : Use SharedAccessProtocol HttpsOnly
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5376.severity = none
 
 # Title    : Use Container Level Access Policy
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5377.severity = none
 
 # Title    : Do not disable ServicePointManagerSecurityProtocols
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5378.severity = none
 
 # Title    : Ensure Key Derivation Function algorithm is sufficiently strong
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5379.severity = none
 
 # Title    : Do Not Add Certificates To Root Store
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5380.severity = none
 
 # Title    : Ensure Certificates Are Not Added To Root Store
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5381.severity = none
 
 # Title    : Use Secure Cookies In ASP.NET Core
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5382.severity = none
 
 # Title    : Ensure Use Secure Cookies In ASP.NET Core
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5383.severity = none
 
 # Title    : Do Not Use Digital Signature Algorithm (DSA)
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5384.severity = none
 
 # Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5385.severity = none
 
 # Title    : Avoid hardcoding SecurityProtocolType value
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5386.severity = none
 
 # Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5387.severity = none
 
 # Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5388.severity = none
 
 # Title    : Do Not Add Archive Item's Path To The Target File System Path
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5389.severity = none
 
 # Title    : Do not hard-code encryption key
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5390.severity = none
 
 # Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5391.severity = none
 
 # Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5392.severity = none
 
 # Title    : Do not use unsafe DllImportSearchPath value
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5393.severity = none
 
 # Title    : Do not use insecure randomness
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5394.severity = none
 
 # Title    : Miss HttpVerb attribute for action methods
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
-# Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5395.severity = none
 
 # Title    : Set HttpOnly to true for HttpCookie
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5396.severity = none
 
 # Title    : Do not use deprecated SslProtocols values
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5397.severity = none
 
 # Title    : Avoid hardcoded SslProtocols values
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5398.severity = none
 
 # Title    : HttpClients should enable certificate revocation list checks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5399.severity = none
 
 # Title    : Ensure HttpClient certificate revocation list check is not disabled
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5400.severity = none
 
 # Title    : Do not use CreateEncryptor with non-default IV
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5401.severity = none
 
 # Title    : Use CreateEncryptor with the default IV 
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA5402.severity = none
 
 # Title    : Do not hard-code certificate
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
-# Tags     : Dataflow, Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5403.severity = none
 
 # Title    : Do not disable token validation checks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5404.severity = none
 
 # Title    : Do not always skip token validation in delegates
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.CA5405.severity = none
 
-# Title    : Avoid single use string builders in frequently called class members.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR1001.severity = none
-
-# Title    : Use bitwise operations instead of 'Enum.HasFlag'
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Obsolete
-dotnet_diagnostic.CPR101.severity = none
-
-# Title    : Use HashSet.Contains instead of List.Contains
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR102.severity = none
-
-# Title    : Use Ordinal and OrdinalIgnoreCase instead of InvariantCulture when localization is not required.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR103.severity = warning
-
-# Title    : Use DateTime.UtcNow instead of DateTime.Now when time zone conversion is not applicable.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR105.severity = none
-
-# Title    : MemoryStream.ToArray() is memory inefficient and can often be avoided.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR107.severity = none
-
-# Title    : List.AddRange() is memory inefficient.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Obsolete
-dotnet_diagnostic.CPR108.severity = none
-
-# Title    : List.Reverse can cause boxing. Implement your own reverse for better performance.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Obsolete
-dotnet_diagnostic.CPR109.severity = none
-
-# Title    : Specify an initial list size when initializing a list to reduce reallocations.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Too noisy
-dotnet_diagnostic.CPR110.severity = none
-
-# Title    : ImmutableDictionary is memory inefficient. Use IReadOnlyDictionary if readonly collection is needed.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR111.severity = none
-
-# Title    : ImmutableList is memory inefficient. Use IReadOnlyList if a readonly collection is needed.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR112.severity = none
-
-# Title    : Avoid Linq as much as possible since much of the functionality is inefficient.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Too noisy
-dotnet_diagnostic.CPR113.severity = none
-
-# Title    : string.StartWith and string.EndsWith can be implemented more efficiently checking characters with the indexer for short strings.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR114.severity = none
-
-# Title    : string.Contains with string.ToLower() or string.ToUpper() causes allocations which can be avoided with a case insensitive comparison.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR115.severity = none
-
-# Title    : string.Equals with string.ToLower() or string.ToUpper() causes allocations which can be avoided with a case insensitive comparison.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR116.severity = none
-
-# Title    : operator== with string.ToLower() or string.ToUpper() causes allocations which can be avoided with a case insensitive comparison.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR117.severity = none
-
-# Title    : Linq.SequenceEqual is inefficient.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR118.severity = none
-
-# Title    : Use Debug.WriteLine for debugging instead of Console.WriteLine.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : Duplicate
-dotnet_diagnostic.CPR119.severity = none
-
-# Title    : File.ReadAllXXX should be replaced by using a StreamReader to avoid adding objects to the large object heap (LOH).
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR120.severity = none
-
-# Title    : Specify 'concurrencyLevel' and 'capacity' in the ConcurrentDictionary ctor.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR121.severity = none
-
-# Title    : ConcurrentDictionary.Keys and ConcurrentDictionary.Values takes a lock defeats the benefits of concurrency.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR122.severity = none
-
-# Title    : ConcurrentDictionary Count, ToArray(), CopyTo() and Clear() take locks and defeats the benefits of the concurrency.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR123.severity = none
-
-# Title    : TraceSource.TraceEvent does a lock on each listener and can cause lock contention.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR124.severity = none
-
-# Title    : String interning can cause lock contention.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR125.severity = none
-
-# Title    : string.Format and StringBuilder.AppendFormat are not efficient for concatenation.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR126.severity = none
-
-# Title    : Use a custom implementation of IComparer rather than Nullable.Compare.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR127.severity = warning
-
-# Title    : Process.GetProcessName/Process.GetMachineName does a lot of processing. Use once per process and save the result.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR128.severity = none
-
-# Title    : string.IndexOf is inefficient when used to check the beginning of string.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR129.severity = none
-
-# Title    : ArrayList is non-generic.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR130.severity = none
-
-# Title    : Hashtable is non-generic.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR131.severity = none
-
-# Title    : Avoid char.ToString.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR134.severity = none
-
-# Title    : Stream.CopyTo should be used with buffer size.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR135.severity = none
-
-# Title    : StreamReader.ReadLine can allocate StringBuilder instances each call if the lines are longer than the buffer size.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR136.severity = none
-
-# Title    : Random class instances should be shared as statics. Random is not thread safe so locks, ThreadLocal class or [ThreadStatic] attribute should be used for synchronization.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR138.severity = none
-
-# Title    : Regular expressions should be reused from static fields or properties.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR139.severity = none
-
-# Title    : TextWriter.WriteLine(string) allocates a char array. Use different overload or make two calls.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR140.severity = none
-
-# Title    : Reduce delegate allocations by storing them in static fields and properties.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-# Comment  : This rule flags most lambda uses, which makes it extremely verbose and not particularly useful
-dotnet_diagnostic.CPR145.severity = none
-
-# Title    : Extra dictionary access
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR500.severity = none
-
-# Title    : Avoid repeated type checking.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR501.severity = none
-
-# Title    : Do not cast multiple times.
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR502.severity = none
-
-# Title    : Extra HashSet access
-# Category : Performance Analysis
-# Help Link: http://aka.ms/cprwiki
-dotnet_diagnostic.CPR503.severity = none
-
-# Title    : Do not use banned insecure deserialization APIs
-# Category : Security
-# Help Link: https://aka.ms/ia2989
-dotnet_diagnostic.IA2989.severity = none
-
-# Title    : Do Not Use Banned APIs For Insecure Deserializers
-# Category : Security
-# Help Link: https://aka.ms/ia2992
-dotnet_diagnostic.IA2992.severity = none
-
-# Title    : Do Not Use Banned Constructors For Insecure Deserializers
-# Category : Security
-# Help Link: https://aka.ms/ia2993
-dotnet_diagnostic.IA2993.severity = none
-
-# Title    : Do Not Use ResourceSet Without ResourceReader
-# Category : Security
-# Help Link: https://aka.ms/ia2994
-dotnet_diagnostic.IA2994.severity = none
-
-# Title    : Do Not Use ResourceReader
-# Category : Security
-# Help Link: https://aka.ms/ia2995
-dotnet_diagnostic.IA2995.severity = none
-
-# Title    : Do Not Use ResXResourceReader Without ITypeResolutionService
-# Category : Security
-# Help Link: https://aka.ms/ia2996
-dotnet_diagnostic.IA2996.severity = none
-
-# Title    : Do Not Use TypeNameHandling Other Than None
-# Category : Security
-# Help Link: https://aka.ms/ia2997
-dotnet_diagnostic.IA2997.severity = none
-
-# Title    : Do Not Deserialize With BinaryFormatter Without Binder
-# Category : Security
-# Help Link: https://aka.ms/ia2998
-dotnet_diagnostic.IA2998.severity = none
-
-# Title    : Do Not Set BinaryFormatter.Binder to null
-# Category : Security
-# Help Link: https://aka.ms/ia2999
-dotnet_diagnostic.IA2999.severity = none
-
-# Title    : Do Not Use Weak Cryptographic Algorithms
-# Category : Security
-# Help Link: http://aka.ms/IA5350
-# Tags     : Telemetry
-dotnet_diagnostic.IA5350.severity = none
-
-# Title    : Do Not Use Broken Cryptographic Algorithms
-# Category : Security
-# Help Link: http://aka.ms/IA5351
-# Tags     : Telemetry
-dotnet_diagnostic.IA5351.severity = none
-
-# Title    : Do Not Misuse Cryptographic APIs 
-# Category : Security
-# Help Link: http://aka.ms/IA5352
-# Tags     : Telemetry
-dotnet_diagnostic.IA5352.severity = none
-
-# Title    : Use approved crypto libraries for the supported platform
-# Category : Security
-# Help Link: https://aka.ms/ia5359
-# Tags     : Telemetry
-dotnet_diagnostic.IA5359.severity = none
-
-# Title    : Custom web token handler was found
-# Category : Security
-# Help Link: https://aka.ms/ia6450
-# Tags     : Telemetry
-dotnet_diagnostic.IA6450.severity = none
-
-# Title    : Implement required validations for app asserted actor token
-# Category : Security
-# Help Link: https://aka.ms/ia6451
-# Tags     : Telemetry
-dotnet_diagnostic.IA6451.severity = none
-
-# Title    : Do not disable {0}
-# Category : Security
-# Help Link: https://aka.ms/ia6452
-# Tags     : Telemetry
-dotnet_diagnostic.IA6452.severity = none
-
-# Title    : Do not disable {0}
-# Category : Security
-# Help Link: https://aka.ms/ia6453
-# Tags     : Telemetry
-dotnet_diagnostic.IA6453.severity = none
-
-# Title    : Do not disable {0}
-# Category : Security
-# Help Link: https://aka.ms/ia6454
-# Tags     : Telemetry
-dotnet_diagnostic.IA6454.severity = none
-
-# Title    : Do Not Use Insecure PowerShell LanguageModes
-# Category : Security
-# Help Link: https://aka.ms/ia6456
-# Tags     : Telemetry
-dotnet_diagnostic.IA6456.severity = none
-
-# Title    : Review PowerShell Execution for PowerShell Injection
-# Category : Security
-# Help Link: https://aka.ms/IA6457
-dotnet_diagnostic.IA6457.severity = none
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
 
 # Title    : Simplify name
 # Category : Style
@@ -2247,25 +1696,23 @@ dotnet_style_qualification_for_property = false
 
 # Title    : Remove Unnecessary Cast
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
 dotnet_diagnostic.IDE0004.severity = warning
 
 # Title    : Using directive is unnecessary.
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
 dotnet_diagnostic.IDE0005.severity = none
 
 # Title    : Using directive is unnecessary.
 # Category : Style
-# Tags     : Telemetry, EnforceOnBuild_Never, NotConfigurable, Unnecessary
+# Redundant: S1128
 dotnet_diagnostic.IDE0005_gen.severity = none
 
 # Title    : Use implicit type
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
 dotnet_diagnostic.IDE0007.severity = silent
 csharp_style_var_elsewhere = true
 csharp_style_var_for_built_in_types = false
@@ -2273,243 +1720,213 @@ csharp_style_var_when_type_is_apparent = true
 
 # Title    : Use explicit type
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
 dotnet_diagnostic.IDE0008.severity = silent
 
 # Title    : Member access should be qualified.
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
-# Tags     : Telemetry, EnforceOnBuild_Never
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0009.severity = none
 
 # Title    : Add missing cases
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
 dotnet_diagnostic.IDE0010.severity = silent
 
 # Title    : Add braces
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
 dotnet_diagnostic.IDE0011.severity = warning
 csharp_prefer_braces = true
 
 # Title    : Use 'throw' expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
 dotnet_diagnostic.IDE0016.severity = warning
 csharp_style_throw_expression = true
 
 # Title    : Simplify object initialization
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
 dotnet_diagnostic.IDE0017.severity = warning
 dotnet_style_object_initializer = true
 
 # Title    : Inline variable declaration
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
 dotnet_diagnostic.IDE0018.severity = warning
 csharp_style_inlined_variable_declaration = true
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
 dotnet_diagnostic.IDE0019.severity = silent
 csharp_style_pattern_matching_over_is_with_cast_check = true
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
 dotnet_diagnostic.IDE0020.severity = silent
 csharp_style_pattern_matching_over_is_with_cast_check
 
-# Title    : Use expression body for constructors
+# Title    : Use expression body for constructor
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
 dotnet_diagnostic.IDE0021.severity = warning
 csharp_style_expression_bodied_constructors = false
 
-# Title    : Use expression body for methods
+# Title    : Use expression body for method
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
 dotnet_diagnostic.IDE0022.severity = silent
 csharp_style_expression_bodied_methods = when_on_single_line
 
-# Title    : Use expression body for conversion operators
+# Title    : Use expression body for conversion operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
 dotnet_diagnostic.IDE0023.severity = warning
 csharp_style_expression_bodied_operators = false
 
-# Title    : Use expression body for operators
+# Title    : Use expression body for operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
 dotnet_diagnostic.IDE0024.severity = warning
 csharp_style_expression_bodied_operators = false
 
-# Title    : Use expression body for properties
+# Title    : Use expression body for property
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
 dotnet_diagnostic.IDE0025.severity = warning
 csharp_style_expression_bodied_properties = true
 
-# Title    : Use expression body for indexers
+# Title    : Use expression body for indexer
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
 dotnet_diagnostic.IDE0026.severity = warning
 csharp_style_expression_bodied_indexers = true
 
-# Title    : Use expression body for accessors
+# Title    : Use expression body for accessor
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
 dotnet_diagnostic.IDE0027.severity = warning
 csharp_style_expression_bodied_accessors = true
 
 # Title    : Simplify collection initialization
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
 dotnet_diagnostic.IDE0028.severity = warning
 dotnet_style_collection_initializer = true
 
 # Title    : Use coalesce expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
 dotnet_diagnostic.IDE0029.severity = warning
 dotnet_style_coalesce_expression = true
 
 # Title    : Use coalesce expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
 dotnet_diagnostic.IDE0030.severity = warning
 dotnet_style_coalesce_expression = true
 
 # Title    : Use null propagation
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
 dotnet_diagnostic.IDE0031.severity = warning
 dotnet_style_null_propagation = true
 
 # Title    : Use auto property
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
 dotnet_diagnostic.IDE0032.severity = warning
 dotnet_style_prefer_auto_properties = true
 
 # Title    : Use explicitly provided tuple name
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
 dotnet_diagnostic.IDE0033.severity = warning
 dotnet_style_explicit_tuple_names = true
 
 # Title    : Simplify 'default' expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
 dotnet_diagnostic.IDE0034.severity = warning
 csharp_prefer_simple_default_expression = true
 
 # Title    : Unreachable code detected
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
-# Tags     : Telemetry, EnforceOnBuild_Never, NotConfigurable, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0035.severity = warning
 
 # Title    : Order modifiers
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
 dotnet_diagnostic.IDE0036.severity = silent
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
 
 # Title    : Use inferred member name
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
 dotnet_diagnostic.IDE0037.severity = silent
 dotnet_style_prefer_inferred_anonymous_type_member_names = true
 dotnet_style_prefer_inferred_tuple_names = true
 
 # Title    : Use local function
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
 dotnet_diagnostic.IDE0039.severity = silent
 csharp_style_prefer_local_over_anonymous_function = false
 
 # Title    : Add accessibility modifiers
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
 dotnet_diagnostic.IDE0040.severity = warning
 dotnet_style_require_accessibility_modifiers = for_non_interface_members
 
 # Title    : Use 'is null' check
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
 dotnet_diagnostic.IDE0041.severity = warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true
 
 # Title    : Deconstruct variable declaration
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
 dotnet_diagnostic.IDE0042.severity = silent
 csharp_style_deconstructed_variable_declaration = true
 
 # Title    : Invalid format string
 # Category : Compiler
-# Tags     : EnforceOnBuild_HighlyRecommended
 dotnet_diagnostic.IDE0043.severity = warning
 
 # Title    : Add readonly modifier
 # Category : Style
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
 dotnet_diagnostic.IDE0044.severity = warning
 dotnet_style_readonly_field = true:warning
 
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
 # Title    : Convert to conditional expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
 dotnet_diagnostic.IDE0045.severity = silent
 dotnet_style_prefer_conditional_expression_over_assignment = true
 
 # Title    : Convert to conditional expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
 dotnet_diagnostic.IDE0046.severity = silent
 dotnet_style_prefer_conditional_expression_over_return = true
 
 # Title    : Remove unnecessary parentheses
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
 dotnet_diagnostic.IDE0047.severity = silent
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
@@ -2518,8 +1935,7 @@ dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
 
 # Title    : Add parentheses for clarity
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
 dotnet_diagnostic.IDE0048.severity = silent
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
@@ -2536,41 +1952,35 @@ dotnet_diagnostic.IDE0049.severity = none
 
 # Title    : Convert to tuple
 # Category : Style
-# Tags     : Telemetry
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0050.severity = silent
 
 # Title    : Remove unused private members
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
-dotnet_diagnostic.IDE0051.severity = none
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
 
 # Title    : Remove unread private members
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
 dotnet_diagnostic.IDE0052.severity = warning
 
-# Title    : Use expression body for lambda expressions
+# Title    : Use block body for lambda expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
 # Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
 dotnet_diagnostic.IDE0053.severity = suggestion
 csharp_style_expression_bodied_lambdas = when_on_single_line
 
 # Title    : Use compound assignment
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
 dotnet_diagnostic.IDE0054.severity = warning
 dotnet_style_prefer_compound_assignment = true
 
 # Title    : Fix formatting
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
 dotnet_diagnostic.IDE0055.severity = warning
 dotnet_style_namespace_match_folder = true
 csharp_new_line_before_catch = true
@@ -2613,68 +2023,59 @@ csharp_preserve_single_line_statements = false
 
 # Title    : Use index operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
 dotnet_diagnostic.IDE0056.severity = silent
 csharp_style_prefer_index_operator = true
 
 # Title    : Use range operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
 dotnet_diagnostic.IDE0057.severity = silent
 csharp_style_prefer_range_operator = true:warning
 
 # Title    : Expression value is never used
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
 dotnet_diagnostic.IDE0058.severity = none
 
 # Title    : Unnecessary assignment of a value
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
 dotnet_diagnostic.IDE0059.severity = none
 
 # Title    : Remove unused parameter
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
 dotnet_diagnostic.IDE0060.severity = warning
 dotnet_code_quality_unused_parameters = all
 
-# Title    : Use expression body for local functions
+# Title    : Use expression body for local function
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
 dotnet_diagnostic.IDE0061.severity = warning
 csharp_style_expression_bodied_local_functions = true
 
 # Title    : Make local function 'static'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
 dotnet_diagnostic.IDE0062.severity = warning
 csharp_prefer_static_local_function = true
 
 # Title    : Use simple 'using' statement
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
 dotnet_diagnostic.IDE0063.severity = warning
 csharp_prefer_simple_using_statement = true
 
 # Title    : Make readonly fields writable
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
 dotnet_diagnostic.IDE0064.severity = warning
 
 # Title    : Misplaced using directive
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
 dotnet_diagnostic.IDE0065.severity = warning
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
@@ -2682,228 +2083,214 @@ csharp_using_directive_placement = outside_namespace:suggestion
 
 # Title    : Convert switch statement to expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
 dotnet_diagnostic.IDE0066.severity = warning
 csharp_style_prefer_switch_expression = true:warning
 
 # Title    : Use 'System.HashCode'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
 dotnet_diagnostic.IDE0070.severity = warning
 
 # Title    : Simplify interpolation
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
 dotnet_diagnostic.IDE0071.severity = warning
 dotnet_style_prefer_simplified_interpolation = true
 
 # Title    : Add missing cases
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
 dotnet_diagnostic.IDE0072.severity = silent
 
-# Title    : The file header is missing or not located at the top of the file
+# Title    : The file header does not match the required text
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
 dotnet_diagnostic.IDE0073.severity = warning
 
 # Title    : Use compound assignment
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0074.severity = suggestion
 dotnet_style_prefer_compound_assignment = true
 
 # Title    : Simplify conditional expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
 dotnet_diagnostic.IDE0075.severity = warning
 dotnet_style_prefer_simplified_boolean_expressions = true
 
 # Title    : Invalid global 'SuppressMessageAttribute'
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
 dotnet_diagnostic.IDE0076.severity = warning
 
 # Title    : Avoid legacy format target in 'SuppressMessageAttribute'
 # Category : CodeQuality
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
 dotnet_diagnostic.IDE0077.severity = warning
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
 dotnet_diagnostic.IDE0078.severity = silent
 csharp_style_prefer_pattern_matching = true
 
 # Title    : Remove unnecessary suppression
 # Category : Style
-# Tags     : Telemetry
 # Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
 dotnet_diagnostic.IDE0079.severity = suggestion
 dotnet_remove_unnecessary_suppression_exclusions = CS0618
 
 # Title    : Remove unnecessary suppression operator
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
 dotnet_diagnostic.IDE0080.severity = warning
 
 # Title    : 'typeof' can be converted  to 'nameof'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
 dotnet_diagnostic.IDE0082.severity = warning
 
 # Title    : Use pattern matching
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
 dotnet_diagnostic.IDE0083.severity = silent
 csharp_style_prefer_not_pattern = true
 
 # Title    : Use 'new(...)'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
 dotnet_diagnostic.IDE0090.severity = warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 
 # Title    : Remove redundant equality
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
 # Comment  : S1125 triggers in more cases
+# Redundant: S1125
 dotnet_diagnostic.IDE0100.severity = none
 
 # Title    : Remove unnecessary discard
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
 dotnet_diagnostic.IDE0110.severity = warning
 
 # Title    : Simplify LINQ expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
 dotnet_diagnostic.IDE0120.severity = silent
 
 # Title    : Namespace does not match folder structure
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
 dotnet_diagnostic.IDE0130.severity = silent
 
 # Title    : Prefer 'null' check over type check
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
 dotnet_diagnostic.IDE0150.severity = warning
 csharp_style_prefer_null_check_over_type_check = true
 
 # Title    : Convert to block scoped namespace
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
 dotnet_diagnostic.IDE0160.severity = silent
 csharp_style_namespace_declarations = file_scoped
 
 # Title    : Convert to file-scoped namespace
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
 dotnet_diagnostic.IDE0161.severity = silent
 csharp_style_namespace_declarations = file_scoped
 
 # Title    : Property pattern can be simplified
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
 dotnet_diagnostic.IDE0170.severity = silent
 csharp_style_prefer_extended_property_pattern = true
 
 # Title    : Use tuple to swap values
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
-# Tags     : Telemetry, EnforceOnBuild_HighlyRecommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
 dotnet_diagnostic.IDE0180.severity = silent
 csharp_style_prefer_tuple_swap = true
 
 # Title    : Null check can be simplified
 # Category : Style
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
 dotnet_diagnostic.IDE0190.severity = silent
 
 # Title    : Remove unnecessary lambda expression
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
 dotnet_diagnostic.IDE0200.severity = silent
 
 # Title    : Convert to top-level statements
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
 dotnet_diagnostic.IDE0210.severity = silent
 
 # Title    : Convert to 'Program.Main' style program
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
 dotnet_diagnostic.IDE0211.severity = silent
 
 # Title    : Add explicit cast
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
 dotnet_diagnostic.IDE0220.severity = silent
 
 # Title    : Use UTF-8 string literal
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
 dotnet_diagnostic.IDE0230.severity = silent
 
 # Title    : Remove redundant nullable directive
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
 dotnet_diagnostic.IDE0240.severity = warning
 
 # Title    : Remove unnecessary nullable directive
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
-# Tags     : Telemetry, EnforceOnBuild_Recommended, Unnecessary
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
 dotnet_diagnostic.IDE0241.severity = warning
 
 # Title    : Make struct 'readonly'
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
 dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
 
 # Title    : Delegate invocation can be simplified.
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
 dotnet_diagnostic.IDE1005.severity = warning
 csharp_style_conditional_delegate_call = true
 
 # Title    : Naming Styles
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
-# Tags     : Telemetry, EnforceOnBuild_Recommended
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
 dotnet_diagnostic.IDE1006.severity = warning
 dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
 dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
@@ -2982,34 +2369,39 @@ dotnet_naming_style.tpascalcase.capitalization = pascal_case
 
 # Title    : Avoid multiple blank lines
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
 dotnet_diagnostic.IDE2000.severity = warning
 dotnet_style_allow_multiple_blank_lines_experimental = false
 
 # Title    : Embedded statements must be on their own line
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
 dotnet_diagnostic.IDE2001.severity = warning
 
 # Title    : Consecutive braces must not have blank line between them
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
 dotnet_diagnostic.IDE2002.severity = warning
 
 # Title    : Blank line required between block and subsequent statement
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
 dotnet_diagnostic.IDE2003.severity = silent
 
 # Title    : Blank line not allowed after constructor initializer colon
 # Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
-# Tags     : Telemetry, EnforceOnBuild_WhenExplicitlyEnabled
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
 dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
 
 # Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 # Category : Trimming
@@ -3238,7 +2630,6 @@ dotnet_diagnostic.IL3000.severity = warning
 # Title    : Avoid using accessing Assembly file path when publishing as a single-file
 # Category : Publish
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.IL3000.severity = warning
 
 # Title    : Avoid accessing Assembly file path when publishing as a single file
@@ -3248,7 +2639,6 @@ dotnet_diagnostic.IL3001.severity = warning
 # Title    : Avoid using accessing Assembly file path when publishing as a single-file
 # Category : Publish
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
-# Tags     : Telemetry, EnabledRuleInAggressiveMode
 dotnet_diagnostic.IL3001.severity = warning
 
 # Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
@@ -3277,2789 +2667,2286 @@ dotnet_diagnostic.IL3056.severity = warning
 
 # Title    : Use source generated logging methods for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a000
+# Help Link: https://TODO/r9a000
 dotnet_diagnostic.R9A000.severity = none
 
-# Title    : Use 'Microsoft.IO.RecyclableMemoryStream' instead of 'System.IO.MemoryStream' for improved performance
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a001
-dotnet_diagnostic.R9A001.severity = none
-
-# Title    : Use higher performance methods from 'IExtendedDistributedCache'
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a003
-dotnet_diagnostic.R9A003.severity = none
-
-# Title    : Use the 'Microsoft.R9.Extensions.Caching.Redis' package instead of 'Microsoft.Extensions.Caching.StackExchangeRedis'
-# Category : Resilience
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a005
-dotnet_diagnostic.R9A005.severity = warning
-
-# Title    : Update return type to match metric type
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a006
-dotnet_diagnostic.R9A006.severity = error
-
-# Title    : Remove method body
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a007
-dotnet_diagnostic.R9A007.severity = error
-
-# Title    : Add a parameter of type 'IMeter' to the method declaration
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a008
-dotnet_diagnostic.R9A008.severity = error
-
-# Title    : Update method parameters for dimensions to be string type
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a009
-dotnet_diagnostic.R9A009.severity = error
-
-# Title    : Make method static
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a010
-dotnet_diagnostic.R9A010.severity = error
-
-# Title    : Make method partial
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a011
-dotnet_diagnostic.R9A011.severity = error
-
-# Title    : Make method public
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a012
-dotnet_diagnostic.R9A012.severity = warning
-
-# Title    : Seal non-public classes for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a013
-dotnet_diagnostic.R9A013.severity = none
-
-# Title    : Use the 'Microsoft.R9.Extensions.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a014
+# Help Link: https://TODO/r9a014
 dotnet_diagnostic.R9A014.severity = none
 
-# Title    : Use the 'Microsoft.R9.Extensions.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a015
+# Help Link: https://TODO/r9a015
 dotnet_diagnostic.R9A015.severity = none
 
-# Title    : Use eager options validation
-# Category : Reliability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a016
-dotnet_diagnostic.R9A016.severity = none
-
-# Title    : Use asynchronous operations instead of legacy thread blocking code
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a017
-dotnet_diagnostic.R9A017.severity = none
-
-# Title    : Use 'Microsoft.R9.Extensions.Text.CompositeFormat' instead of 'string.Format' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a018
+# Help Link: https://TODO/r9a018
 dotnet_diagnostic.R9A018.severity = none
 
 # Title    : Remove unnecessary dictionary lookups
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a019
+# Help Link: https://TODO/r9a019
 dotnet_diagnostic.R9A019.severity = none
 
 # Title    : Remove unnecessary set lookups
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a020
+# Help Link: https://TODO/r9a020
 dotnet_diagnostic.R9A020.severity = none
 
 # Title    : Perform message formatting in the body of the logging method
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a021
+# Help Link: https://TODO/r9a021
 dotnet_diagnostic.R9A021.severity = none
 
 # Title    : Use 'System.TimeProvider' to make the code easier to test
 # Category : Reliability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a022
+# Help Link: https://TODO/r9a022
 dotnet_diagnostic.R9A022.severity = none
-
-# Title    : Use 'Microsoft.R9.Extensions.Time.PerfStopwatch' instead of 'System.Diagnostics.Stopwatch' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a023
-dotnet_diagnostic.R9A023.severity = none
-
-# Title    : Propagate data classification
-# Category : Privacy
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a024
-dotnet_diagnostic.R9A024.severity = none
-
-# Title    : Use fixed format for 'System.ObsoleteAttribute' message
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a025
-dotnet_diagnostic.R9A025.severity = none
-
-# Title    : Minimum deprecation period for an obsolete public API
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a026
-dotnet_diagnostic.R9A026.severity = none
-
-# Title    : Use fixed API surface format for soft deleted members
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a027
-dotnet_diagnostic.R9A027.severity = none
-
-# Title    : Argument provided for user input parameter on user data vending API is not from any request context
-# Category : Privacy
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a028
-dotnet_diagnostic.R9A028.severity = none
 
 # Title    : Using experimental API
 # Category : Reliability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a029
+# Help Link: https://TODO/r9a029
 dotnet_diagnostic.R9A029.severity = none
 
 # Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a030
+# Help Link: https://TODO/r9a030
 dotnet_diagnostic.R9A030.severity = none
 
 # Title    : Make types declared in an executable internal
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a031
+# Help Link: https://TODO/r9a031
 dotnet_diagnostic.R9A031.severity = none
 
 # Title    : Consider using an array instead of a collection
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a032
+# Help Link: https://TODO/r9a032
 dotnet_diagnostic.R9A032.severity = none
 
 # Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a033
+# Help Link: https://TODO/r9a033
 dotnet_diagnostic.R9A033.severity = none
 
-# Title    : Optimize method group use to avoid allocations
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a034
-dotnet_diagnostic.R9A034.severity = none
-
-# Title    : Make struct readonly
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a035
-dotnet_diagnostic.R9A035.severity = none
-
-# Title    : Use 'Microsoft.R9.Extensions.Text.NumericExtensions.ToInvariantString' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a036
+# Help Link: https://TODO/r9a036
 dotnet_diagnostic.R9A036.severity = none
 
 # Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a037
+# Help Link: https://TODO/r9a037
 dotnet_diagnostic.R9A037.severity = none
-
-# Title    : Use 'Microsoft.R9.Extensions.Pools.PoolFactory' instead for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a038
-dotnet_diagnostic.R9A038.severity = none
-
-# Title    : Remove superfluous null checks when compiling in a nullable context
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a039
-dotnet_diagnostic.R9A039.severity = none
 
 # Title    : Use generic collections instead of legacy collections for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a040
+# Help Link: https://TODO/r9a040
 dotnet_diagnostic.R9A040.severity = none
 
-# Title    : Use concrete types when possible for improved performance
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a041
-dotnet_diagnostic.R9A041.severity = none
-
-# Title    : Annotate all User Data APIs parameters
-# Category : Privacy
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a042
-dotnet_diagnostic.R9A042.severity = warning
-
-# Title    : Use 'Microsoft.R9.Extensions.Text.StringSplitExtensions.TrySplit' for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a043
+# Help Link: https://TODO/r9a043
 dotnet_diagnostic.R9A043.severity = none
 
 # Title    : Assign array of literal values to a static field for improved performance
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a044
+# Help Link: https://TODO/r9a044
 dotnet_diagnostic.R9A044.severity = none
 
-# Title    : Use 'Array.Empty<T>' instead of allocating a 0-element array for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a045
-dotnet_diagnostic.R9A045.severity = none
-
-# Title    : Source generated metrics (fast metrics) should be located in 'Metric' class
-# Category : Readability
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a046
-dotnet_diagnostic.R9A046.severity = warning
-
-# Title    : Do not use manual metrics, use fast (source generated) metrics instead for better performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a047
-dotnet_diagnostic.R9A047.severity = none
-
-# Title    : Use the 'Count' or 'Length' properties instead of the 'Any' method for improved performance
-# Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a048
-dotnet_diagnostic.R9A048.severity = none
-
-# Title    : Newly added API must be annotated with experimental attribute
+# Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a049
-dotnet_diagnostic.R9A049.severity = none
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
 
-# Title    : An experimental API was marked as obsolete
+# Title    : Experimental symbols cannot be marked as obsolete
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a050
-dotnet_diagnostic.R9A050.severity = none
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
 
-# Title    : A stable API was marked as experimental
+# Title    : Published symbols cannot be marked experimental
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a051
-dotnet_diagnostic.R9A051.severity = none
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
 
-# Title    : A stable API was deleted outside the deprecation period
+# Title    : Published symbols cannot be deleted to maintain compatibility
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a052
-dotnet_diagnostic.R9A052.severity = none
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
 
 # Title    : A deprecated API is not annotated with the obsolete attribute
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
-dotnet_diagnostic.R9A053.severity = none
+dotnet_diagnostic.R9A053.severity = warning
 
 # Title    : A deprecated API is marked as experimental
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
-dotnet_diagnostic.R9A054.severity = none
+dotnet_diagnostic.R9A054.severity = warning
 
-# Title    : The signature of a stable API has changed
+# Title    : Published symbols cannot be changed to maintain compatibility
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a055
-dotnet_diagnostic.R9A055.severity = none
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
 
 # Title    : Fire-and-forget async call inside a 'using' block
 # Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a056
+# Help Link: https://TODO/r9a056
 dotnet_diagnostic.R9A056.severity = warning
-
-# Title    : Use consistent versions of R9 assemblies
-# Category : Correctness
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a057
-dotnet_diagnostic.R9A057.severity = warning
 
 # Title    : Consider removing unnecessary conditional access operator (?)
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a058
+# Help Link: https://TODO/r9a058
 dotnet_diagnostic.R9A058.severity = suggestion
 
 # Title    : Consider removing unnecessary null coalescing assignment (??=)
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a059
+# Help Link: https://TODO/r9a059
 dotnet_diagnostic.R9A059.severity = suggestion
 
 # Title    : Consider removing unnecessary null coalescing operator (??)
 # Category : Performance
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a060
+# Help Link: https://TODO/r9a060
 dotnet_diagnostic.R9A060.severity = suggestion
 
 # Title    : The async method doesn't support cancellation
 # Category : Resilience
-# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a061
+# Help Link: https://TODO/r9a061
 dotnet_diagnostic.R9A061.severity = none
 
 # Title    : 
 # Category : Style
-# Tags     : Telemetry, EnforceOnBuild_Never, NotConfigurable
 dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
 
 # Title    : Methods and properties should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: IDE1006
 dotnet_diagnostic.S100.severity = none
 
 # Title    : Method overrides should not change parameter defaults
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1006.severity = warning
 
 # Title    : Types should be named in PascalCase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE1006
 dotnet_diagnostic.S101.severity = none
 
 # Title    : Lines should not be too long
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S103.severity = warning
 
 # Title    : Files should not have too many lines of code
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S104.severity = warning
 
 # Title    : Destructors should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1065
 dotnet_diagnostic.S1048.severity = none
 
 # Title    : Tabulation characters should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: SA1027
 dotnet_diagnostic.S105.severity = none
 
 # Title    : Standard outputs should not be used directly to log anything
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S106.severity = none
 
 # Title    : Collapsible "if" statements should be merged
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1066.severity = none
 
 # Title    : Expressions should not be too complex
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1067.severity = warning
 
 # Title    : Methods should not have too many parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S107.severity = warning
 
 # Title    : URIs should not be hardcoded
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1075.severity = warning
 
 # Title    : Nested blocks of code should not be left empty
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S108.severity = warning
 
 # Title    : Magic numbers should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S109.severity = warning
 
 # Title    : Inheritance tree of classes should not be too deep
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S110.severity = warning
 
 # Title    : Fields should not have public accessibility
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1051
 dotnet_diagnostic.S1104.severity = none
 
 # Title    : A close curly brace should be located at the beginning of a line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: SA1500
 dotnet_diagnostic.S1109.severity = none
 
 # Title    : Redundant pairs of parentheses should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: SA1119
 dotnet_diagnostic.S1110.severity = none
 
 # Title    : Empty statements should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: SA1106
 dotnet_diagnostic.S1116.severity = none
 
 # Title    : Local variables should not shadow class fields
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1117.severity = warning
 
 # Title    : Utility classes should not have public constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1052
 dotnet_diagnostic.S1118.severity = none
 
 # Title    : General exceptions should never be thrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA2219
 dotnet_diagnostic.S112.severity = none
 
 # Title    : Assignments should not be made from within sub-expressions
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1121.severity = warning
 
 # Title    : "Obsolete" attributes should include explanations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1041
 dotnet_diagnostic.S1123.severity = none
 
 # Title    : Boolean literals should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1125.severity = warning
 
 # Title    : Unused "using" should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1128.severity = warning
 
 # Title    : Files should contain an empty newline at the end
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S113.severity = none
 
 # Title    : Track uses of "FIXME" tags
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1134.severity = warning
 
 # Title    : Track uses of "TODO" tags
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1135.severity = warning
 
 # Title    : Unused private types or members should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay, Unnecessary
 dotnet_diagnostic.S1144.severity = warning
 
 # Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1145.severity = warning
 
 # Title    : Exit methods should not be called
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1147.severity = warning
 
 # Title    : "switch case" clauses should not have too many lines of code
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1151.severity = none
 
 # Title    : "Any()" should be used to test for emptiness
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1155.severity = warning
 
 # Title    : Exceptions should not be thrown in finally blocks
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA2219
 dotnet_diagnostic.S1163.severity = none
 
 # Title    : Empty arrays and collections should be returned instead of null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1168.severity = warning
 
 # Title    : Unused method parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0060
 dotnet_diagnostic.S1172.severity = none
 
 # Title    : Overriding members should do more than simply call the same member in the base class
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1185.severity = warning
 
 # Title    : Methods should not be empty
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1186.severity = warning
 
 # Title    : String literals should not be duplicated
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1192.severity = suggestion
 
 # Title    : Nested code blocks should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1199.severity = warning
 
 # Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1200.severity = none
 
 # Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CS0659
 dotnet_diagnostic.S1206.severity = none
 
 # Title    : Control structures should use curly braces
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: SA1503
 dotnet_diagnostic.S121.severity = none
 
 # Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1036
 dotnet_diagnostic.S1210.severity = none
 
 # Title    : "GC.Collect" should not be called
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1215.severity = none
 
 # Title    : Statements should be on separate lines
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S122.severity = none
 
 # Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1226.severity = warning
 
 # Title    : break statements should not be used except for switch cases
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1227.severity = none
 
 # Title    : Floating point numbers should not be tested for equality
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1244.severity = error
 
 # Title    : Sections of code should not be commented out
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S125.severity = warning
 
 # Title    : "if ... else if" constructs should end with "else" clauses
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S126.severity = none
 
 # Title    : A "while" loop should be used instead of a "for" loop
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1264.severity = warning
 
 # Title    : "for" loop stop conditions should be invariant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S127.severity = warning
 
 # Title    : "switch" statements should have at least 3 "case" clauses
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1301.severity = none
 
 # Title    : Track uses of in-source issue suppressions
 # Category : Info Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
-# Tags     : C#, MainSourceScope, TestSourceScope
 # Comment  : Suppressions are frequently necessary.
 dotnet_diagnostic.S1309.severity = none
 
 # Title    : "switch/Select" statements should contain a "default/Case Else" clauses
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S131.severity = none
 
 # Title    : Using hardcoded IP addresses is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1313.severity = warning
 
 # Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S134.severity = none
 
 # Title    : Functions should not have too many lines of code
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S138.severity = none
 
 # Title    : Culture should be specified for "string" operations
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1449.severity = warning
 
 # Title    : Private fields only used as local variables in methods should become local variables
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1450.severity = warning
 
 # Title    : Track lack of copyright and license headers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: IDE0073
 dotnet_diagnostic.S1451.severity = none
 
 # Title    : "switch" statements should not have too many "case" clauses
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1479.severity = warning
 
 # Title    : Unused local variables should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CS0168
 dotnet_diagnostic.S1481.severity = none
 
 # Title    : Methods and properties should not be too complex
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1541.severity = none
 
 # Title    : Tests should not be ignored
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S1607.severity = warning
 
 # Title    : Strings should not be concatenated using '+' in a loop
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1643.severity = warning
 
 # Title    : Variables should not be self-assigned
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1656.severity = warning
 
 # Title    : Multiple variables should not be declared on the same line
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1659.severity = warning
 
 # Title    : An abstract class should have both abstract and concrete methods
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1694.severity = warning
 
 # Title    : NullReferenceException should not be caught
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1696.severity = warning
 
 # Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1697.severity = warning
 
 # Title    : "==" should not be used when "Equals" is overridden
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S1698.severity = warning
 
 # Title    : Constructors should only call non-overridable methods
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1699.severity = warning
 
 # Title    : Loops with at most one iteration should be refactored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1751.severity = warning
 
 # Title    : Identical expressions should not be used on both sides of a binary operator
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1764.severity = warning
 
 # Title    : "switch" statements should not be nested
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1821.severity = none
 
 # Title    : Objects should not be created to be dropped immediately without being used
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1848.severity = warning
 
 # Title    : Unused assignments should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0059
 dotnet_diagnostic.S1854.severity = none
 
 # Title    : "ToString()" calls should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1858.severity = warning
 
 # Title    : Related "if/else if" statements should not have the same condition
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1862.severity = warning
 
 # Title    : Two branches in a conditional structure should not have exactly the same implementation
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S1871.severity = warning
 
 # Title    : Redundant casts should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0004
 dotnet_diagnostic.S1905.severity = none
 
 # Title    : Inheritance list should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1939.severity = warning
 
 # Title    : Boolean checks should not be inverted
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1940.severity = warning
 
 # Title    : Inappropriate casts should not be made
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S1944.severity = warning
 
 # Title    : "for" loop increment clauses should modify the loops' counters
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S1994.severity = warning
 
 # Title    : Hashes should include an unpredictable salt
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : Analysis is too slow
 dotnet_diagnostic.S2053.severity = none
 
 # Title    : Hard-coded credentials are security-sensitive
 # Category : Blocker Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2068.severity = warning
 
 # Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
-# Tags     : C#, MainSourceScope
+# Redundant: CA5350
 dotnet_diagnostic.S2070.severity = none
 
 # Title    : Formatting SQL queries is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2077.severity = warning
 
 # Title    : Creating cookies without the "secure" flag is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2092.severity = warning
 
 # Title    : Collections should not be passed as arguments to their own methods
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2114.severity = warning
 
 # Title    : A secure password should be used when connecting to a database
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2115.severity = warning
 
 # Title    : Values should not be uselessly incremented
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2123.severity = warning
 
 # Title    : Underscores should be used to make large numbers readable
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2148.severity = warning
 
 # Title    : "sealed" classes should not have "protected" members
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2156.severity = warning
 
 # Title    : Short-circuit logic should be used in boolean contexts
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2178.severity = warning
 
 # Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2183.severity = warning
 
 # Title    : Results of integer division should not be assigned to floating point variables
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2184.severity = warning
 
 # Title    : TestCases should contain tests
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S2187.severity = warning
 
 # Title    : Recursion should not be infinite
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2190.severity = warning
 
 # Title    : Modulus results should not be checked for direct equality
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2197.severity = warning
 
 # Title    : Return values from functions without side effects should not be ignored
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA1806
 dotnet_diagnostic.S2201.severity = none
 
 # Title    : Runtime type checking should be simplified
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2219.severity = warning
 
 # Title    : "Exception" should not be caught
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2221.severity = none
 
 # Title    : Locks should be released on all paths
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2222.severity = warning
 
 # Title    : Non-constant static fields should not be visible
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2223.severity = warning
 
 # Title    : "ToString()" method should not return null
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2225.severity = warning
 
 # Title    : Console logging should not be used
 # Category : Minor Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2228.severity = none
 
 # Title    : Parameters should be passed in the correct order
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2234.severity = warning
 
 # Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2245.severity = warning
 
 # Title    : A "for" loop update clause should move the counter in the right direction
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2251.severity = warning
 
 # Title    : For-loop conditions should be true at least once
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2252.severity = warning
 
 # Title    : Writing cookies is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2255.severity = warning
 
 # Title    : Using non-standard cryptographic algorithms is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2257.severity = warning
 
 # Title    : Null pointers should not be dereferenced
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : Redundant, covered by modern C# compiler
 dotnet_diagnostic.S2259.severity = none
 
 # Title    : Composite format strings should not lead to unexpected behavior at runtime
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2275.severity = warning
 
 # Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2278.severity = warning
 
 # Title    : Field-like events should not be virtual
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2290.severity = warning
 
 # Title    : Overflow checking should not be disabled for "Enumerable.Sum"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2291.severity = warning
 
 # Title    : Trivial properties should be auto-implemented
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0032
 dotnet_diagnostic.S2292.severity = none
 
 # Title    : "nameof" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2302.severity = warning
 
 # Title    : "async" and "await" should not be used as identifiers
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2306.severity = warning
 
 # Title    : Methods and properties that don't access instance data should be static
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1822
 dotnet_diagnostic.S2325.severity = none
 
 # Title    : Unused type parameters should be removed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 # Comment  : Valid pattern used in a number of places
 dotnet_diagnostic.S2326.severity = none
 
 # Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2327.severity = warning
 
 # Title    : "GetHashCode" should not reference mutable fields
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2328.severity = warning
 
 # Title    : Array covariance should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2330.severity = warning
 
 # Title    : Redundant modifiers should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2333.severity = warning
 
 # Title    : Public constant members should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2339.severity = none
 
 # Title    : Enumeration types should comply with a naming convention
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2342.severity = none
 
 # Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2344.severity = warning
 
 # Title    : Flags enumerations should explicitly initialize all their members
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2345.severity = warning
 
 # Title    : Flags enumerations zero-value members should be named "None"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1008
 dotnet_diagnostic.S2346.severity = none
 
 # Title    : Fields should be private
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
-# Tags     : C#, MainSourceScope
+# Redundant: CA1051
 dotnet_diagnostic.S2357.severity = none
 
 # Title    : Optional parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2360.severity = none
 
 # Title    : Properties should not make collection or array copies
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2365.severity = warning
 
 # Title    : Public methods should not have multidimensional array parameters
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2368.severity = warning
 
 # Title    : Exceptions should not be thrown from property getters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2372.severity = warning
 
 # Title    : Write-only properties should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2376.severity = warning
 
 # Title    : Mutable fields should not be "public static"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2386.severity = warning
 
 # Title    : Child class fields should not shadow parent class fields
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2387.severity = warning
 
 # Title    : Types and methods should not have too many generic parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
-dotnet_diagnostic.S2436.severity = warning
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
 
 # Title    : Silly bit operations should not be performed
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay, Unnecessary
 dotnet_diagnostic.S2437.severity = warning
 
 # Title    : Whitespace and control characters in string literals should be explicit
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2479.severity = warning
 
 # Title    : Generic exceptions should not be ignored
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2486.severity = warning
 
 # Title    : Shared resources should not be used for locking
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2551.severity = warning
 
 # Title    : Conditionally executed code should be reachable
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1508
 dotnet_diagnostic.S2583.severity = none
 
 # Title    : Boolean expressions should not be gratuitous
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2589.severity = warning
 
 # Title    : Setting loose file permissions is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2612.severity = warning
 
 # Title    : The length returned from a stream read should be checked
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2674.severity = warning
 
 # Title    : Multiline blocks should be enclosed in curly braces
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2681.severity = warning
 
 # Title    : "NaN" should not be used in comparisons
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2688.severity = warning
 
 # Title    : "IndexOf" checks should not be for positive numbers
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2692.severity = warning
 
 # Title    : Instance members should not write to "static" fields
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2696.severity = warning
 
 # Title    : Tests should include assertions
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S2699.severity = warning
 
 # Title    : Literal boolean values should not be used in assertions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
-# Tags     : C#, TestSourceScope
 dotnet_diagnostic.S2701.severity = warning
 
 # Title    : "catch" clauses should do more than rethrow
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2737.severity = warning
 
 # Title    : Static fields should not be used in generic types
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2743.severity = none
 
 # Title    : XML parsers should not be vulnerable to XXE attacks
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2755.severity = warning
 
 # Title    : "=+" should not be used instead of "+="
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2757.severity = warning
 
 # Title    : The ternary operator should not return the same value regardless of the condition
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2758.severity = warning
 
 # Title    : Sequential tests should not check the same condition
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2760.severity = warning
 
 # Title    : Doubled prefix operators "!!" and "~~" should not be used
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2761.severity = warning
 
 # Title    : SQL keywords should be delimited by whitespace
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2857.severity = warning
 
 # Title    : "IDisposables" should be disposed
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
-# Comment  : Duplicate, see CA2000
+# Redundant: CA2000
 dotnet_diagnostic.S2930.severity = none
 
 # Title    : Classes with "IDisposable" members should implement "IDisposable"
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
-# Tags     : C#, MainSourceScope, TestSourceScope
-dotnet_diagnostic.S2931.severity = warning
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
 
 # Title    : Fields that are only assigned in the constructor should be "readonly"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: IDE0044
 dotnet_diagnostic.S2933.severity = none
 
 # Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2934.severity = warning
 
 # Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S2952.severity = warning
 
 # Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S2953.severity = warning
 
 # Title    : Generic parameters not constrained to reference types should not be compared to "null"
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S2955.severity = warning
 
 # Title    : "IEnumerable" LINQs should be simplified
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2971.severity = warning
 
 # Title    : "Object.ReferenceEquals" should not be used for value types
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2995.severity = warning
 
 # Title    : "ThreadStatic" fields should not be initialized
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2996.severity = warning
 
 # Title    : "IDisposables" created in a "using" statement should not be returned
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S2997.severity = warning
 
 # Title    : "ThreadStatic" should not be used on non-static fields
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3005.severity = warning
 
 # Title    : Static fields should not be updated in constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3010.severity = warning
 
 # Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3011.severity = warning
 
 # Title    : Members should not be initialized to default values
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1805
 dotnet_diagnostic.S3052.severity = none
 
 # Title    : Types should not have members with visibility set higher than the type's visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3059.severity = none
 
 # Title    : "is" should not be used with "this"
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3060.severity = warning
 
 # Title    : "async" methods should not return "void"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: VSTHRD100
 dotnet_diagnostic.S3168.severity = none
 
 # Title    : Multiple "OrderBy" calls should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3169.severity = warning
 
 # Title    : Delegates should not be subtracted
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3172.severity = warning
 
 # Title    : "interface" instances should not be cast to concrete types
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3215.severity = warning
 
 # Title    : "ConfigureAwait(false)" should be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
-# Tags     : C#, MainSourceScope
+# Redundant: CA2007
 dotnet_diagnostic.S3216.severity = none
 
 # Title    : "Explicit" conversions of "foreach" loops should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3217.severity = warning
 
 # Title    : Inner class members should not shadow outer class "static" or type members
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3218.severity = warning
 
 # Title    : Method calls should not resolve ambiguously to overloads with "params"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3220.severity = warning
 
 # Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3234.severity = warning
 
 # Title    : Redundant parentheses should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3235.severity = warning
 
 # Title    : Caller information arguments should not be provided explicitly
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3236.severity = warning
 
 # Title    : "value" parameters should be used
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3237.severity = warning
 
 # Title    : The simplest possible condition syntax should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: IDE0054
 dotnet_diagnostic.S3240.severity = none
 
 # Title    : Methods should not return values that are never used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3241.severity = warning
 
 # Title    : Method parameters should be declared with base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
-# Tags     : C#, MainSourceScope, TestSourceScope
 # Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
 dotnet_diagnostic.S3242.severity = none
 
 # Title    : Anonymous delegates should not be used to unsubscribe from Events
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3244.severity = warning
 
 # Title    : Generic type parameters should be co/contravariant when possible
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3246.severity = warning
 
 # Title    : Duplicate casts should not be made
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3247.severity = warning
 
 # Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3249.severity = warning
 
 # Title    : Implementations should be provided for "partial" methods
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3251.severity = warning
 
 # Title    : Constructor and destructor declarations should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3253.severity = warning
 
 # Title    : Default parameter values should not be passed as arguments
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3254.severity = warning
 
 # Title    : "string.IsNullOrEmpty" should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3256.severity = warning
 
 # Title    : Declarations and initializations should be as concise as possible
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3257.severity = warning
 
 # Title    : Non-derived "private" classes and records should be "sealed"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: R9A013
 dotnet_diagnostic.S3260.severity = none
 
 # Title    : Namespaces should not be empty
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3261.severity = warning
 
 # Title    : "params" should be used on overrides
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3262.severity = warning
 
 # Title    : Static fields should appear in the order they must be initialized 
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3263.severity = warning
 
 # Title    : Events should be invoked
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3264.severity = warning
 
 # Title    : Non-flags enums should not be used in bitwise operations
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3265.severity = warning
 
 # Title    : Loops should be simplified with "LINQ" expressions
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3267.severity = none
 
 # Title    : Cipher Block Chaining IVs should be unpredictable
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : Analysis is too slow
 dotnet_diagnostic.S3329.severity = none
 
 # Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3330.severity = warning
 
 # Title    : Caller information parameters should come at the end of the parameter list
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3343.severity = warning
 
 # Title    : Expressions used in "Debug.Assert" should not produce side effects
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3346.severity = warning
 
 # Title    : Unchanged local variables should be "const"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3353.severity = warning
 
 # Title    : Ternary operators should not be nested
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3358.severity = warning
 
 # Title    : "this" should not be exposed from constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S3366.severity = warning
 
 # Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1710
 dotnet_diagnostic.S3376.severity = none
 
 # Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3397.severity = warning
 
 # Title    : Methods should not return constants
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3400.severity = warning
 
 # Title    : Assertion arguments should be passed in the correct order
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S3415.severity = warning
 
 # Title    : Method overloads with default parameter values should not overlap 
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3427.severity = warning
 
 # Title    : "[ExpectedException]" should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
-# Tags     : C#, TestSourceScope
 dotnet_diagnostic.S3431.severity = warning
 
 # Title    : Test method signatures should be correct
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
-# Tags     : C#, TestSourceScope, SonarWay
 dotnet_diagnostic.S3433.severity = warning
 
 # Title    : Variables should not be checked against the values they're about to be assigned
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3440.severity = warning
 
 # Title    : Redundant property names should be omitted in anonymous classes
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3441.severity = warning
 
 # Title    : "abstract" classes should not have "public" constructors
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3442.severity = warning
 
 # Title    : Type should not be examined on "System.Type" instances
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3443.severity = warning
 
 # Title    : Interfaces should not simply inherit from base interfaces with colliding members
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3444.severity = warning
 
 # Title    : Exceptions should not be explicitly rethrown
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3445.severity = warning
 
 # Title    : "[Optional]" should not be used on "ref" or "out" parameters
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3447.severity = warning
 
 # Title    : Right operands of shift operators should be integers
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3449.severity = warning
 
 # Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3450.severity = warning
 
 # Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3451.severity = warning
 
 # Title    : Classes should not have only "private" constructors
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3453.severity = warning
 
 # Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3456.severity = warning
 
 # Title    : Composite format strings should be used correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3457.severity = warning
 
 # Title    : Empty "case" clauses that fall through to the "default" should be omitted
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3458.severity = warning
 
 # Title    : Unassigned members should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3459.severity = warning
 
 # Title    : Type inheritance should not be recursive
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3464.severity = warning
 
 # Title    : Optional parameters should be passed to "base" calls
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3466.severity = warning
 
 # Title    : Empty "default" clauses should be removed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3532.severity = warning
 
 # Title    : "ServiceContract" and "OperationContract" attributes should be used together
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3597.severity = warning
 
 # Title    : One-way "OperationContract" methods should have "void" return type
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3598.severity = warning
 
 # Title    : "params" should not be introduced on overrides
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3600.severity = warning
 
 # Title    : Methods with "Pure" attribute should return a value 
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3603.severity = warning
 
 # Title    : Member initializer values should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3604.severity = warning
 
 # Title    : Nullable type comparison should not be redundant
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3610.severity = warning
 
 # Title    : Jump statements should not be redundant
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3626.severity = warning
 
 # Title    : Empty nullable value should not be accessed
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3655.severity = warning
 
 # Title    : Exception constructors should not throw exceptions
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3693.severity = warning
 
 # Title    : Track use of "NotImplementedException"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3717.severity = warning
 
 # Title    : Cognitive Complexity of methods should not be too high
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 # Comment  : Code gets complicated
 dotnet_diagnostic.S3776.severity = none
 
 # Title    : "SafeHandle.DangerousGetHandle" should not be called
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3869.severity = warning
 
 # Title    : Exception types should be "public"
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1064
 dotnet_diagnostic.S3871.severity = none
 
 # Title    : Parameter names should not duplicate the names of their methods
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3872.severity = warning
 
 # Title    : "out" and "ref" parameters should not be used
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1021
 dotnet_diagnostic.S3874.severity = none
 
 # Title    : "operator==" should not be overloaded on reference types
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3875.severity = warning
 
 # Title    : Strings or integral types should be used for indexers
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3876.severity = warning
 
 # Title    : Exceptions should not be thrown from unexpected methods
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3877.severity = none
 
 # Title    : Finalizers should not be empty
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3880.severity = warning
 
 # Title    : "IDisposable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3881.severity = none
 
 # Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
 # Category : Blocker Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3884.severity = warning
 
 # Title    : "Assembly.Load" should be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3885.severity = warning
 
 # Title    : Mutable, non-private fields should not be "readonly"
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3887.severity = warning
 
 # Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3889.severity = warning
 
 # Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3897.severity = warning
 
 # Title    : Value types should implement "IEquatable<T>"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3898.severity = none
 
 # Title    : Arguments of public methods should be validated against null
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1062
 dotnet_diagnostic.S3900.severity = none
 
 # Title    : "Assembly.GetExecutingAssembly" should not be called
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3902.severity = warning
 
 # Title    : Types should be defined in named namespaces
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 # Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
 dotnet_diagnostic.S3903.severity = none
 
 # Title    : Assemblies should have version information
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S3904.severity = warning
 
 # Title    : Event Handlers should have the correct signature
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3906.severity = warning
 
 # Title    : Generic event handlers should be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3908.severity = warning
 
 # Title    : Collections should implement the generic interface
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1010
 dotnet_diagnostic.S3909.severity = none
 
 # Title    : All branches in a conditional structure should not have exactly the same implementation
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3923.severity = warning
 
 # Title    : "ISerializable" should be implemented correctly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
-# Tags     : C#, MainSourceScope, SonarWay
 # Comment  : TODO - is ISerializable still relevant?
 dotnet_diagnostic.S3925.severity = none
 
 # Title    : Deserialization methods should be provided for "OptionalField" members
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3926.severity = warning
 
 # Title    : Serialization event handlers should be implemented correctly
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3927.severity = warning
 
 # Title    : Parameter names used into ArgumentException constructors should match an existing one 
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3928.severity = none
 
 # Title    : Number patterns should be regular
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3937.severity = warning
 
 # Title    : Calculations should not overflow
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
-# Tags     : C#, MainSourceScope, TestSourceScope, Unnecessary
 dotnet_diagnostic.S3949.severity = suggestion
 
 # Title    : "Generic.List" instances should not be part of public APIs
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
-# Tags     : C#, MainSourceScope
-dotnet_diagnostic.S3956.severity = warning
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
 
 # Title    : "static readonly" constants should be "const" instead
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1802
 dotnet_diagnostic.S3962.severity = none
 
 # Title    : "static" fields should be initialized inline
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1810 and CA2207
 dotnet_diagnostic.S3963.severity = none
 
 # Title    : Objects should not be disposed more than once
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3966.severity = warning
 
 # Title    : Multidimensional arrays should not be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3967.severity = warning
 
 # Title    : "GC.SuppressFinalize" should not be called
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3971.severity = warning
 
 # Title    : Conditionals should start on new lines
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3972.severity = warning
 
 # Title    : A conditionally executed single line should be denoted by indentation
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3973.severity = warning
 
 # Title    : Collection sizes and array length comparisons should make sense
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3981.severity = warning
 
 # Title    : Exceptions should not be created without being thrown
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3984.severity = warning
 
 # Title    : Assemblies should be marked as CLS compliant
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1014
 dotnet_diagnostic.S3990.severity = none
 
 # Title    : Assemblies should explicitly specify COM visibility
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1017
 dotnet_diagnostic.S3992.severity = none
 
 # Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1018
 dotnet_diagnostic.S3993.severity = none
 
 # Title    : URI Parameters should not be strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3994.severity = none
 
 # Title    : URI return values should not be strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3995.severity = warning
 
 # Title    : URI properties should not be strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3996.severity = warning
 
 # Title    : String URI overloads should call "System.Uri" overloads
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S3997.severity = warning
 
 # Title    : Threads should not lock on objects with weak identity
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S3998.severity = warning
 
 # Title    : Pointers to unmanaged memory should not be visible
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4000.severity = warning
 
 # Title    : Disposable types should declare finalizers
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4002.severity = warning
 
 # Title    : Collection properties should be readonly
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA2227
 dotnet_diagnostic.S4004.severity = none
 
 # Title    : "System.Uri" arguments should be used instead of strings
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA2234
 dotnet_diagnostic.S4005.severity = none
 
 # Title    : Inherited member visibility should not be decreased
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4015.severity = warning
 
 # Title    : Enumeration members should not be named "Reserved"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4016.severity = warning
 
 # Title    : Method signatures should not contain nested generic types
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4017.severity = none
 
 # Title    : All type parameters should be used in the parameter list to enable type inference
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4018.severity = none
 
 # Title    : Base class methods should not be hidden
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4019.severity = warning
 
 # Title    : Enumerations should have "Int32" storage
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4022.severity = warning
 
 # Title    : Interfaces should not be empty
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4023.severity = warning
 
 # Title    : Child class fields should not differ from parent class fields only by capitalization
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4025.severity = warning
 
 # Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4026.severity = warning
 
 # Title    : Exceptions should provide standard constructors
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1032
 dotnet_diagnostic.S4027.severity = none
 
 # Title    : Classes implementing "IEquatable<T>" should be sealed
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4035.severity = warning
 
 # Title    : Searching OS commands in PATH is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4036.severity = warning
 
 # Title    : Interface methods should be callable by derived types
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4039.severity = warning
 
 # Title    : Strings should be normalized to uppercase
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1308
 dotnet_diagnostic.S4040.severity = none
 
 # Title    : Type names should not match namespaces
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4041.severity = warning
 
 # Title    : Generics should be used when appropriate
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4047.severity = warning
 
 # Title    : Properties should be preferred
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
-# Tags     : C#, MainSourceScope
-dotnet_diagnostic.S4049.severity = warning
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
 
 # Title    : Operators should be overloaded consistently
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4050.severity = warning
 
 # Title    : Types should not extend outdated base types
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4052.severity = warning
 
 # Title    : Literals should not be passed as localized parameters
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4055.severity = none
 
 # Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
-# Tags     : C#, MainSourceScope, TestSourceScope
-dotnet_diagnostic.S4056.severity = warning
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
 
 # Title    : Locales should be set for data types
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4057.severity = warning
 
 # Title    : Overloads with a "StringComparison" parameter should be used
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
-# Tags     : C#, MainSourceScope, TestSourceScope
+# Redundant: CA1310
 dotnet_diagnostic.S4058.severity = none
 
 # Title    : Property names should not match get methods
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4059.severity = warning
 
 # Title    : Non-abstract attributes should be sealed
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
-# Tags     : C#, MainSourceScope
+# Redundant: CA1813
 dotnet_diagnostic.S4060.severity = none
 
 # Title    : "params" should be used instead of "varargs"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4061.severity = warning
 
 # Title    : Operator overloads should have named alternatives
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
-# Tags     : C#, MainSourceScope
+# Redundant: CA2225
 dotnet_diagnostic.S4069.severity = none
 
 # Title    : Non-flags enums should not be marked with "FlagsAttribute"
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA2217
 dotnet_diagnostic.S4070.severity = none
 
 # Title    : Method overloads should be grouped together
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4136.severity = warning
 
 # Title    : Duplicate values should not be passed as arguments
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4142.severity = warning
 
 # Title    : Collection elements should not be replaced unconditionally
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4143.severity = warning
 
 # Title    : Methods should not have identical implementations
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4144.severity = warning
 
 # Title    : Empty collections should not be accessed or iterated
 # Category : Minor Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4158.severity = warning
 
 # Title    : Classes should implement their "ExportAttribute" interfaces
 # Category : Blocker Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4159.severity = warning
 
 # Title    : Native methods should be wrapped
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4200.severity = warning
 
 # Title    : Null checks should not be used with "is"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4201.severity = warning
 
 # Title    : Windows Forms entry points should be marked with STAThread
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4210.severity = warning
 
 # Title    : Members should not have conflicting transparency annotations
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4211.severity = warning
 
 # Title    : Serialization constructors should be secured
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4212.severity = warning
 
 # Title    : "P/Invoke" methods should not be visible
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4214.severity = warning
 
 # Title    : Events should have proper arguments
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4220.severity = warning
 
 # Title    : Extension methods should not extend "object"
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4225.severity = warning
 
 # Title    : Extensions should be in separate namespaces
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4226.severity = none
 
 # Title    : "ConstructorArgument" parameters should exist in constructors
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4260.severity = warning
 
 # Title    : Methods should be named according to their synchronicities
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4261.severity = none
 
 # Title    : Getters and setters should access the expected fields
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4275.severity = warning
 
 # Title    : "Shared" parts should not be created with "new"
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4277.severity = warning
 
 # Title    : Weak SSL/TLS protocols should not be used
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4423.severity = warning
 
 # Title    : Cryptographic keys should be robust
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4426.severity = warning
 
 # Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
 # Category : Major Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4428.severity = warning
 
 # Title    : AES encryption algorithm should be used with secured mode
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4432.severity = warning
 
 # Title    : LDAP connections should be authenticated
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4433.severity = warning
 
 # Title    : Parameter validation in yielding methods should be wrapped
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4456.severity = warning
 
 # Title    : Parameter validation in "async"/"await" methods should be wrapped
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S4457.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
-# Tags     : C#, MainSourceScope
+# Redundant: VSTHRD002
 dotnet_diagnostic.S4462.severity = none
 
 # Title    : Unread "private" fields should be removed
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay, Unnecessary
+# Redundant: IDE0052
 dotnet_diagnostic.S4487.severity = none
 
 # Title    : Disabling CSRF protections is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4502.severity = warning
 
 # Title    : Delivering code in production with debug features activated is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4507.severity = warning
 
 # Title    : "default" clauses should be first or last
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4524.severity = warning
 
 # Title    : ASP.NET HTTP request validation feature should not be disabled
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4564.severity = warning
 
 # Title    : "new Guid()" should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4581.severity = warning
 
 # Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4583.severity = warning
 
 # Title    : Non-async "Task/Task<T>" methods should not return null
 # Category : Critical Bug
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4586.severity = warning
 
 # Title    : String offset-based methods should be preferred for finding substrings from offsets
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S4635.severity = warning
 
 # Title    : Using regular expressions is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4784.severity = warning
 
 # Title    : Encrypting data is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4787.severity = warning
 
 # Title    : Using weak hashing algorithms is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4790.severity = warning
 
 # Title    : Configuring loggers is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S4792.severity = warning
 
 # Title    : Using Sockets is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4818.severity = warning
 
 # Title    : Using command line arguments is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4823.severity = warning
 
 # Title    : Reading the Standard Input is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4829.severity = warning
 
 # Title    : Server certificates should be verified during SSL/TLS connections
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
-# Tags     : C#, MainSourceScope, SonarWay
+# Redundant: CA5359
 dotnet_diagnostic.S4830.severity = none
 
 # Title    : Controlling permissions is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S4834.severity = warning
 
 # Title    : "ValueTask" should be consumed correctly
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S5034.severity = warning
 
 # Title    : Expanding archive files without controlling resource consumption is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5042.severity = warning
 
 # Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
 # Category : Minor Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5122.severity = warning
 
 # Title    : Using clear-text protocols is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5332.severity = warning
 
 # Title    : Using publicly writable directories is security-sensitive
 # Category : Critical Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5443.severity = warning
 
 # Title    : Insecure temporary file creation methods should not be used
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5445.severity = warning
 
 # Title    : Encryption algorithms should be used with secure mode and padding scheme
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5542.severity = warning
 
 # Title    : Cipher algorithms should be robust
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5547.severity = warning
 
 # Title    : JWT should be signed and verified with strong cipher algorithms
 # Category : Critical Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5659.severity = warning
 
 # Title    : Allowing requests with excessive content length is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S5693.severity = warning
 
 # Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5753.severity = warning
 
 # Title    : Deserializing objects without performing data validation is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S5766.severity = warning
 
 # Title    : Types allowed to be deserialized should be restricted
 # Category : Major Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S5773.severity = warning
 
 # Title    : Use a testable date/time provider
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
-# Tags     : C#, MainSourceScope
+# Redundant: R9A022
 dotnet_diagnostic.S6354.severity = none
 
 # Title    : Azure Functions should be stateless
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6419.severity = warning
 
 # Title    : Client instances should not be recreated on each Azure Function invocation
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6420.severity = warning
 
 # Title    : Azure Functions should use Structured Error Handling
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S6421.severity = warning
 
 # Title    : Calls to "async" methods should not be blocking in Azure Functions
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6422.severity = warning
 
 # Title    : Azure Functions should log all failures
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
-# Tags     : C#, MainSourceScope
 dotnet_diagnostic.S6423.severity = warning
 
 # Title    : Interfaces for durable entities should satisfy the restrictions
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6424.severity = warning
 
 # Title    : Not specifying a timeout for regular expressions is security-sensitive
 # Category : Major Security Hotspot
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
-# Tags     : C#, MainSourceScope, SonarWay
 dotnet_diagnostic.S6444.severity = warning
 
 # Title    : Literal suffixes should be upper case
 # Category : Minor Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S818.severity = warning
 
 # Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
-# Tags     : C#, MainSourceScope, TestSourceScope
 dotnet_diagnostic.S881.severity = suggestion
 
 # Title    : "goto" statement should not be used
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
 dotnet_diagnostic.S907.severity = warning
 
 # Title    : Parameter names should match base declaration and other partial definitions
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
-# Tags     : C#, MainSourceScope, TestSourceScope, SonarWay
+# Redundant: CA1725
 dotnet_diagnostic.S927.severity = none
 
 # Title    : Copy-paste token calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-cpd.severity = warning
 
 # Title    : Log generator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-log.severity = none
 
 # Title    : File metadata generator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-metadata.severity = warning
 
 # Title    : Metrics calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-metrics.severity = warning
 
 # Title    : Symbol reference calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-symbolRef.severity = warning
 
 # Title    : Token type calculator
 # Category : 
-# Tags     : MainSourceScope, TestSourceScope, Utility, NotConfigurable
 dotnet_diagnostic.S9999-token-type.severity = warning
 
 # Title    : XML comment analysis disabled
@@ -6075,21 +4962,25 @@ dotnet_diagnostic.SA0002.severity = warning
 # Title    : Keywords should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1000.severity = none
 
 # Title    : Commas should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1001.severity = none
 
 # Title    : Semicolons should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1002.severity = none
 
 # Title    : Symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1003.severity = none
 
 # Title    : Documentation lines should begin with single space
@@ -6110,101 +5001,121 @@ dotnet_diagnostic.SA1006.severity = warning
 # Title    : Operator keyword should be followed by space
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1007.severity = none
 
 # Title    : Opening parenthesis should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1008.severity = none
 
 # Title    : Closing parenthesis should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1009.severity = none
 
 # Title    : Opening square brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1010.severity = none
 
 # Title    : Closing square brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1011.severity = none
 
 # Title    : Opening braces should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1012.severity = none
 
 # Title    : Closing braces should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1013.severity = none
 
 # Title    : Opening generic brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1014.severity = none
 
 # Title    : Closing generic brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1015.severity = none
 
 # Title    : Opening attribute brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1016.severity = none
 
 # Title    : Closing attribute brackets should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1017.severity = none
 
 # Title    : Nullable type symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1018.severity = none
 
 # Title    : Member access symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1019.severity = none
 
 # Title    : Increment decrement symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1020.severity = none
 
 # Title    : Negative signs should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1021.severity = none
 
 # Title    : Positive signs should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1022.severity = none
 
 # Title    : Dereference and access of symbols should be spaced correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1023.severity = none
 
 # Title    : Colons Should Be Spaced Correctly
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1024.severity = none
 
 # Title    : Code should not contain multiple whitespace in a row
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1025.severity = none
 
 # Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1026.severity = none
 
 # Title    : Use tabs correctly
@@ -6215,8 +5126,8 @@ dotnet_diagnostic.SA1027.severity = warning
 # Title    : Code should not contain trailing whitespace
 # Category : StyleCop.CSharp.SpacingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
-# Tags     : Unnecessary
-dotnet_diagnostic.SA1028.severity = warning
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
 
 # Title    : Do not prefix calls with base unless local implementation exists
 # Category : StyleCop.CSharp.ReadabilityRules
@@ -6251,12 +5162,12 @@ dotnet_diagnostic.SA1105.severity = warning
 # Title    : Code should not contain empty statements
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1106.severity = warning
 
 # Title    : Code should not contain multiple statements on one line
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
 dotnet_diagnostic.SA1107.severity = none
 
 # Title    : Block statements should not contain embedded comments
@@ -6267,7 +5178,6 @@ dotnet_diagnostic.SA1108.severity = warning
 # Title    : Block statements should not contain embedded regions
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1109.severity = warning
 
 # Title    : Opening parenthesis or bracket should be on declaration line
@@ -6323,7 +5233,6 @@ dotnet_diagnostic.SA1119.severity = warning
 # Title    : Statement should not use unnecessary parenthesis
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
-# Tags     : Unnecessary, NotConfigurable
 dotnet_diagnostic.SA1119_p.severity = none
 
 # Title    : Comments should contain text
@@ -6334,7 +5243,6 @@ dotnet_diagnostic.SA1120.severity = warning
 # Title    : Use built-in type alias
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1121.severity = warning
 
 # Title    : Use string.Empty for empty strings
@@ -6360,7 +5268,6 @@ dotnet_diagnostic.SA1125.severity = warning
 # Title    : Prefix calls correctly
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1126.severity = none
 
 # Title    : Generic type constraints should be on their own line
@@ -6392,6 +5299,7 @@ dotnet_diagnostic.SA1131.severity = warning
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
 # Comment  : S1169 handles fields and variables
+# Redundant: S1169
 dotnet_diagnostic.SA1132.severity = none
 
 # Title    : Do not combine attributes
@@ -6402,6 +5310,7 @@ dotnet_diagnostic.SA1133.severity = warning
 # Title    : Attributes should not share line
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
 dotnet_diagnostic.SA1134.severity = none
 
 # Title    : Using directives should be qualified
@@ -6433,11 +5342,13 @@ dotnet_diagnostic.SA1141.severity = warning
 # Title    : Refer to tuple fields by name
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
 dotnet_diagnostic.SA1142.severity = none
 
 # Title    : Using directives should be placed correctly
 # Category : StyleCop.CSharp.OrderingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
 dotnet_diagnostic.SA1200.severity = none
 
 # Title    : Elements should appear in the correct order
@@ -6523,52 +5434,61 @@ dotnet_diagnostic.SA1217.severity = warning
 # Title    : Element should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1300.severity = none
 
 # Title    : Element should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
-# Tags     : NotConfigurable
+# Redundant: IDE1006
 dotnet_diagnostic.SA1301.severity = none
 
 # Title    : Interface names should begin with I
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1302.severity = none
 
 # Title    : Const field names should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1303.severity = none
 
 # Title    : Non-private readonly fields should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1304.severity = none
 
 # Title    : Field names should not use Hungarian notation
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1305.severity = none
 
 # Title    : Field names should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1306.severity = none
 
 # Title    : Accessible fields should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1307.severity = none
 
 # Title    : Variable names should not be prefixed
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1308.severity = none
 
 # Title    : Field names should not begin with underscore
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1309.severity = none
 
 # Title    : Field names should not contain underscore
@@ -6579,21 +5499,25 @@ dotnet_diagnostic.SA1310.severity = warning
 # Title    : Static readonly fields should begin with upper-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1311.severity = none
 
 # Title    : Variable names should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1312.severity = none
 
 # Title    : Parameter names should begin with lower-case letter
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1313.severity = none
 
 # Title    : Type parameter names should begin with T
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
 dotnet_diagnostic.SA1314.severity = none
 
 # Title    : Tuple element names should use correct casing
@@ -6609,6 +5533,7 @@ dotnet_diagnostic.SA1400.severity = warning
 # Title    : Fields should be private
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
 dotnet_diagnostic.SA1401.severity = none
 
 # Title    : File may only contain a single type
@@ -6649,19 +5574,16 @@ dotnet_diagnostic.SA1408.severity = warning
 # Title    : Remove unnecessary code
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1409.severity = warning
 
 # Title    : Remove delegate parenthesis when possible
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1410.severity = warning
 
 # Title    : Attribute constructor should not use unnecessary parenthesis
 # Category : StyleCop.CSharp.MaintainabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SA1411.severity = warning
 
 # Title    : Store files as UTF-8 with byte order mark
@@ -6698,6 +5620,7 @@ dotnet_diagnostic.SA1502.severity = warning
 # Title    : Braces should not be omitted
 # Category : StyleCop.CSharp.LayoutRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
 dotnet_diagnostic.SA1503.severity = none
 
 # Title    : All accessors should be single-line or multi-line
@@ -6718,11 +5641,13 @@ dotnet_diagnostic.SA1506.severity = warning
 # Title    : Code should not contain multiple blank lines in a row
 # Category : StyleCop.CSharp.LayoutRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
 dotnet_diagnostic.SA1507.severity = none
 
 # Title    : Closing braces should not be preceded by blank line
 # Category : StyleCop.CSharp.LayoutRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
 dotnet_diagnostic.SA1508.severity = none
 
 # Title    : Opening braces should not be preceded by blank line
@@ -6803,7 +5728,6 @@ dotnet_diagnostic.SA1602.severity = none
 # Title    : Documentation should contain valid XML
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1603.severity = warning
 
 # Title    : Element documentation should have summary
@@ -6844,6 +5768,7 @@ dotnet_diagnostic.SA1610.severity = none
 # Title    : Element parameters should be documented
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
 dotnet_diagnostic.SA1611.severity = none
 
 # Title    : Element parameter documentation should match element parameters
@@ -6929,7 +5854,6 @@ dotnet_diagnostic.SA1627.severity = warning
 # Title    : Documentation text should begin with a capital letter
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1628.severity = warning
 
 # Title    : Documentation text should end with a period
@@ -6940,24 +5864,22 @@ dotnet_diagnostic.SA1629.severity = warning
 # Title    : Documentation text should contain whitespace
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1630.severity = warning
 
 # Title    : Documentation should meet character percentage
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1631.severity = warning
 
 # Title    : Documentation text should meet minimum character length
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1632.severity = warning
 
 # Title    : File should have header
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
 dotnet_diagnostic.SA1633.severity = none
 
 # Title    : File header should show copyright
@@ -7013,25 +5935,21 @@ dotnet_diagnostic.SA1643.severity = warning
 # Title    : Documentation headers should not contain blank lines
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1644.severity = warning
 
 # Title    : Included documentation file does not exist
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1645.severity = warning
 
 # Title    : Included documentation XPath does not exist
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1646.severity = warning
 
 # Title    : Include node does not contain valid file and path
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
-# Tags     : NotConfigurable
 dotnet_diagnostic.SA1647.severity = warning
 
 # Title    : inheritdoc should be used with inheriting class
@@ -7047,7 +5965,6 @@ dotnet_diagnostic.SA1649.severity = warning
 # Title    : Element documentation should be spelled correctly
 # Category : StyleCop.CSharp.DocumentationRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
-# Tags     : NotConfigurable
 # Comment  : Deprecated
 dotnet_diagnostic.SA1650.severity = none
 
@@ -7059,17 +5976,18 @@ dotnet_diagnostic.SA1651.severity = warning
 # Title    : Do not prefix local calls with 'this.'
 # Category : StyleCop.CSharp.ReadabilityRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
-# Tags     : Unnecessary
 dotnet_diagnostic.SX1101.severity = warning
 
 # Title    : Field names should begin with underscore
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
 dotnet_diagnostic.SX1309.severity = none
 
 # Title    : Static field names should begin with underscore
 # Category : StyleCop.CSharp.NamingRules
 # Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
 dotnet_diagnostic.SX1309S.severity = none
 
 # Title    : Avoid legacy thread switching APIs
@@ -7095,7 +6013,6 @@ dotnet_diagnostic.VSTHRD004.severity = error
 # Title    : Invoke single-threaded types on Main thread
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
-# Tags     : CompilationEnd
 dotnet_diagnostic.VSTHRD010.severity = warning
 
 # Title    : Use AsyncLazy<T>
@@ -7161,11 +6078,13 @@ dotnet_diagnostic.VSTHRD109.severity = error
 # Title    : Observe result of async calls
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
 dotnet_diagnostic.VSTHRD110.severity = none
 
 # Title    : Use ConfigureAwait(bool)
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
 dotnet_diagnostic.VSTHRD111.severity = none
 
 # Title    : Implement System.IAsyncDisposable

--- a/test/ToBeRemoved/Options.ValidateOnStart.Tests/Helpers/ComplexOptions.cs
+++ b/test/ToBeRemoved/Options.ValidateOnStart.Tests/Helpers/ComplexOptions.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable IDE0051
+
 namespace Microsoft.Extensions.Options.Validation.Test;
 
 public class ComplexOptions


### PR DESCRIPTION
- Add the DiagConfig tool which is used to process diagnostic configuration YAML files and output .editorconfig files for use in this source tree as well as in the curated Microsoft.Extensions.StaticAnalysis package. See README for details.

- Add the ApiChief tool which is used to support API lifecycle and API reviews. See README for details.

- Add the eng/Diags folder which has the YAML diagnostic configuration files. This controls the diagnostic setting for the .editorconfig files in this repo, along with the settings distributed to customers in the Microsoft.Extensions.StaticAnalysis package.

- Add scripts to support using DiagConfig and ApiChief. Those need some tender loving care from someone that knows Arcade stuff, but they're a starting point.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/3993)