### PR TITLE
Add the API baseline files, and enable the API lifecycle analyzer

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,11 +22,9 @@
     <!-- Prevent analyzer crashes from stopping things -->
     <NoWarn>$(NoWarn);AD0001</NoWarn>
 
-    <!-- R9A029 is for R9 customers, not for R9 itself -->
+    <!-- R9A029 is for customers, not for this repo -->
     <NoWarn>$(NoWarn);R9A029</NoWarn>
 
-    <!-- Temporary -->
-    <NoWarn>$(NoWarn);R9A049</NoWarn>
 
     <!-- NU5104: A stable release of a package should not have a prerelease dependency -->
     <NoWarn>$(NoWarn);NU5104</NoWarn>
@@ -52,6 +50,20 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
+
+  <ItemGroup Condition="('$(Stage)' == 'normal' OR '$(Stage)' == 'obsolete') AND '$(OutputType)' != 'Exe' AND '$(IsPackable)' == 'true' AND '$(Api)' != 'false'">
+    <AdditionalFiles Include="$(MSBuildProjectName).json" Visible="False" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <Target
+    Name="AddApiBaselineFilesToRoot"
+    Condition="('$(Stage)' == 'normal' OR '$(Stage)'=='obsolete') AND '$(OutputType)' != 'Exe' AND '$(IsPackable)' == 'true' AND '$(Api)' != 'false'"
+    BeforeTargets="BeforeCompile">
+      <WriteLinesToFile
+        File="$(MSBuildProjectName).json"
+        Lines=""
+        Condition="!Exists('$(MSBuildProjectName).json')" />
+  </Target>
 
   <ItemGroup Condition="'$(Stage)' == 'dev' AND '$(OutputType)' != 'Exe' AND '$(Api)' != 'false'">
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExperimentalAttribute" />

--- a/bench/.editorconfig
+++ b/bench/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2023-05-23 23:01:34Z
+# Generated : 2023-05-24 21:09:52Z
 # Max Tier  : 2147483647
 # Attributes: general, performance
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -2760,37 +2760,37 @@ dotnet_diagnostic.R9A044.severity = warning
 # Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a049
-dotnet_diagnostic.R9A049.severity = warning
+dotnet_diagnostic.R9A049.severity = none
 
 # Title    : Experimental symbols cannot be marked as obsolete
 # Category : Correctness
 # Help Link: https://TODO/r9a050
-dotnet_diagnostic.R9A050.severity = warning
+dotnet_diagnostic.R9A050.severity = none
 
 # Title    : Published symbols cannot be marked experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a051
-dotnet_diagnostic.R9A051.severity = warning
+dotnet_diagnostic.R9A051.severity = none
 
 # Title    : Published symbols cannot be deleted to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a052
-dotnet_diagnostic.R9A052.severity = warning
+dotnet_diagnostic.R9A052.severity = none
 
 # Title    : A deprecated API is not annotated with the obsolete attribute
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
-dotnet_diagnostic.R9A053.severity = warning
+dotnet_diagnostic.R9A053.severity = none
 
 # Title    : A deprecated API is marked as experimental
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
-dotnet_diagnostic.R9A054.severity = warning
+dotnet_diagnostic.R9A054.severity = none
 
 # Title    : Published symbols cannot be changed to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a055
-dotnet_diagnostic.R9A055.severity = warning
+dotnet_diagnostic.R9A055.severity = none
 
 # Title    : Fire-and-forget async call inside a 'using' block
 # Category : Correctness

--- a/eng/Diags/Microsoft.Extensions.LocalAnalyzers.yml
+++ b/eng/Diags/Microsoft.Extensions.LocalAnalyzers.yml
@@ -51,6 +51,8 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+        Severity: None
+      api:
         Severity: Warning
   R9A050:
     Metadata:
@@ -62,6 +64,8 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+        Severity: None
+      api:
         Severity: Warning
   R9A051:
     Metadata:
@@ -73,6 +77,8 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+        Severity: None
+      api:
         Severity: Warning
   R9A052:
     Metadata:
@@ -84,6 +90,8 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+        Severity: None
+      api:
         Severity: Warning
   R9A053:
     Metadata:
@@ -94,6 +102,9 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+      general:
+        Severity: None
+      api:
         Severity: Warning
   R9A054:
     Metadata:
@@ -104,6 +115,8 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+        Severity: None
+      api:
         Severity: Warning
   R9A055:
     Metadata:
@@ -115,4 +128,6 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
+        Severity: None
+      api:
         Severity: Warning

--- a/eng/Packages/General.props
+++ b/eng/Packages/General.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.18.3" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.41.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.41.0" />
-    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.0.0.7106-preview2" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.28.0-preview"/>
     <PackageVersion Include="Microsoft.Azure.KeyVault.AzureServiceDeploy" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />

--- a/eng/Tools/.editorconfig
+++ b/eng/Tools/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2023-05-23 23:01:34Z
+# Generated : 2023-05-24 21:09:52Z
 # Max Tier  : 2147483647
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -2758,37 +2758,37 @@ dotnet_diagnostic.R9A044.severity = none
 # Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a049
-dotnet_diagnostic.R9A049.severity = warning
+dotnet_diagnostic.R9A049.severity = none
 
 # Title    : Experimental symbols cannot be marked as obsolete
 # Category : Correctness
 # Help Link: https://TODO/r9a050
-dotnet_diagnostic.R9A050.severity = warning
+dotnet_diagnostic.R9A050.severity = none
 
 # Title    : Published symbols cannot be marked experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a051
-dotnet_diagnostic.R9A051.severity = warning
+dotnet_diagnostic.R9A051.severity = none
 
 # Title    : Published symbols cannot be deleted to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a052
-dotnet_diagnostic.R9A052.severity = warning
+dotnet_diagnostic.R9A052.severity = none
 
 # Title    : A deprecated API is not annotated with the obsolete attribute
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
-dotnet_diagnostic.R9A053.severity = warning
+dotnet_diagnostic.R9A053.severity = none
 
 # Title    : A deprecated API is marked as experimental
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
-dotnet_diagnostic.R9A054.severity = warning
+dotnet_diagnostic.R9A054.severity = none
 
 # Title    : Published symbols cannot be changed to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a055
-dotnet_diagnostic.R9A055.severity = warning
+dotnet_diagnostic.R9A055.severity = none
 
 # Title    : Fire-and-forget async call inside a 'using' block
 # Category : Correctness

--- a/scripts/MakeApiBaselines.ps1
+++ b/scripts/MakeApiBaselines.ps1
@@ -1,0 +1,22 @@
+#!/usr/bin/env pwsh
+<#
+.DESCRIPTION
+    Creates API baseline files representing the current API surface exposed by this repo.
+#>
+
+$Project = $PSScriptRoot + "/../eng/Tools/ApiChief/ApiChief.csproj"
+$Command = $PSScriptRoot + "/../artifacts/bin/ApiChief/Debug/net8.0/ApiChief.exe"
+
+Write-Output "Building ApiChief tool"
+
+& dotnet build $Project --nologo --verbosity q
+
+Write-Output "Creating API baseline files in the src/Libraries folder"
+
+Get-ChildItem -Path src/Libraries -Depth 1 -Include *.csproj | ForEach-Object `
+{
+    $name = Split-Path $_.FullName -LeafBase
+    $path = "$PSScriptRoot\..\artifacts\bin\$name\Debug\net8.0\$name.dll"
+    Write-Host "  Processing" $name
+    & $Command $path emit baseline -o "src/Libraries/$name/$name.json"
+}

--- a/scripts/MakeEditorConfigs.ps1
+++ b/scripts/MakeEditorConfigs.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+    #!/usr/bin/env pwsh
 <#
 .DESCRIPTION
     Builds and invokes the DiagConfig tool to generate the .editorconfig files we use within the source base
@@ -15,10 +15,16 @@ Write-Output "Building DiagConfig tool"
 Write-Output "Creating .editorconfig files"
 
 # The files we use for this repo
-& $Command $Diags editorconfig save --exclude xunit.analyzers src/.editorconfig       general,api,performance,production
-& $Command $Diags editorconfig save --exclude xunit.analyzers bench/.editorconfig     general,performance
-& $Command $Diags editorconfig save --exclude xunit.analyzers eng/Tools/.editorconfig general
-& $Command $Diags editorconfig save                           test/.editorconfig      general,test
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/Analyzers/.editorconfig       general,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/Generators/.editorconfig      general,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/Libraries/.editorconfig       general,api,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/ToBeMoved/.editorconfig       general,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/ToBeRemoved/.editorconfig     general,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/LegacySupport/.editorconfig  general,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers src/Shared/.editorconfig          general,performance,production
+& $Command $Diags editorconfig save --exclude xunit.analyzers bench/.editorconfig               general,performance
+& $Command $Diags editorconfig save --exclude xunit.analyzers eng/Tools/.editorconfig           general
+& $Command $Diags editorconfig save                           test/.editorconfig                general,test
 
 # The files we publish with the M.E.StaticAnalysis package
 

--- a/scripts/PrepForAPIReview.ps1
+++ b/scripts/PrepForAPIReview.ps1
@@ -7,7 +7,7 @@
 #>
 
 param (
-    [Parameter(Mandatory = $true, HelpMessage="Path to the assemly to extract the API from.", Position = 0, ParameterSetName = "AssemblyPath")]
+    [Parameter(Mandatory = $true, HelpMessage="Path to the assembly to extract the API from.", Position = 0, ParameterSetName = "AssemblyPath")]
     [string]$AssemblyPath
 )
 

--- a/src/Analyzers/.editorconfig
+++ b/src/Analyzers/.editorconfig
@@ -1,0 +1,6118 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:50Z
+# Max Tier  : 2147483647
+# Attributes: general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = none
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = none
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = none
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Analyzers/Directory.Build.props
+++ b/src/Analyzers/Directory.Build.props
@@ -5,5 +5,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>n/a</GenerateDocumentationFile>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <Api>false</Api>
   </PropertyGroup>
 </Project>

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/ApiLifecycleAnalyzer.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/ApiLifecycleAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.LocalAnalyzers.ApiLifecycle;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
 {
-    private const string ExperimentalAttributeFullName = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
+    private const string ExperimentalAttributeFullName = "global::System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
     private const string ObsoleteAttributeFullName = "System.ObsoleteAttribute";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
@@ -66,12 +66,11 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
     {
         var compilation = context.Compilation;
         var obsoleteAttribute = compilation.GetTypeByMetadataName(ObsoleteAttributeFullName);
-        var experimentalAttribute = compilation.GetTypeByMetadataName(ExperimentalAttributeFullName);
 
         // flag symbols found in the code, but not in the model
         foreach (var symbol in assemblyAnalysis.NotFoundInBaseline)
         {
-            if (!symbol.IsContaminated(experimentalAttribute))
+            if (!symbol.IsContaminated(ExperimentalAttributeFullName))
             {
                 context.ReportDiagnostic(Diagnostic.Create(DiagDescriptors.NewSymbolsMustBeMarkedExperimental, symbol.Locations.FirstOrDefault(), symbol));
             }
@@ -102,7 +101,7 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
         // now make sure attributes are applied correctly
         foreach (var (symbol, stage) in assemblyAnalysis.FoundInBaseline)
         {
-            var isMarkedExperimental = symbol.IsContaminated(experimentalAttribute);
+            var isMarkedExperimental = symbol.IsContaminated(ExperimentalAttributeFullName);
             var isMarkedObsolete = symbol.IsContaminated(obsoleteAttribute);
 
             if (stage == Stage.Experimental)
@@ -151,12 +150,11 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
             .Where(symbol => symbol.IsExternallyVisible() && symbol.Kind == SymbolKind.NamedType)
             .Cast<INamedTypeSymbol>();
 
-        var experimentalAttribute = context.Compilation.GetTypeByMetadataName(ExperimentalAttributeFullName);
         var obsoleteAttribute = context.Compilation.GetTypeByMetadataName(ObsoleteAttributeFullName);
 
         foreach (var type in types)
         {
-            if (!type.IsContaminated(experimentalAttribute))
+            if (!type.IsContaminated(ExperimentalAttributeFullName))
             {
                 context.ReportDiagnostic(Diagnostic.Create(DiagDescriptors.NewSymbolsMustBeMarkedExperimental, type.Locations.FirstOrDefault(), type));
             }

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/AssemblyAnalysis.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/AssemblyAnalysis.cs
@@ -141,9 +141,21 @@ internal sealed class AssemblyAnalysis
         var baseTypes = new HashSet<string>(type.AllInterfaces.Select(x => x.ToDisplayString(_shortSymbolNameFormat)));
         var baseType = type.BaseType;
 
-        if (baseType != null && baseType.SpecialType != SpecialType.System_Object && baseType.SpecialType != SpecialType.System_ValueType)
+        if (type.EnumUnderlyingType != null)
         {
-            _ = baseTypes.Add(baseType.ToDisplayString(_shortSymbolNameFormat));
+            baseTypes.Clear();
+
+            if (type.EnumUnderlyingType.SpecialType != SpecialType.System_Int32)
+            {
+                _ = baseTypes.Add(type.EnumUnderlyingType.ToDisplayString(_format));
+            }
+        }
+        else
+        {
+            if (baseType != null && baseType.SpecialType != SpecialType.System_Object && baseType.SpecialType != SpecialType.System_ValueType)
+            {
+                _ = baseTypes.Add(baseType.ToDisplayString(_shortSymbolNameFormat));
+            }
         }
 
         foreach (var @base in typeDef.BaseTypes)

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Assembly.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Assembly.cs
@@ -24,4 +24,6 @@ internal sealed class Assembly
         Name = string.Empty;
         Types = Array.Empty<TypeDef>();
     }
+
+    public override string ToString() => Name;
 }

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Field.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Field.cs
@@ -21,4 +21,6 @@ internal sealed class Field
 
         Stage = stage;
     }
+
+    public override string ToString() => $"{Member}:{Stage}";
 }

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Method.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Method.cs
@@ -26,4 +26,6 @@ internal sealed class Method
             Stage = Stage.Experimental;
         }
     }
+
+    public override string ToString() => $"{Member}:{Stage}";
 }

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Prop.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/Prop.cs
@@ -21,4 +21,6 @@ internal sealed class Prop
 
         Stage = stage;
     }
+
+    public override string ToString() => $"{Member}:{Stage}";
 }

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/TypeDef.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Model/TypeDef.cs
@@ -28,4 +28,6 @@ internal sealed class TypeDef
         Properties = value.GetValueArray<Prop>(nameof(Properties));
         Fields = value.GetValueArray<Field>(nameof(Fields));
     }
+
+    public override string ToString() => $"{ModifiersAndName}:{Stage}";
 }

--- a/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Utils.cs
+++ b/src/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Utils.cs
@@ -73,13 +73,7 @@ internal static class Utils
     private static void GetBaseTypesImpl(List<string> results, string baseTypesString)
     {
         var generic = 0;
-        var last = 1;
-
-        if (baseTypesString.IndexOf(',') == -1)
-        {
-            results.Add(baseTypesString.Trim());
-            return;
-        }
+        var start = 0;
 
         for (var i = 0; i < baseTypesString.Length; i++)
         {
@@ -87,19 +81,17 @@ internal static class Utils
             {
                 generic++;
             }
-
-            if (baseTypesString[i] == '>')
+            else if (baseTypesString[i] == '>')
             {
                 generic--;
             }
-
-            if (baseTypesString[i] == ',' && generic == 0)
+            else if (generic == 0 && baseTypesString[i] == ',')
             {
-                results.Add(baseTypesString.Substring(last, i - last));
-#pragma warning disable S109 // Magic numbers should not be used
-                last = i + 2; // ", "
-#pragma warning restore S109 // Magic numbers should not be used
+                results.Add(baseTypesString.Substring(start, i - start).Trim());
+                start = i + 1;
             }
         }
+
+        results.Add(baseTypesString.Substring(start, baseTypesString.Length - start).Trim());
     }
 }

--- a/src/Generators/.editorconfig
+++ b/src/Generators/.editorconfig
@@ -1,0 +1,6118 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:50Z
+# Max Tier  : 2147483647
+# Attributes: general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = none
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = none
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = none
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Generators/Directory.Build.props
+++ b/src/Generators/Directory.Build.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>n/a</GenerateDocumentationFile>
+    <Api>false</Api>
   </PropertyGroup>
 </Project>

--- a/src/LegacySupport/.editorconfig
+++ b/src/LegacySupport/.editorconfig
@@ -1,0 +1,6118 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:51Z
+# Max Tier  : 2147483647
+# Attributes: general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = none
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = none
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = none
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Libraries/.editorconfig
+++ b/src/Libraries/.editorconfig
@@ -1,0 +1,6140 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:50Z
+# Max Tier  : 2147483647
+# Attributes: api, general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = warning
+dotnet_code_quality.CA1000.api_surface = public
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = warning
+dotnet_code_quality.CA1002.api_surface = public
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = warning
+dotnet_code_quality.CA1003.api_surface = all
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = warning
+dotnet_code_quality.CA1005.api_surface = public
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = warning
+dotnet_code_quality.CA1008.api_surface = public
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = public
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = warning
+dotnet_code_quality.CA1024.api_surface = public
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = warning
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = warning
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = warning
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = warning
+dotnet_code_quality.CA1043.api_surface = public, protected
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = suggestion
+dotnet_code_quality.CA1045.api_surface = public
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = warning
+dotnet_code_quality.CA1050.api_surface = public
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = warning
+dotnet_code_quality.CA1051.api_surface = public
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = warning
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = warning
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = warning
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = warning
+dotnet_code_quality.CA1062.api_surface = public, protected
+dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
+dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = warning
+dotnet_code_quality.CA1068.api_surface = public, protected
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = warning
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = warning
+dotnet_code_quality.CA1700.api_surface = public
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = warning
+dotnet_code_quality.CA1708.api_surface = public
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = warning
+dotnet_code_quality.CA1710.api_surface = public
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = warning
+dotnet_code_quality.CA1711.api_surface = public
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = warning
+dotnet_code_quality.CA1720.api_surface = public
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = warning
+dotnet_code_quality.CA1721.api_surface = public
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = warning
+dotnet_code_quality.CA1724.api_surface = public
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = warning
+dotnet_code_quality.CA2109.api_surface = public
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = warning
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = warning
+dotnet_code_quality.CA2225.api_surface = public
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = warning
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = warning
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = warning
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = warning
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = warning
+

--- a/src/Libraries/Microsoft.AspNetCore.AsyncState/Microsoft.AspNetCore.AsyncState.json
+++ b/src/Libraries/Microsoft.AspNetCore.AsyncState/Microsoft.AspNetCore.AsyncState.json
@@ -1,0 +1,15 @@
+{
+  "Name": "Microsoft.AspNetCore.AsyncState, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.AspNetCore.AsyncState.AsyncStateHttpContextExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.AsyncState.AsyncStateHttpContextExtensions.AddAsyncStateHttpContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.AspNetCore.ConnectionTimeout/Microsoft.AspNetCore.ConnectionTimeout.json
+++ b/src/Libraries/Microsoft.AspNetCore.ConnectionTimeout/Microsoft.AspNetCore.ConnectionTimeout.json
@@ -1,0 +1,39 @@
+{
+  "Name": "Microsoft.AspNetCore.ConnectionTimeout, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.AspNetCore.Connections.ConnectionTimeoutExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Connections.ConnectionTimeoutExtensions.AddConnectionTimeout(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Connections.ConnectionTimeoutOptions> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Connections.ConnectionTimeoutExtensions.AddConnectionTimeout(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions Microsoft.AspNetCore.Connections.ConnectionTimeoutExtensions.UseConnectionTimeout(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions listenOptions);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.Connections.ConnectionTimeoutOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Connections.ConnectionTimeoutOptions.ConnectionTimeoutOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.AspNetCore.Connections.ConnectionTimeoutOptions.Timeout { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.AspNetCore.HeaderParsing/Microsoft.AspNetCore.HeaderParsing.json
+++ b/src/Libraries/Microsoft.AspNetCore.HeaderParsing/Microsoft.AspNetCore.HeaderParsing.json
@@ -1,0 +1,298 @@
+{
+  "Name": "Microsoft.AspNetCore.HeaderParsing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.AspNetCore.HeaderParsing.CommonHeaders",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.MediaTypeHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.Accept { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.StringWithQualityHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.AcceptEncoding { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.StringWithQualityHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.AcceptLanguage { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<Microsoft.Net.Http.Headers.CacheControlHeaderValue> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.CacheControl { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<Microsoft.Net.Http.Headers.ContentDispositionHeaderValue> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.ContentDisposition { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<Microsoft.Net.Http.Headers.MediaTypeHeaderValue> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.ContentType { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.CookieHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.Cookie { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.DateTimeOffset> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.Date { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<Microsoft.AspNetCore.HeaderParsing.HostHeaderValue> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.Host { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.EntityTagHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.IfMatch { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.EntityTagHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.IfModifiedSince { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<Microsoft.Net.Http.Headers.EntityTagHeaderValue>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.IfNoneMatch { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<Microsoft.Net.Http.Headers.RangeConditionHeaderValue> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.IfRange { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.DateTimeOffset> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.IfUnmodifiedSince { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<Microsoft.Net.Http.Headers.RangeHeaderValue> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.Range { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Uri> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.Referer { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderSetup<System.Collections.Generic.IReadOnlyList<System.Net.IPAddress>> Microsoft.AspNetCore.HeaderParsing.CommonHeaders.XForwardedFor { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.AspNetCore.HeaderParsing.HeaderKey<T> where T : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "override string Microsoft.AspNetCore.HeaderParsing.HeaderKey<T>.ToString();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.AspNetCore.HeaderParsing.HeaderKey<T>.Name { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "abstract class Microsoft.AspNetCore.HeaderParsing.HeaderParser<T> where T : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HeaderParser<T>.HeaderParser();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "abstract bool Microsoft.AspNetCore.HeaderParsing.HeaderParser<T>.TryParse(Microsoft.Extensions.Primitives.StringValues values, out T? result, out string? error);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions.AddHeaderParsing(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions.AddHeaderParsing(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.HeaderParsing.HeaderParsingOptions> configuration);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions.AddHeaderParsing(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.HeaderParsing.HeaderParsingFeature Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions.GetHeaderParsing(this Microsoft.AspNetCore.Http.HttpRequest request);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions.TryGetHeaderValue<T>(this Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.HeaderParsing.HeaderKey<T> header, out T? value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.AspNetCore.HeaderParsing.HeaderParsingExtensions.TryGetHeaderValue<T>(this Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.HeaderParsing.HeaderKey<T> header, out T? value, out Microsoft.AspNetCore.HeaderParsing.ParsingResult result);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.AspNetCore.HeaderParsing.HeaderParsingFeature",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "bool Microsoft.AspNetCore.HeaderParsing.HeaderParsingFeature.TryGetHeaderValue<T>(Microsoft.AspNetCore.HeaderParsing.HeaderKey<T> header, out T? value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.AspNetCore.HeaderParsing.HeaderParsingFeature.TryGetHeaderValue<T>(Microsoft.AspNetCore.HeaderParsing.HeaderKey<T> header, out T? value, out Microsoft.AspNetCore.HeaderParsing.ParsingResult result);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.HeaderParsing.HeaderParsingOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HeaderParsingOptions.HeaderParsingOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.AspNetCore.HeaderParsing.HeaderParsingOptions.DefaultMaxCachedValuesPerHeader { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> Microsoft.AspNetCore.HeaderParsing.HeaderParsingOptions.DefaultValues { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, int> Microsoft.AspNetCore.HeaderParsing.HeaderParsingOptions.MaxCachedValuesPerHeader { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader> where THeader : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader>.HeaderSetup(string headerName, System.Type parserType, bool cacheable = false);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader>.HeaderSetup(string headerName, Microsoft.AspNetCore.HeaderParsing.HeaderParser<THeader> instance, bool cacheable = false);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader>.Cacheable { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader>.HeaderName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HeaderParser<THeader>? Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader>.ParserInstance { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Type? Microsoft.AspNetCore.HeaderParsing.HeaderSetup<THeader>.ParserType { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.AspNetCore.HeaderParsing.HostHeaderValue : System.IEquatable<Microsoft.AspNetCore.HeaderParsing.HostHeaderValue>",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.HostHeaderValue(string host, int? port);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.HostHeaderValue();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.Equals(Microsoft.AspNetCore.HeaderParsing.HostHeaderValue other);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override bool Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.Equals(object? obj);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override int Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.GetHashCode();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.operator ==(Microsoft.AspNetCore.HeaderParsing.HostHeaderValue left, Microsoft.AspNetCore.HeaderParsing.HostHeaderValue right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.operator !=(Microsoft.AspNetCore.HeaderParsing.HostHeaderValue left, Microsoft.AspNetCore.HeaderParsing.HostHeaderValue right);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override string Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.ToString();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.TryParse(string value, out Microsoft.AspNetCore.HeaderParsing.HostHeaderValue result);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.Host { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.AspNetCore.HeaderParsing.HostHeaderValue.Port { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.AspNetCore.HeaderParsing.IHeaderRegistry",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.HeaderKey<T> Microsoft.AspNetCore.HeaderParsing.IHeaderRegistry.Register<T>(Microsoft.AspNetCore.HeaderParsing.HeaderSetup<T> setup);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.AspNetCore.HeaderParsing.ParsingResult",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.HeaderParsing.ParsingResult.ParsingResult();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.AspNetCore.HeaderParsing.ParsingResult Microsoft.AspNetCore.HeaderParsing.ParsingResult.Error",
+          "Stage": "Experimental",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.AspNetCore.HeaderParsing.ParsingResult Microsoft.AspNetCore.HeaderParsing.ParsingResult.NotFound",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const Microsoft.AspNetCore.HeaderParsing.ParsingResult Microsoft.AspNetCore.HeaderParsing.ParsingResult.Success",
+          "Stage": "Experimental",
+          "Value": "0"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.AspNetCore.Telemetry.Middleware/Microsoft.AspNetCore.Telemetry.Middleware.json
+++ b/src/Libraries/Microsoft.AspNetCore.Telemetry.Middleware/Microsoft.AspNetCore.Telemetry.Middleware.json
@@ -1,0 +1,315 @@
+{
+  "Name": "Microsoft.AspNetCore.Telemetry.Middleware, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.Duration",
+          "Stage": "Stable",
+          "Value": "duration"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.Host",
+          "Stage": "Stable",
+          "Value": "httpHost"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.Method",
+          "Stage": "Stable",
+          "Value": "httpMethod"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.Path",
+          "Stage": "Stable",
+          "Value": "httpPath"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.RequestBody",
+          "Stage": "Stable",
+          "Value": "httpRequestBody"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.RequestHeaderPrefix",
+          "Stage": "Stable",
+          "Value": "httpRequestHeader_"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.ResponseBody",
+          "Stage": "Stable",
+          "Value": "httpResponseBody"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.ResponseHeaderPrefix",
+          "Stage": "Stable",
+          "Value": "httpResponseHeader_"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.StatusCode",
+          "Stage": "Stable",
+          "Value": "httpStatusCode"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static System.Collections.Generic.IReadOnlyList<string> Microsoft.AspNetCore.Telemetry.HttpLoggingDimensions.DimensionNames { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.HttpLoggingServiceExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpLoggingServiceExtensions.AddHttpLogEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpLoggingServiceExtensions.AddHttpLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpLoggingServiceExtensions.AddHttpLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Telemetry.LoggingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpLoggingServiceExtensions.AddHttpLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Builder.IApplicationBuilder Microsoft.AspNetCore.Telemetry.HttpLoggingServiceExtensions.UseHttpLoggingMiddleware(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder.HttpMeteringBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder.Services { get; private set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.HttpMeteringExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpMeteringExtensions.AddHttpMetering(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpMeteringExtensions.AddHttpMetering(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder>? build);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder Microsoft.AspNetCore.Telemetry.HttpMeteringExtensions.AddMetricEnricher<T>(this Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder Microsoft.AspNetCore.Telemetry.HttpMeteringExtensions.AddMetricEnricher(this Microsoft.AspNetCore.Telemetry.HttpMeteringBuilder builder, Microsoft.AspNetCore.Telemetry.IIncomingRequestMetricEnricher enricher);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Builder.IApplicationBuilder Microsoft.AspNetCore.Telemetry.HttpMeteringExtensions.UseHttpMetering(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.AspNetCore.Telemetry.IHttpLogEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.AspNetCore.Telemetry.IHttpLogEnricher.Enrich(Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag enrichmentBag, Microsoft.AspNetCore.Http.HttpRequest request, Microsoft.AspNetCore.Http.HttpResponse response);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.AspNetCore.Telemetry.IIncomingRequestMetricEnricher : Microsoft.Extensions.Telemetry.Enrichment.IMetricEnricher",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<string> Microsoft.AspNetCore.Telemetry.IIncomingRequestMetricEnricher.DimensionNames { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode.IncomingPathLoggingMode();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode.Formatted",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode.Structured",
+          "Stage": "Stable",
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.Telemetry.LoggingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.LoggingOptions.LoggingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.AspNetCore.Telemetry.LoggingOptions.BodySizeLimit { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.AspNetCore.Telemetry.LoggingOptions.ExcludePathStartsWith { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.AspNetCore.Telemetry.LoggingOptions.LogBody { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.AspNetCore.Telemetry.LoggingOptions.LogRequestStart { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.AspNetCore.Telemetry.LoggingOptions.RequestBodyContentTypes { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.AspNetCore.Telemetry.LoggingOptions.RequestBodyReadTimeout { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.AspNetCore.Telemetry.LoggingOptions.RequestHeadersDataClasses { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.IncomingPathLoggingMode Microsoft.AspNetCore.Telemetry.LoggingOptions.RequestPathLoggingMode { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.AspNetCore.Telemetry.LoggingOptions.RequestPathParameterRedactionMode { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.AspNetCore.Telemetry.LoggingOptions.ResponseBodyContentTypes { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.AspNetCore.Telemetry.LoggingOptions.ResponseHeadersDataClasses { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.AspNetCore.Telemetry.LoggingOptions.RouteParameterDataClasses { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.RequestCheckpointConstants",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.RequestCheckpointConstants.ElapsedResponseProcessed",
+          "Stage": "Stable",
+          "Value": "eltrspproc"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.RequestCheckpointConstants.ElapsedTillEntryMiddleware",
+          "Stage": "Stable",
+          "Value": "eltenm"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.RequestCheckpointConstants.ElapsedTillFinished",
+          "Stage": "Stable",
+          "Value": "eltltf"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.RequestCheckpointConstants.ElapsedTillHeaders",
+          "Stage": "Stable",
+          "Value": "elthdr"
+        },
+        {
+          "Member": "const string Microsoft.AspNetCore.Telemetry.RequestCheckpointConstants.ElapsedTillPipelineExitMiddleware",
+          "Stage": "Stable",
+          "Value": "eltexm"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.RequestCheckpointExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestCheckpointExtensions.AddRequestCheckpoint(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Builder.IApplicationBuilder Microsoft.AspNetCore.Telemetry.RequestCheckpointExtensions.UseRequestCheckpoint(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryExtensions.AddRequestLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryExtensions.AddRequestLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryExtensions.AddRequestLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Builder.IApplicationBuilder Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryExtensions.UseRequestLatencyTelemetry(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryOptions.RequestLatencyTelemetryOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.AspNetCore.Telemetry.RequestLatencyTelemetryOptions.LatencyDataExportTimeout { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.AspNetCore.Telemetry/Microsoft.AspNetCore.Telemetry.json
+++ b/src/Libraries/Microsoft.AspNetCore.Telemetry/Microsoft.AspNetCore.Telemetry.json
@@ -1,0 +1,111 @@
+{
+  "Name": "Microsoft.AspNetCore.Telemetry, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.HttpTracingExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.AspNetCore.Telemetry.IHttpTraceEnricher enricher);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTraceEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.AspNetCore.Telemetry.IHttpTraceEnricher enricher);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTracing(this OpenTelemetry.Trace.TracerProviderBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTracing(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Microsoft.AspNetCore.Telemetry.HttpTracingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.AspNetCore.Telemetry.HttpTracingExtensions.AddHttpTracing(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.Telemetry.HttpTracingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.HttpTracingOptions.HttpTracingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.AspNetCore.Telemetry.HttpTracingOptions.ExcludePathStartsWith { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.AspNetCore.Telemetry.HttpTracingOptions.IncludePath { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.AspNetCore.Telemetry.HttpTracingOptions.RequestPathParameterRedactionMode { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.AspNetCore.Telemetry.HttpTracingOptions.RouteParameterDataClasses { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.AspNetCore.Telemetry.IHttpTraceEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.AspNetCore.Telemetry.IHttpTraceEnricher.Enrich(System.Diagnostics.Activity activity, Microsoft.AspNetCore.Http.HttpRequest request);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.AspNetCore.Telemetry.RequestHeadersEnricherExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestHeadersEnricherExtensions.AddRequestHeadersLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestHeadersEnricherExtensions.AddRequestHeadersLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Telemetry.RequestHeadersLogEnricherOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.AspNetCore.Telemetry.RequestHeadersEnricherExtensions.AddRequestHeadersLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.AspNetCore.Telemetry.RequestHeadersLogEnricherOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.AspNetCore.Telemetry.RequestHeadersLogEnricherOptions.RequestHeadersLogEnricherOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.AspNetCore.Telemetry.RequestHeadersLogEnricherOptions.HeadersDataClasses { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.json
+++ b/src/Libraries/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.json
@@ -1,0 +1,31 @@
+{
+  "Name": "Microsoft.AspNetCore.Testing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.AspNetCore.Testing.ServiceFakesExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Net.Http.HttpClient Microsoft.AspNetCore.Testing.ServiceFakesExtensions.CreateClient(this Microsoft.Extensions.Hosting.IHost host, System.Net.Http.HttpMessageHandler? handler = null, System.Func<System.Uri, bool>? addressFilter = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Collections.Generic.IEnumerable<System.Uri> Microsoft.AspNetCore.Testing.ServiceFakesExtensions.GetListenUris(this Microsoft.Extensions.Hosting.IHost host);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Hosting.IWebHostBuilder Microsoft.AspNetCore.Testing.ServiceFakesExtensions.ListenHttpOnAnyPort(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Hosting.IWebHostBuilder Microsoft.AspNetCore.Testing.ServiceFakesExtensions.ListenHttpsOnAnyPort(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2? sslCertificate = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.AspNetCore.Hosting.IWebHostBuilder Microsoft.AspNetCore.Testing.ServiceFakesExtensions.UseTestStartup(this Microsoft.AspNetCore.Hosting.IWebHostBuilder builder);",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.Application/Microsoft.Extensions.AmbientMetadata.Application.json
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.Application/Microsoft.Extensions.AmbientMetadata.Application.json
@@ -1,0 +1,55 @@
+{
+  "Name": "Microsoft.Extensions.AmbientMetadata.Application, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.AmbientMetadata.ApplicationMetadata",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AmbientMetadata.ApplicationMetadata.ApplicationMetadata();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.AmbientMetadata.ApplicationMetadata.ApplicationName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.ApplicationMetadata.BuildVersion { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.AmbientMetadata.ApplicationMetadata.DeploymentRing { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.AmbientMetadata.ApplicationMetadata.EnvironmentName { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.AmbientMetadata.ApplicationMetadataExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Configuration.IConfigurationBuilder Microsoft.Extensions.AmbientMetadata.ApplicationMetadataExtensions.AddApplicationMetadata(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment, string sectionName = \"ambientmetadata:application\");",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.AmbientMetadata.ApplicationMetadataExtensions.AddApplicationMetadata(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.AmbientMetadata.ApplicationMetadataExtensions.AddApplicationMetadata(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.AmbientMetadata.ApplicationMetadata> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.AmbientMetadata.ApplicationMetadataExtensions.UseApplicationMetadata(this Microsoft.Extensions.Hosting.IHostBuilder builder, string sectionName = \"ambientmetadata:application\");",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.AsyncState/Microsoft.Extensions.AsyncState.json
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/Microsoft.Extensions.AsyncState.json
@@ -1,0 +1,101 @@
+{
+  "Name": "Microsoft.Extensions.AsyncState, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.Extensions.AsyncState.AsyncStateExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.AsyncState.AsyncStateExtensions.AddAsyncStateCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.AsyncState.AsyncStateExtensions.TryRemoveAsyncStateCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.AsyncState.AsyncStateToken : System.IEquatable<Microsoft.Extensions.AsyncState.AsyncStateToken>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.AsyncState.AsyncStateToken.AsyncStateToken();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.AsyncState.AsyncStateToken.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.AsyncState.AsyncStateToken.Equals(Microsoft.Extensions.AsyncState.AsyncStateToken other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.AsyncState.AsyncStateToken.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.AsyncState.AsyncStateToken.operator ==(Microsoft.Extensions.AsyncState.AsyncStateToken left, Microsoft.Extensions.AsyncState.AsyncStateToken right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.AsyncState.AsyncStateToken.operator !=(Microsoft.Extensions.AsyncState.AsyncStateToken left, Microsoft.Extensions.AsyncState.AsyncStateToken right);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.AsyncState.IAsyncContext<T> where T : notnull",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "T? Microsoft.Extensions.AsyncState.IAsyncContext<T>.Get();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.AsyncState.IAsyncContext<T>.Set(T? context);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.AsyncState.IAsyncContext<T>.TryGet(out T? context);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.AsyncState.IAsyncLocalContext<T> : Microsoft.Extensions.AsyncState.IAsyncContext<T> where T : class",
+      "Stage": "Experimental"
+    },
+    {
+      "Type": "interface Microsoft.Extensions.AsyncState.IAsyncState",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "object? Microsoft.Extensions.AsyncState.IAsyncState.Get(Microsoft.Extensions.AsyncState.AsyncStateToken token);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.AsyncState.IAsyncState.Initialize();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.AsyncState.AsyncStateToken Microsoft.Extensions.AsyncState.IAsyncState.RegisterAsyncContext();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.AsyncState.IAsyncState.Reset();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.AsyncState.IAsyncState.Set(Microsoft.Extensions.AsyncState.AsyncStateToken token, object? value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.AsyncState.IAsyncState.TryGet(Microsoft.Extensions.AsyncState.AsyncStateToken token, out object? value);",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/Microsoft.Extensions.Compliance.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/Microsoft.Extensions.Compliance.Abstractions.json
@@ -1,0 +1,203 @@
+{
+  "Name": "Microsoft.Extensions.Compliance.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "readonly struct Microsoft.Extensions.Compliance.Classification.DataClassification : System.IEquatable<Microsoft.Extensions.Compliance.Classification.DataClassification>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.DataClassification.DataClassification(string taxonomyName, ulong value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.DataClassification.DataClassification();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Classification.DataClassification.Combine(Microsoft.Extensions.Compliance.Classification.DataClassification left, Microsoft.Extensions.Compliance.Classification.DataClassification right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.Compliance.Classification.DataClassification.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Compliance.Classification.DataClassification.Equals(Microsoft.Extensions.Compliance.Classification.DataClassification other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Classification.DataClassification.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Classification.DataClassification.operator |(Microsoft.Extensions.Compliance.Classification.DataClassification left, Microsoft.Extensions.Compliance.Classification.DataClassification right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Compliance.Classification.DataClassification.operator ==(Microsoft.Extensions.Compliance.Classification.DataClassification left, Microsoft.Extensions.Compliance.Classification.DataClassification right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Compliance.Classification.DataClassification.operator !=(Microsoft.Extensions.Compliance.Classification.DataClassification left, Microsoft.Extensions.Compliance.Classification.DataClassification right);",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const ulong Microsoft.Extensions.Compliance.Classification.DataClassification.NoneTaxonomyValue",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const ulong Microsoft.Extensions.Compliance.Classification.DataClassification.UnknownTaxonomyValue",
+          "Stage": "Stable",
+          "Value": "9223372036854775808"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Classification.DataClassification.None { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Classification.DataClassification.TaxonomyName { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Classification.DataClassification.Unknown { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "ulong Microsoft.Extensions.Compliance.Classification.DataClassification.Value { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute.DataClassificationAttribute(Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute.Classification { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute.Notes { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder.SetFallbackRedactor<T>();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder.SetRedactor<T>(params Microsoft.Extensions.Compliance.Classification.DataClassification[] classifications);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Compliance.Redaction.IRedactorProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.Redactor Microsoft.Extensions.Compliance.Redaction.IRedactorProvider.GetRedactor(Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Classification.NoDataClassificationAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.NoDataClassificationAttribute.NoDataClassificationAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Compliance.Redaction.RedactionAbstractionsExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static System.Text.StringBuilder Microsoft.Extensions.Compliance.Redaction.RedactionAbstractionsExtensions.AppendRedacted(this System.Text.StringBuilder stringBuilder, Microsoft.Extensions.Compliance.Redaction.Redactor redactor, string? value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static System.Text.StringBuilder Microsoft.Extensions.Compliance.Redaction.RedactionAbstractionsExtensions.AppendRedacted(this System.Text.StringBuilder stringBuilder, Microsoft.Extensions.Compliance.Redaction.Redactor redactor, System.ReadOnlySpan<char> value);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "abstract class Microsoft.Extensions.Compliance.Redaction.Redactor",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.Redactor.Redactor();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "abstract int Microsoft.Extensions.Compliance.Redaction.Redactor.GetRedactedLength(System.ReadOnlySpan<char> input);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Compliance.Redaction.Redactor.GetRedactedLength(string? input);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Redaction.Redactor.Redact(System.ReadOnlySpan<char> source);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "abstract int Microsoft.Extensions.Compliance.Redaction.Redactor.Redact(System.ReadOnlySpan<char> source, System.Span<char> destination);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Compliance.Redaction.Redactor.Redact(string? source, System.Span<char> destination);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "virtual string Microsoft.Extensions.Compliance.Redaction.Redactor.Redact(string? source);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Redaction.Redactor.Redact<T>(T value, string? format = null, System.IFormatProvider? provider = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Compliance.Redaction.Redactor.Redact<T>(T value, System.Span<char> destination, string? format = null, System.IFormatProvider? provider = null);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Classification.UnknownDataClassificationAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.UnknownDataClassificationAttribute.UnknownDataClassificationAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/Microsoft.Extensions.Compliance.Redaction.json
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/Microsoft.Extensions.Compliance.Redaction.json
@@ -1,0 +1,145 @@
+{
+  "Name": "Microsoft.Extensions.Compliance.Redaction, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Redaction.ErasingRedactor : Microsoft.Extensions.Compliance.Redaction.Redactor",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.ErasingRedactor.ErasingRedactor();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Redaction.ErasingRedactor.GetRedactedLength(System.ReadOnlySpan<char> input);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Redaction.ErasingRedactor.Redact(System.ReadOnlySpan<char> source, System.Span<char> destination);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.ErasingRedactor Microsoft.Extensions.Compliance.Redaction.ErasingRedactor.Instance { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Redaction.NullRedactor : Microsoft.Extensions.Compliance.Redaction.Redactor",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.NullRedactor.NullRedactor();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Redaction.NullRedactor.GetRedactedLength(System.ReadOnlySpan<char> input);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Redaction.NullRedactor.Redact(System.ReadOnlySpan<char> source, System.Span<char> destination);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.Compliance.Redaction.NullRedactor.Redact(string? source);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.NullRedactor Microsoft.Extensions.Compliance.Redaction.NullRedactor.Instance { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Redaction.NullRedactorProvider : Microsoft.Extensions.Compliance.Redaction.IRedactorProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.NullRedactorProvider.NullRedactorProvider();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.Redactor Microsoft.Extensions.Compliance.Redaction.NullRedactorProvider.GetRedactor(Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.NullRedactorProvider Microsoft.Extensions.Compliance.Redaction.NullRedactorProvider.Instance { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Compliance.Redaction.RedactionExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.AddRedaction(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.AddRedaction(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.ConfigureRedaction(this Microsoft.Extensions.Hosting.IHostBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.ConfigureRedaction(this Microsoft.Extensions.Hosting.IHostBuilder builder, System.Action<Microsoft.Extensions.Hosting.HostBuilderContext, Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.ConfigureRedaction(this Microsoft.Extensions.Hosting.IHostBuilder builder, System.Action<Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.SetXXHash3Redactor(this Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder builder, System.Action<Microsoft.Extensions.Compliance.Redaction.XXHash3RedactorOptions> configure, params Microsoft.Extensions.Compliance.Classification.DataClassification[] classifications);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Redaction.RedactionExtensions.SetXXHash3Redactor(this Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section, params Microsoft.Extensions.Compliance.Classification.DataClassification[] classifications);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Redaction.XXHash3Redactor : Microsoft.Extensions.Compliance.Redaction.Redactor",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.XXHash3Redactor.XXHash3Redactor(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Compliance.Redaction.XXHash3RedactorOptions> options);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Redaction.XXHash3Redactor.GetRedactedLength(System.ReadOnlySpan<char> input);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Redaction.XXHash3Redactor.Redact(System.ReadOnlySpan<char> source, System.Span<char> destination);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Compliance.Redaction.XXHash3RedactorOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.XXHash3RedactorOptions.XXHash3RedactorOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "ulong Microsoft.Extensions.Compliance.Redaction.XXHash3RedactorOptions.HashSeed { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Compliance.Testing/Microsoft.Extensions.Compliance.Testing.json
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Testing/Microsoft.Extensions.Compliance.Testing.json
@@ -1,0 +1,299 @@
+{
+  "Name": "Microsoft.Extensions.Compliance.Testing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector.FakeRedactionCollector();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Compliance.Testing.RedactedData> Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector.AllRedactedData { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Compliance.Testing.RedactorRequested> Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector.AllRedactorRequests { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.RedactedData Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector.LastRedactedData { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.RedactorRequested Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector.LastRedactorRequested { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions.AddFakeRedaction(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions.AddFakeRedaction(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions.GetFakeRedactionCollector(this System.IServiceProvider serviceProvider);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions.SetFakeRedactor(this Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder builder, params Microsoft.Extensions.Compliance.Classification.DataClassification[] classifications);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions.SetFakeRedactor(this Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder builder, System.Action<Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions> configure, params Microsoft.Extensions.Compliance.Classification.DataClassification[] classifications);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder Microsoft.Extensions.Compliance.Testing.FakeRedactionExtensions.SetFakeRedactor(this Microsoft.Extensions.Compliance.Redaction.IRedactionBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section, params Microsoft.Extensions.Compliance.Classification.DataClassification[] classifications);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Compliance.Testing.FakeRedactor : Microsoft.Extensions.Compliance.Redaction.Redactor",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.FakeRedactor.FakeRedactor(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions>? options = null, Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector? collector = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Testing.FakeRedactor Microsoft.Extensions.Compliance.Testing.FakeRedactor.Create(Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions? options = null, Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector? collector = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Testing.FakeRedactor.GetRedactedLength(System.ReadOnlySpan<char> input);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Testing.FakeRedactor.Redact(System.ReadOnlySpan<char> source, System.Span<char> destination);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector Microsoft.Extensions.Compliance.Testing.FakeRedactor.EventCollector { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions.FakeRedactorOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions.RedactionFormat { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Compliance.Testing.FakeRedactorProvider : Microsoft.Extensions.Compliance.Redaction.IRedactorProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.FakeRedactorProvider.FakeRedactorProvider(Microsoft.Extensions.Compliance.Testing.FakeRedactorOptions? options = null, Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector? eventCollector = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Redaction.Redactor Microsoft.Extensions.Compliance.Testing.FakeRedactorProvider.GetRedactor(Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector Microsoft.Extensions.Compliance.Testing.FakeRedactorProvider.Collector { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Testing.PrivateDataAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.PrivateDataAttribute.PrivateDataAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Compliance.Testing.PublicDataAttribute : Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.PublicDataAttribute.PublicDataAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Compliance.Testing.RedactedData : System.IEquatable<Microsoft.Extensions.Compliance.Testing.RedactedData>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.RedactedData.RedactedData(string original, string redacted, int sequenceNumber);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.RedactedData.RedactedData();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.Compliance.Testing.RedactedData.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Compliance.Testing.RedactedData.Equals(Microsoft.Extensions.Compliance.Testing.RedactedData other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Testing.RedactedData.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Compliance.Testing.RedactedData.operator ==(Microsoft.Extensions.Compliance.Testing.RedactedData left, Microsoft.Extensions.Compliance.Testing.RedactedData right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Compliance.Testing.RedactedData.operator !=(Microsoft.Extensions.Compliance.Testing.RedactedData left, Microsoft.Extensions.Compliance.Testing.RedactedData right);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Testing.RedactedData.Original { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Compliance.Testing.RedactedData.Redacted { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Compliance.Testing.RedactedData.SequenceNumber { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Compliance.Testing.RedactorRequested : System.IEquatable<Microsoft.Extensions.Compliance.Testing.RedactorRequested>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.RedactorRequested.RedactorRequested(Microsoft.Extensions.Compliance.Classification.DataClassification classification, int sequenceNumber);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.RedactorRequested.RedactorRequested();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.Compliance.Testing.RedactorRequested.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Compliance.Testing.RedactorRequested.Equals(Microsoft.Extensions.Compliance.Testing.RedactorRequested other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Compliance.Testing.RedactorRequested.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Compliance.Testing.RedactorRequested.operator ==(Microsoft.Extensions.Compliance.Testing.RedactorRequested left, Microsoft.Extensions.Compliance.Testing.RedactorRequested right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Compliance.Testing.RedactorRequested.operator !=(Microsoft.Extensions.Compliance.Testing.RedactorRequested left, Microsoft.Extensions.Compliance.Testing.RedactorRequested right);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Testing.RedactorRequested.DataClassification { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Compliance.Testing.RedactorRequested.SequenceNumber { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Compliance.Testing.SimpleClassifications",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Testing.SimpleClassifications.PrivateData { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Classification.DataClassification Microsoft.Extensions.Compliance.Testing.SimpleClassifications.PublicData { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static string Microsoft.Extensions.Compliance.Testing.SimpleClassifications.TaxonomyName { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy : ulong",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.SimpleTaxonomy();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.None",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.PrivateData",
+          "Stage": "Stable",
+          "Value": "2"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.PublicData",
+          "Stage": "Stable",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.Unknown",
+          "Stage": "Stable",
+          "Value": "9223372036854775808"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Compliance.Testing.SimpleTaxonomyExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomyExtensions.AsSimpleTaxonomy(this Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ExceptionSummarization/Microsoft.Extensions.Diagnostics.ExceptionSummarization.json
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ExceptionSummarization/Microsoft.Extensions.Diagnostics.ExceptionSummarization.json
@@ -1,0 +1,121 @@
+{
+  "Name": "Microsoft.Extensions.Diagnostics.ExceptionSummarization, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummarizationExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummarizationExtensions.AddExceptionSummarizer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummarizationExtensions.AddExceptionSummarizer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummarizationExtensions.AddHttpProvider(this Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary : System.IEquatable<Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.ExceptionSummary(string exceptionType, string description, string additionalDetails);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.ExceptionSummary();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.Equals(Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.operator ==(Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary left, Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.operator !=(Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary left, Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.ToString();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.AdditionalDetails { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.Description { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary.ExceptionType { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder.AddProvider<T>();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizationBuilder.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizer",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ExceptionSummarization.ExceptionSummary Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummarizer.Summarize(System.Exception exception);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummaryProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "int Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummaryProvider.Describe(System.Exception exception, out string? additionalDetails);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummaryProvider.Descriptions { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IEnumerable<System.Type> Microsoft.Extensions.Diagnostics.ExceptionSummarization.IExceptionSummaryProvider.SupportedExceptionTypes { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.Core/Microsoft.Extensions.Diagnostics.HealthChecks.Core.json
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.Core/Microsoft.Extensions.Diagnostics.HealthChecks.Core.json
@@ -1,0 +1,85 @@
+{
+  "Name": "Microsoft.Extensions.Diagnostics.HealthChecks.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddApplicationLifecycleHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddApplicationLifecycleHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Collections.Generic.IEnumerable<string> tags);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddKubernetesHealthCheckPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddKubernetesHealthCheckPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddKubernetesHealthCheckPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Diagnostics.HealthChecks.KubernetesHealthCheckPublisherOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddManualHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddManualHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Collections.Generic.IEnumerable<string> tags);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.AddTelemetryHealthCheckPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static void Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.ReportHealthy(this Microsoft.Extensions.Diagnostics.HealthChecks.IManualHealthCheck manualHealthCheck);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static void Microsoft.Extensions.Diagnostics.HealthChecks.CoreHealthChecksExtensions.ReportUnhealthy(this Microsoft.Extensions.Diagnostics.HealthChecks.IManualHealthCheck manualHealthCheck, string reason);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.HealthChecks.IManualHealthCheck : System.IDisposable",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult Microsoft.Extensions.Diagnostics.HealthChecks.IManualHealthCheck.Result { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.HealthChecks.IManualHealthCheck<T> : Microsoft.Extensions.Diagnostics.HealthChecks.IManualHealthCheck, System.IDisposable",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "class Microsoft.Extensions.Diagnostics.HealthChecks.KubernetesHealthCheckPublisherOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.HealthChecks.KubernetesHealthCheckPublisherOptions.KubernetesHealthCheckPublisherOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Diagnostics.HealthChecks.KubernetesHealthCheckPublisherOptions.MaxPendingConnections { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Diagnostics.HealthChecks.KubernetesHealthCheckPublisherOptions.TcpPort { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.json
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.json
@@ -1,0 +1,79 @@
+{
+  "Name": "Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUsageThresholds",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUsageThresholds.ResourceUsageThresholds();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "double? Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUsageThresholds.DegradedUtilizationPercentage { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "double? Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUsageThresholds.UnhealthyUtilizationPercentage { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions.ResourceUtilizationHealthCheckOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUsageThresholds Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions.CpuThresholds { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUsageThresholds Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions.MemoryThresholds { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions.SamplingWindow { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions.AddResourceUtilizationHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions.AddResourceUtilizationHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Collections.Generic.IEnumerable<string> tags);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions.AddResourceUtilizationHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions.AddResourceUtilizationHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Collections.Generic.IEnumerable<string> tags);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions.AddResourceUtilizationHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthChecksExtensions.AddResourceUtilizationHealthCheck(this Microsoft.Extensions.DependencyInjection.IHealthChecksBuilder builder, System.Action<Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilizationHealthCheckOptions> configure, System.Collections.Generic.IEnumerable<string> tags);",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Microsoft.Extensions.Diagnostics.ResourceMonitoring.json
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Microsoft.Extensions.Diagnostics.ResourceMonitoring.json
@@ -1,0 +1,267 @@
+{
+  "Name": "Microsoft.Extensions.Diagnostics.ResourceMonitoring, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.ResourceMonitoring.CountersSetup",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static void Microsoft.Extensions.Diagnostics.ResourceMonitoring.CountersSetup.PreparePerformanceCounters();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationPublisher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationPublisher.PublishAsync(Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization utilization, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTracker",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTracker.GetUtilization(System.TimeSpan window);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder.AddPublisher<T>();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationCounters",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "static string Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationCounters.CpuConsumptionPercentage { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static string Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationCounters.MemoryConsumptionPercentage { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationProviderOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationProviderOptions.LinuxResourceUtilizationProviderOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationProviderOptions.CpuConsumptionRefreshInterval { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationProviderOptions.MemoryConsumptionRefreshInterval { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxUtilizationExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxUtilizationExtensions.AddLinuxProvider(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxUtilizationExtensions.AddLinuxProvider(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxUtilizationExtensions.AddLinuxProvider(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder, System.Action<Microsoft.Extensions.Diagnostics.ResourceMonitoring.LinuxResourceUtilizationProviderOptions> configure);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions.AddNullResourceUtilization(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions.AddNullResourceUtilizationProvider(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions.AddResourceUtilization(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions.ConfigureResourceUtilization(this Microsoft.Extensions.Hosting.IHostBuilder builder, System.Action<Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions.ConfigureTracker(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder, System.Action<Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceUtilizationTrackerOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceMonitoringExtensions.ConfigureTracker(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceUtilizationTrackerOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceUtilizationTrackerOptions.ResourceUtilizationTrackerOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceUtilizationTrackerOptions.CalculationPeriod { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceUtilizationTrackerOptions.CollectionWindow { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.ResourceMonitoring.ResourceUtilizationTrackerOptions.SamplingInterval { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources.SystemResources(double guaranteedCpuUnits, double maximumCpuUnits, ulong guaranteedMemoryInBytes, ulong maximumMemoryInBytes);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources.SystemResources();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "double Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources.GuaranteedCpuUnits { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "ulong Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources.GuaranteedMemoryInBytes { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "double Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources.MaximumCpuUnits { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "ulong Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources.MaximumMemoryInBytes { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization.Utilization(double cpuUsedPercentage, ulong memoryUsedInBytes, Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources systemResources);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization.Utilization();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "double Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization.CpuUsedPercentage { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "ulong Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization.MemoryUsedInBytes { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "double Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization.MemoryUsedPercentage { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.SystemResources Microsoft.Extensions.Diagnostics.ResourceMonitoring.Utilization.SystemResources { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsCountersOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsCountersOptions.WindowsCountersOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsCountersOptions.CachingInterval { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsCountersOptions.InstanceIpAddresses { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsUtilizationExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsUtilizationExtensions.AddWindowsCounters(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsUtilizationExtensions.AddWindowsCounters(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsUtilizationExtensions.AddWindowsCounters(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder, System.Action<Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsCountersOptions> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsUtilizationExtensions.AddWindowsPerfCounterPublisher(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder Microsoft.Extensions.Diagnostics.ResourceMonitoring.WindowsUtilizationExtensions.AddWindowsProvider(this Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceUtilizationTrackerBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.EnumStrings/Microsoft.Extensions.EnumStrings.json
+++ b/src/Libraries/Microsoft.Extensions.EnumStrings/Microsoft.Extensions.EnumStrings.json
@@ -1,0 +1,41 @@
+{
+  "Name": "Microsoft.Extensions.EnumStrings, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "sealed class Microsoft.Extensions.EnumStrings.EnumStringsAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.EnumStrings.EnumStringsAttribute.EnumStringsAttribute();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.EnumStrings.EnumStringsAttribute.EnumStringsAttribute(System.Type enumType);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Type? Microsoft.Extensions.EnumStrings.EnumStringsAttribute.EnumType { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.EnumStrings.EnumStringsAttribute.ExtensionClassModifiers { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.EnumStrings.EnumStringsAttribute.ExtensionClassName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.EnumStrings.EnumStringsAttribute.ExtensionMethodName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.EnumStrings.EnumStringsAttribute.ExtensionNamespace { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Hosting.Testing/Microsoft.Extensions.Hosting.Testing.json
+++ b/src/Libraries/Microsoft.Extensions.Hosting.Testing/Microsoft.Extensions.Hosting.Testing.json
@@ -1,0 +1,123 @@
+{
+  "Name": "Microsoft.Extensions.Hosting.Testing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "sealed class Microsoft.Extensions.Hosting.Testing.FakeHost : Microsoft.Extensions.Hosting.IHost, System.IDisposable",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.FakeHost.CreateBuilder();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.FakeHost.CreateBuilder(System.Action<Microsoft.Extensions.Hosting.Testing.FakeHostOptions> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.FakeHost.CreateBuilder(Microsoft.Extensions.Hosting.Testing.FakeHostOptions options);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Hosting.Testing.FakeHost.Dispose();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task Microsoft.Extensions.Hosting.Testing.FakeHost.StartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task Microsoft.Extensions.Hosting.Testing.FakeHost.StopAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.IServiceProvider Microsoft.Extensions.Hosting.Testing.FakeHost.Services { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Hosting.Testing.FakeHostOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Hosting.Testing.FakeHostOptions.FakeHostOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Hosting.Testing.FakeHostOptions.FakeLogging { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Hosting.Testing.FakeHostOptions.FakeRedaction { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Hosting.Testing.FakeHostOptions.ShutDownTimeout { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Hosting.Testing.FakeHostOptions.StartUpTimeout { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Hosting.Testing.FakeHostOptions.TimeToLive { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Hosting.Testing.FakeHostOptions.ValidateOnBuild { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Hosting.Testing.FakeHostOptions.ValidateScopes { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.AddFakeLoggingOutputSink(this Microsoft.Extensions.Hosting.IHostBuilder builder, System.Action<string> callback);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.Configure(this Microsoft.Extensions.Hosting.IHostBuilder builder, System.Action<Microsoft.Extensions.Hosting.IHostBuilder> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.ConfigureAppConfiguration(this Microsoft.Extensions.Hosting.IHostBuilder builder, params (string key, string value)[] configurations);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.ConfigureAppConfiguration(this Microsoft.Extensions.Hosting.IHostBuilder builder, string key, string value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.ConfigureHostConfiguration(this Microsoft.Extensions.Hosting.IHostBuilder builder, params (string key, string value)[] configurations);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Hosting.IHostBuilder Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.ConfigureHostConfiguration(this Microsoft.Extensions.Hosting.IHostBuilder builder, string key, string value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.GetFakeLogCollector(this Microsoft.Extensions.Hosting.IHost host);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Compliance.Testing.FakeRedactionCollector Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.GetFakeRedactionCollector(this Microsoft.Extensions.Hosting.IHost host);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task Microsoft.Extensions.Hosting.Testing.HostingFakesExtensions.StartAndStopAsync(this Microsoft.Extensions.Hosting.IHostedService service, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Http.AutoClient/Microsoft.Extensions.Http.AutoClient.json
+++ b/src/Libraries/Microsoft.Extensions.Http.AutoClient/Microsoft.Extensions.Http.AutoClient.json
@@ -1,0 +1,327 @@
+{
+  "Name": "Microsoft.Extensions.Http.AutoClient, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.AutoClientAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.AutoClientAttribute.AutoClientAttribute(string httpClientName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.AutoClientAttribute.AutoClientAttribute(string httpClientName, string customDependencyName);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.Http.AutoClient.AutoClientAttribute.CustomDependencyName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.AutoClientAttribute.HttpClientName { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.AutoClient.AutoClientException : System.Exception",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.AutoClientException.AutoClientException(string? message, string path, Microsoft.Extensions.Http.AutoClient.AutoClientHttpError? error = null);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.AutoClientHttpError? Microsoft.Extensions.Http.AutoClient.AutoClientException.HttpError { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.AutoClientException.Path { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? Microsoft.Extensions.Http.AutoClient.AutoClientException.StatusCode { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.AutoClient.AutoClientHttpError",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.AutoClientHttpError.AutoClientHttpError(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> responseHeaders, string rawContent, string? reasonPhrase);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Threading.Tasks.Task<Microsoft.Extensions.Http.AutoClient.AutoClientHttpError> Microsoft.Extensions.Http.AutoClient.AutoClientHttpError.CreateAsync(System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.AutoClientHttpError.RawContent { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Http.AutoClient.AutoClientHttpError.ReasonPhrase { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> Microsoft.Extensions.Http.AutoClient.AutoClientHttpError.ResponseHeaders { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Http.AutoClient.AutoClientHttpError.StatusCode { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.AutoClient.AutoClientOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.AutoClientOptions.AutoClientOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Text.Json.JsonSerializerOptions Microsoft.Extensions.Http.AutoClient.AutoClientOptions.JsonSerializerOptions { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.BodyAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.BodyAttribute.BodyAttribute();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.BodyAttribute.BodyAttribute(Microsoft.Extensions.Http.AutoClient.BodyContentType contentType);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.BodyContentType Microsoft.Extensions.Http.AutoClient.BodyAttribute.ContentType { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Http.AutoClient.BodyContentType",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.BodyContentType.BodyContentType();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Http.AutoClient.BodyContentType Microsoft.Extensions.Http.AutoClient.BodyContentType.ApplicationJson",
+          "Stage": "Experimental",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Http.AutoClient.BodyContentType Microsoft.Extensions.Http.AutoClient.BodyContentType.TextPlain",
+          "Stage": "Experimental",
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.DeleteAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.DeleteAttribute.DeleteAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.DeleteAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.GetAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.GetAttribute.GetAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.GetAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.HeadAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.HeadAttribute.HeadAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.HeadAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.HeaderAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.HeaderAttribute.HeaderAttribute(string header);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.HeaderAttribute.Header { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.OptionsAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.OptionsAttribute.OptionsAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.OptionsAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.PatchAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.PatchAttribute.PatchAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.PatchAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.PostAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.PostAttribute.PostAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.PostAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.PutAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.PutAttribute.PutAttribute(string path);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.PutAttribute.Path { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.QueryAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.QueryAttribute.QueryAttribute();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.QueryAttribute.QueryAttribute(string key);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.Http.AutoClient.QueryAttribute.Key { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.RequestNameAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.RequestNameAttribute.RequestNameAttribute(string value);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.RequestNameAttribute.Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute.StaticHeaderAttribute(string header, string value);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute.Header { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute.Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.json
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.json
@@ -1,0 +1,633 @@
+{
+  "Name": "Microsoft.Extensions.Http.Resilience, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.Endpoint",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.Endpoint.Endpoint();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Uri? Microsoft.Extensions.Http.Resilience.Endpoint.Uri { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.EndpointGroup",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.EndpointGroup.EndpointGroup();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.Http.Resilience.WeightedEndpoint> Microsoft.Extensions.Http.Resilience.EndpointGroup.Endpoints { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.FallbackClientHandlerOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FallbackClientHandlerOptions.FallbackClientHandlerOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Uri? Microsoft.Extensions.Http.Resilience.FallbackClientHandlerOptions.BaseFallbackUri { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpFallbackPolicyOptions Microsoft.Extensions.Http.Resilience.FallbackClientHandlerOptions.FallbackPolicyOptions { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HedgingEndpointOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HedgingEndpointOptions.HedgingEndpointOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpBulkheadPolicyOptions Microsoft.Extensions.Http.Resilience.HedgingEndpointOptions.BulkheadOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpCircuitBreakerPolicyOptions Microsoft.Extensions.Http.Resilience.HedgingEndpointOptions.CircuitBreakerOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpTimeoutPolicyOptions Microsoft.Extensions.Http.Resilience.HedgingEndpointOptions.TimeoutOptions { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HedgingHttpClientBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.HedgingHttpClientBuilderExtensions.AddStandardHedgingHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.HedgingHttpClientBuilderExtensions.AddStandardHedgingHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpBulkheadPolicyOptions : Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpBulkheadPolicyOptions.HttpBulkheadPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpCircuitBreakerPolicyOptions : Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<System.Net.Http.HttpResponseMessage>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpCircuitBreakerPolicyOptions.HttpCircuitBreakerPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddFallbackHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.FallbackClientHandlerOptions> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddFallbackHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddFallbackHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Http.Resilience.FallbackClientHandlerOptions> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddResilienceHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, string pipelineIdentifier);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddStandardResilienceHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddStandardResilienceHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpClientBuilderExtensions.AddStandardResilienceHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions.AddFaultInjectionPolicyHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder httpClientBuilder, string chaosPolicyOptionsGroupName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions.AddHttpClientFaultInjection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions.AddHttpClientFaultInjection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions.AddHttpClientFaultInjection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions.AddWeightedFaultInjectionPolicyHandlers(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder httpClientBuilder, System.Action<Microsoft.Extensions.Resilience.FaultInjection.FaultPolicyWeightAssignmentsOptions> weightAssignmentsConfig);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpClientFaultInjectionExtensions.AddWeightedFaultInjectionPolicyHandlers(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder httpClientBuilder, Microsoft.Extensions.Configuration.IConfigurationSection weightAssignmentsConfigSection);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HttpClientHedgingResiliencePredicates",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "static readonly System.Predicate<System.Exception> Microsoft.Extensions.Http.Resilience.HttpClientHedgingResiliencePredicates.IsTransientHttpException",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HttpClientResilienceGenerators",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "static readonly System.Func<Microsoft.Extensions.Resilience.Options.RetryDelayArguments<System.Net.Http.HttpResponseMessage>, System.TimeSpan> Microsoft.Extensions.Http.Resilience.HttpClientResilienceGenerators.HandleRetryAfterHeader",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HttpClientResiliencePredicates",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "static readonly System.Predicate<System.Exception> Microsoft.Extensions.Http.Resilience.HttpClientResiliencePredicates.IsTransientHttpException",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static readonly System.Predicate<System.Net.Http.HttpResponseMessage> Microsoft.Extensions.Http.Resilience.HttpClientResiliencePredicates.IsTransientHttpFailure",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpFallbackPolicyOptions : Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<System.Net.Http.HttpResponseMessage>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpFallbackPolicyOptions.HttpFallbackPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder.HttpFaultInjectionOptionsBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder.AddException(string key, System.Exception exception);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder.AddHttpContent(string key, System.Net.Http.HttpContent content);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder.Configure();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder.Configure(Microsoft.Extensions.Configuration.IConfiguration section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder Microsoft.Extensions.Http.Resilience.FaultInjection.HttpFaultInjectionOptionsBuilder.Configure(System.Action<Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptions> configureOptions);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpHedgingPolicyOptions : Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<System.Net.Http.HttpResponseMessage>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpHedgingPolicyOptions.HttpHedgingPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HttpResiliencePipelineBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpResiliencePipelineBuilderExtensions.SelectPipelineBy(this Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder builder, System.Func<System.IServiceProvider, Microsoft.Extensions.Http.Resilience.PipelineKeySelector> selectorFactory);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpResiliencePipelineBuilderExtensions.SelectPipelineByAuthority(this Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder builder, Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpRetryPolicyOptions : Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<System.Net.Http.HttpResponseMessage>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpRetryPolicyOptions.HttpRetryPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Http.Resilience.HttpRetryPolicyOptions.ShouldRetryAfterHeader { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions.HttpStandardHedgingResilienceOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HedgingEndpointOptions Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions.EndpointOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpHedgingPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions.HedgingOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpTimeoutPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions.TotalRequestTimeoutOptions { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions.HttpStandardResilienceOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpTimeoutPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions.AttemptTimeoutOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpBulkheadPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions.BulkheadOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpCircuitBreakerPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions.CircuitBreakerOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpRetryPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions.RetryOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpTimeoutPolicyOptions Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions.TotalRequestTimeoutOptions { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.HttpStandardResiliencePipelineBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpStandardResiliencePipelineBuilderExtensions.Configure(this Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpStandardResiliencePipelineBuilderExtensions.Configure(this Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpStandardResiliencePipelineBuilderExtensions.Configure(this Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.HttpStandardResilienceOptions, System.IServiceProvider> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpStandardResiliencePipelineBuilderExtensions.SelectPipelineBy(this Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder builder, System.Func<System.IServiceProvider, Microsoft.Extensions.Http.Resilience.PipelineKeySelector> selectorFactory);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.HttpStandardResiliencePipelineBuilderExtensions.SelectPipelineByAuthority(this Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder builder, Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.HttpTimeoutPolicyOptions : Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.HttpTimeoutPolicyOptions.HttpTimeoutPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.FaultInjection.IHttpClientChaosPolicyFactory",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Polly.Contrib.Simmy.Outcomes.AsyncInjectOutcomePolicy<System.Net.Http.HttpResponseMessage> Microsoft.Extensions.Http.Resilience.FaultInjection.IHttpClientChaosPolicyFactory.CreateHttpResponsePolicy();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder : Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<System.Net.Http.HttpResponseMessage>",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder.PipelineName { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Resilience.IHttpStandardResiliencePipelineBuilder.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.IRequestRoutingStrategy",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "bool Microsoft.Extensions.Http.Resilience.IRequestRoutingStrategy.TryGetNextRoute(out System.Uri? nextRoute);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.IRequestRoutingStrategyFactory",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.IRequestRoutingStrategy Microsoft.Extensions.Http.Resilience.IRequestRoutingStrategyFactory.CreateRoutingStrategy();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.IHttpResiliencePipelineBuilder Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder.EndpointResiliencePipelineBuilder { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder.RoutingStrategyBuilder { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.OrderedGroupsRoutingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.OrderedGroupsRoutingOptions.OrderedGroupsRoutingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.Http.Resilience.EndpointGroup> Microsoft.Extensions.Http.Resilience.OrderedGroupsRoutingOptions.Groups { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "delegate string Microsoft.Extensions.Http.Resilience.PipelineKeySelector(System.Net.Http.HttpRequestMessage requestMessage)",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.FaultInjection.PolicyContextExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Polly.Context Microsoft.Extensions.Http.Resilience.FaultInjection.PolicyContextExtensions.WithCallingRequestMessage(this Polly.Context context, System.Net.Http.HttpRequestMessage request);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions.ConfigureOrderedGroups(this Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions.ConfigureOrderedGroups(this Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.OrderedGroupsRoutingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions.ConfigureOrderedGroups(this Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.OrderedGroupsRoutingOptions, System.IServiceProvider> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions.ConfigureWeightedGroups(this Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions.ConfigureWeightedGroups(this Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.WeightedGroupsRoutingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder Microsoft.Extensions.Http.Resilience.RoutingStrategyBuilderExtensions.ConfigureWeightedGroups(this Microsoft.Extensions.Http.Resilience.IRoutingStrategyBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.WeightedGroupsRoutingOptions, System.IServiceProvider> configure);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Resilience.StandardHedgingHandlerBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.StandardHedgingHandlerBuilderExtensions.Configure(this Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.StandardHedgingHandlerBuilderExtensions.Configure(this Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.StandardHedgingHandlerBuilderExtensions.Configure(this Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder builder, System.Action<Microsoft.Extensions.Http.Resilience.HttpStandardHedgingResilienceOptions, System.IServiceProvider> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.StandardHedgingHandlerBuilderExtensions.SelectPipelineBy(this Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder builder, System.Func<System.IServiceProvider, Microsoft.Extensions.Http.Resilience.PipelineKeySelector> selectorFactory);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder Microsoft.Extensions.Http.Resilience.StandardHedgingHandlerBuilderExtensions.SelectPipelineByAuthority(this Microsoft.Extensions.Http.Resilience.IStandardHedgingHandlerBuilder builder, Microsoft.Extensions.Compliance.Classification.DataClassification classification);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.WeightedEndpoint",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.WeightedEndpoint.WeightedEndpoint();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Uri? Microsoft.Extensions.Http.Resilience.WeightedEndpoint.Uri { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Http.Resilience.WeightedEndpoint.Weight { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.WeightedEndpointGroup : Microsoft.Extensions.Http.Resilience.EndpointGroup",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.WeightedEndpointGroup.WeightedEndpointGroup();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Http.Resilience.WeightedEndpointGroup.Weight { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode.WeightedGroupSelectionMode();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode.EveryAttempt",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode.InitialAttempt",
+          "Stage": "Stable",
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Resilience.WeightedGroupsRoutingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.WeightedGroupsRoutingOptions.WeightedGroupsRoutingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IList<Microsoft.Extensions.Http.Resilience.WeightedEndpointGroup> Microsoft.Extensions.Http.Resilience.WeightedGroupsRoutingOptions.Groups { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Resilience.WeightedGroupSelectionMode Microsoft.Extensions.Http.Resilience.WeightedGroupsRoutingOptions.SelectionMode { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Http.Telemetry/Microsoft.Extensions.Http.Telemetry.json
+++ b/src/Libraries/Microsoft.Extensions.Http.Telemetry/Microsoft.Extensions.Http.Telemetry.json
@@ -1,0 +1,338 @@
+{
+  "Name": "Microsoft.Extensions.Http.Telemetry, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryExtensions.AddDefaultHttpClientLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryExtensions.AddDefaultHttpClientLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryExtensions.AddDefaultHttpClientLatencyTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryOptions> configure);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryOptions.HttpClientLatencyTelemetryOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Http.Telemetry.Latency.HttpClientLatencyTelemetryOptions.EnableDetailedLatencyBreadkdown { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.Duration",
+          "Stage": "Stable",
+          "Value": "duration"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.Host",
+          "Stage": "Stable",
+          "Value": "httpHost"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.Method",
+          "Stage": "Stable",
+          "Value": "httpMethod"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.Path",
+          "Stage": "Stable",
+          "Value": "httpPath"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.RequestBody",
+          "Stage": "Stable",
+          "Value": "httpRequestBody"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.RequestHeaderPrefix",
+          "Stage": "Stable",
+          "Value": "httpRequestHeader_"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.ResponseBody",
+          "Stage": "Stable",
+          "Value": "httpResponseBody"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.ResponseHeaderPrefix",
+          "Stage": "Stable",
+          "Value": "httpResponseHeader_"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.StatusCode",
+          "Stage": "Stable",
+          "Value": "httpStatusCode"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingDimensions.DimensionNames { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddDefaultHttpClientLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddDefaultHttpClientLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddDefaultHttpClientLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddHttpClientLogEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddHttpClientLogging(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddHttpClientLogging(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Telemetry.Logging.HttpClientLoggingExtensions.AddHttpClientLogging(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.Action<Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions> configure);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Telemetry.Metering.HttpClientMeteringExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Metering.HttpClientMeteringExtensions.AddDefaultHttpClientMetering(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder Microsoft.Extensions.Http.Telemetry.Metering.HttpClientMeteringExtensions.AddHttpClientMetering(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Metering.HttpClientMeteringExtensions.AddOutgoingRequestMetricEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Metering.HttpClientMeteringExtensions.AddOutgoingRequestMetricEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Http.Telemetry.Metering.IOutgoingRequestMetricEnricher enricher);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTraceEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Http.Telemetry.Tracing.IHttpClientTraceEnricher enricher);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.Extensions.Http.Telemetry.Tracing.IHttpClientTraceEnricher enricher);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTracing(this OpenTelemetry.Trace.TracerProviderBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTracing(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingExtensions.AddHttpClientTracing(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingOptions.HttpClientTracingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingOptions.RequestPathParameterRedactionMode { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.Extensions.Http.Telemetry.Tracing.HttpClientTracingOptions.RouteParameterDataClasses { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Telemetry.Metering.HttpMeteringHandler : System.Net.Http.DelegatingHandler",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.Metering.HttpMeteringHandler.HttpMeteringHandler(Microsoft.Extensions.Telemetry.Metering.Meter<Microsoft.Extensions.Http.Telemetry.Metering.HttpMeteringHandler> meter, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Http.Telemetry.Metering.IOutgoingRequestMetricEnricher> enrichers);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Microsoft.Extensions.Http.Telemetry.Metering.HttpMeteringHandler.SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Telemetry.Logging.IHttpClientLogEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Http.Telemetry.Logging.IHttpClientLogEnricher.Enrich(Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag enrichmentBag, System.Net.Http.HttpRequestMessage? request = null, System.Net.Http.HttpResponseMessage? response = null);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Telemetry.Tracing.IHttpClientTraceEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Http.Telemetry.Tracing.IHttpClientTraceEnricher.Enrich(System.Diagnostics.Activity activity, System.Net.Http.HttpRequestMessage? request, System.Net.Http.HttpResponseMessage? response);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Telemetry.Tracing.IHttpPathRedactor",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "string Microsoft.Extensions.Http.Telemetry.Tracing.IHttpPathRedactor.Redact(string routeTemplate, string httpPath, System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> parametersToRedact, out int parameterCount);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Telemetry.Metering.IOutgoingRequestMetricEnricher : Microsoft.Extensions.Telemetry.Enrichment.IMetricEnricher",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Http.Telemetry.Metering.IOutgoingRequestMetricEnricher.DimensionNames { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.LoggingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.BodyReadTimeout { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.BodySizeLimit { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.LogBody { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.LogRequestStart { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.RequestBodyContentTypes { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.RequestHeadersDataClasses { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.RequestPathLoggingMode { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.RequestPathParameterRedactionMode { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.ResponseBodyContentTypes { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.ResponseHeadersDataClasses { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Compliance.Classification.DataClassification> Microsoft.Extensions.Http.Telemetry.Logging.LoggingOptions.RouteParameterDataClasses { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode.OutgoingPathLoggingMode();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode.Formatted",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode Microsoft.Extensions.Http.Telemetry.Logging.OutgoingPathLoggingMode.Structured",
+          "Stage": "Stable",
+          "Value": "1"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Options.Contextual/Microsoft.Extensions.Options.Contextual.json
+++ b/src/Libraries/Microsoft.Extensions.Options.Contextual/Microsoft.Extensions.Options.Contextual.json
@@ -1,0 +1,161 @@
+{
+  "Name": "Microsoft.Extensions.Options.Contextual, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.AddContextualOptions(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.Configure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<Microsoft.Extensions.Options.Contextual.IOptionsContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<Microsoft.Extensions.Options.Contextual.IConfigureContextualOptions<TOptions>>> loadOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.Configure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, System.Func<Microsoft.Extensions.Options.Contextual.IOptionsContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<Microsoft.Extensions.Options.Contextual.IConfigureContextualOptions<TOptions>>> loadOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.Configure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Options.Contextual.IOptionsContext, TOptions> configureOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.Configure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, System.Action<Microsoft.Extensions.Options.Contextual.IOptionsContext, TOptions> configureOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.PostConfigure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Options.Contextual.IOptionsContext, TOptions> configureOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.PostConfigure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string? name, System.Action<Microsoft.Extensions.Options.Contextual.IOptionsContext, TOptions> configureOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.PostConfigureAll<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Options.Contextual.IOptionsContext, TOptions> configureOptions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.ValidateContextualOptions<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<TOptions, bool> validate, string failureMessage);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Options.Contextual.ContextualOptionsServiceCollectionExtensions.ValidateContextualOptions<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name, System.Func<TOptions, bool> validate, string failureMessage);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IConfigureContextualOptions<in TOptions> : System.IDisposable where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Options.Contextual.IConfigureContextualOptions<TOptions>.Configure(TOptions options);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IContextualOptions<TOptions> where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask<TOptions> Microsoft.Extensions.Options.Contextual.IContextualOptions<TOptions>.GetAsync<TContext>(in TContext context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IContextualOptionsFactory<TOptions> where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask<TOptions> Microsoft.Extensions.Options.Contextual.IContextualOptionsFactory<TOptions>.CreateAsync<TContext>(string name, in TContext context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.ILoadContextualOptions<TOptions> where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask<Microsoft.Extensions.Options.Contextual.IConfigureContextualOptions<TOptions>> Microsoft.Extensions.Options.Contextual.ILoadContextualOptions<TOptions>.LoadAsync<TContext>(string name, in TContext context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.INamedContextualOptions<TOptions> : Microsoft.Extensions.Options.Contextual.IContextualOptions<TOptions> where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask<TOptions> Microsoft.Extensions.Options.Contextual.INamedContextualOptions<TOptions>.GetAsync<TContext>(string name, in TContext context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IOptionsContext",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Options.Contextual.IOptionsContext.PopulateReceiver<T>(T receiver);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IOptionsContextReceiver",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Options.Contextual.IOptionsContextReceiver.Receive<T>(string key, T value);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IPostConfigureContextualOptions<in TOptions> where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Options.Contextual.IPostConfigureContextualOptions<TOptions>.PostConfigure<TContext>(string name, in TContext context, TOptions options);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Options.Contextual.IValidateContextualOptions<in TOptions> where TOptions : class",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Options.ValidateOptionsResult Microsoft.Extensions.Options.Contextual.IValidateContextualOptions<TOptions>.Validate(string? name, TOptions options);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Options.Contextual.NullConfigureContextualOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Options.Contextual.IConfigureContextualOptions<TOptions> Microsoft.Extensions.Options.Contextual.NullConfigureContextualOptions.GetInstance<TOptions>();",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Options.Contextual.OptionsContextAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Options.Contextual.OptionsContextAttribute.OptionsContextAttribute();",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Options.Validation/Microsoft.Extensions.Options.Validation.json
+++ b/src/Libraries/Microsoft.Extensions.Options.Validation/Microsoft.Extensions.Options.Validation.json
@@ -1,0 +1,55 @@
+{
+  "Name": "Microsoft.Extensions.Options.Validation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "sealed class Microsoft.Extensions.Options.Validation.OptionsValidatorAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Options.Validation.OptionsValidatorAttribute.OptionsValidatorAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Options.Validation.ValidateEnumeratedItemsAttribute : System.Attribute",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Options.Validation.ValidateEnumeratedItemsAttribute.ValidateEnumeratedItemsAttribute();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Options.Validation.ValidateEnumeratedItemsAttribute.ValidateEnumeratedItemsAttribute(System.Type validator);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Type? Microsoft.Extensions.Options.Validation.ValidateEnumeratedItemsAttribute.Validator { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Options.Validation.ValidateObjectMembersAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Options.Validation.ValidateObjectMembersAttribute.ValidateObjectMembersAttribute();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Options.Validation.ValidateObjectMembersAttribute.ValidateObjectMembersAttribute(System.Type validator);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Type? Microsoft.Extensions.Options.Validation.ValidateObjectMembersAttribute.Validator { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.json
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.json
@@ -1,0 +1,1239 @@
+{
+  "Name": "Microsoft.Extensions.Resilience, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "enum Microsoft.Extensions.Resilience.Options.BackoffType",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BackoffType.BackoffType();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Resilience.Options.BackoffType Microsoft.Extensions.Resilience.Options.BackoffType.Constant",
+          "Stage": "Stable",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Resilience.Options.BackoffType Microsoft.Extensions.Resilience.Options.BackoffType.ExponentialWithJitter",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Resilience.Options.BackoffType Microsoft.Extensions.Resilience.Options.BackoffType.Linear",
+          "Stage": "Stable",
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.BreakActionArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BreakActionArguments.BreakActionArguments(System.Exception exception, Polly.Context context, System.TimeSpan breakDuration, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BreakActionArguments.BreakActionArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.BreakActionArguments.BreakDuration { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.BreakActionArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.BreakActionArguments.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Exception Microsoft.Extensions.Resilience.Options.BreakActionArguments.Exception { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult> : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments<TResult>, Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>.BreakActionArguments(Polly.DelegateResult<TResult> result, Polly.Context context, System.TimeSpan breakDuration, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>.BreakActionArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>.BreakDuration { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.DelegateResult<TResult> Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>.Result { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions.BulkheadPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions.MaxConcurrency { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions.MaxQueuedActions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.BulkheadTaskArguments, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions.OnBulkheadRejectedAsync { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.BulkheadTaskArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BulkheadTaskArguments.BulkheadTaskArguments(Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BulkheadTaskArguments.BulkheadTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.BulkheadTaskArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.BulkheadTaskArguments.Context { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase.ChaosPolicyOptionsBase();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase.Enabled { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "double Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase.FaultInjectionRate { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup.ChaosPolicyOptionsGroup();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.ExceptionPolicyOptions? Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup.ExceptionPolicyOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.HttpResponseInjectionPolicyOptions? Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup.HttpResponseInjectionPolicyOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.LatencyPolicyOptions? Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup.LatencyPolicyOptions { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.CircuitBreakerPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.BreakDuration { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "double Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.FailureThreshold { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.MinimumThroughput { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Action<Microsoft.Extensions.Resilience.Options.BreakActionArguments> Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.OnCircuitBreak { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Action<Microsoft.Extensions.Resilience.Options.ResetActionArguments> Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.OnCircuitReset { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.SamplingDuration { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<System.Exception> Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions.ShouldHandleException { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<TResult> : Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<TResult>.CircuitBreakerPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Action<Microsoft.Extensions.Resilience.Options.BreakActionArguments<TResult>> Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<TResult>.OnCircuitBreak { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<TResult> Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<TResult>.ShouldHandleResultAsError { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.ExceptionPolicyOptions : Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.ExceptionPolicyOptions.ExceptionPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Resilience.FaultInjection.ExceptionPolicyOptions.ExceptionKey { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.FailureResultContext",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FailureResultContext.FailureResultContext();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.FailureResultContext Microsoft.Extensions.Resilience.FailureResultContext.Create(string failureSource = \"unknown\", string failureReason = \"unknown\", string additionalInformation = \"unknown\");",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Resilience.FailureResultContext.AdditionalInformation { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Resilience.FailureResultContext.FailureReason { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Resilience.FailureResultContext.FailureSource { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions.FallbackPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.FallbackTaskArguments, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions.OnFallbackAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<System.Exception> Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions.ShouldHandleException { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<TResult> : Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<TResult>.FallbackPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult>, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<TResult>.OnFallbackAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<TResult> Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<TResult>.ShouldHandleResultAsError { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments.FallbackScenarioTaskArguments(Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments.FallbackScenarioTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments.Context { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "delegate System.Threading.Tasks.Task Microsoft.Extensions.Resilience.FallbackScenarioTaskProvider(Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments args)",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "delegate System.Threading.Tasks.Task<TResult> Microsoft.Extensions.Resilience.FallbackScenarioTaskProvider<TResult>(Microsoft.Extensions.Resilience.Options.FallbackScenarioTaskArguments args)",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.FallbackTaskArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackTaskArguments.FallbackTaskArguments(System.Exception exception, Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackTaskArguments.FallbackTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.FallbackTaskArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.FallbackTaskArguments.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Exception Microsoft.Extensions.Resilience.Options.FallbackTaskArguments.Exception { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult> : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments<TResult>, Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult>.FallbackTaskArguments(Polly.DelegateResult<TResult> result, Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult>.FallbackTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult>.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult>.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.DelegateResult<TResult> Microsoft.Extensions.Resilience.Options.FallbackTaskArguments<TResult>.Result { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions.AddFaultInjection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions.AddFaultInjection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions.AddFaultInjection(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static string? Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions.GetFaultInjectionGroupName(this Polly.Context context);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Polly.Context Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions.WithFaultInjection(this Polly.Context context, string groupName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Polly.Context Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionExtensions.WithFaultInjection(this Polly.Context context, Microsoft.Extensions.Resilience.FaultInjection.FaultPolicyWeightAssignmentsOptions weightAssignments);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptions.FaultInjectionOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup> Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptions.ChaosPolicyOptionsGroups { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder.FaultInjectionOptionsBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder.AddException(string key, System.Exception exception);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder.Configure();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder.Configure(Microsoft.Extensions.Configuration.IConfiguration section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptionsBuilder.Configure(System.Action<Microsoft.Extensions.Resilience.FaultInjection.FaultInjectionOptions> configureOptions);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.FaultPolicyWeightAssignmentsOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.FaultPolicyWeightAssignmentsOptions.FaultPolicyWeightAssignmentsOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, double> Microsoft.Extensions.Resilience.FaultInjection.FaultPolicyWeightAssignmentsOptions.WeightAssignments { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "delegate bool Microsoft.Extensions.Resilience.HedgedTaskProvider(Microsoft.Extensions.Resilience.HedgingTaskProviderArguments args, out System.Threading.Tasks.Task? result)",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "delegate bool Microsoft.Extensions.Resilience.HedgedTaskProvider<TResult>(Microsoft.Extensions.Resilience.HedgingTaskProviderArguments args, out System.Threading.Tasks.Task<TResult>? result)",
+      "Stage": "Stable"
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.HedgingDelayArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingDelayArguments.HedgingDelayArguments(Polly.Context context, int attemptNumber, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingDelayArguments.HedgingDelayArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.HedgingDelayArguments.AttemptNumber { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.HedgingDelayArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.HedgingDelayArguments.Context { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.HedgingPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "static readonly System.TimeSpan Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.InfiniteHedgingDelay",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.HedgingDelay { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.HedgingDelayArguments, System.TimeSpan>? Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.HedgingDelayGenerator { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.MaxHedgedAttempts { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.HedgingTaskArguments, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.OnHedgingAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<System.Exception> Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions.ShouldHandleException { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<TResult> : Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<TResult>.HedgingPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<TResult>.OnHedgingAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<TResult> Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<TResult>.ShouldHandleResultAsError { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.HedgingTaskArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingTaskArguments.HedgingTaskArguments(System.Exception exception, Polly.Context context, int attemptNumber, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingTaskArguments.HedgingTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.HedgingTaskArguments.AttemptNumber { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.HedgingTaskArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.HedgingTaskArguments.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Exception Microsoft.Extensions.Resilience.Options.HedgingTaskArguments.Exception { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult> : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments<TResult>, Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>.HedgingTaskArguments(Polly.DelegateResult<TResult> result, Polly.Context context, int attemptNumber, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>.HedgingTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>.AttemptNumber { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.DelegateResult<TResult> Microsoft.Extensions.Resilience.Options.HedgingTaskArguments<TResult>.Result { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.HedgingTaskProviderArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.HedgingTaskProviderArguments.HedgingTaskProviderArguments(Polly.Context context, int attemptNumber, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.HedgingTaskProviderArguments.HedgingTaskProviderArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.HedgingTaskProviderArguments.AttemptNumber { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.HedgingTaskProviderArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.HedgingTaskProviderArguments.Context { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.HttpResponseInjectionPolicyOptions : Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.HttpResponseInjectionPolicyOptions.HttpResponseInjectionPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.Resilience.FaultInjection.HttpResponseInjectionPolicyOptions.HttpContentKey { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Net.HttpStatusCode Microsoft.Extensions.Resilience.FaultInjection.HttpResponseInjectionPolicyOptions.StatusCode { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Resilience.FaultInjection.IChaosPolicyFactory",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Polly.Contrib.Simmy.Outcomes.AsyncInjectOutcomePolicy Microsoft.Extensions.Resilience.FaultInjection.IChaosPolicyFactory.CreateExceptionPolicy();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Contrib.Simmy.Latency.AsyncInjectLatencyPolicy<TResult> Microsoft.Extensions.Resilience.FaultInjection.IChaosPolicyFactory.CreateLatencyPolicy<TResult>();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Resilience.FaultInjection.IFaultInjectionOptionsProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "bool Microsoft.Extensions.Resilience.FaultInjection.IFaultInjectionOptionsProvider.TryGetChaosPolicyOptionsGroup(string optionsGroupName, out Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsGroup? optionsGroup);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.InjectedFaultException : System.Exception",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.InjectedFaultException.InjectedFaultException();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.InjectedFaultException.InjectedFaultException(string message);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.InjectedFaultException.InjectedFaultException(string message, System.Exception innerException);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult>",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult>.PipelineName { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult>.Services { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Resilience.IResiliencePipelineProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Polly.IAsyncPolicy<TResult> Microsoft.Extensions.Resilience.IResiliencePipelineProvider.GetPipeline<TResult>(string pipelineName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.IAsyncPolicy<TResult> Microsoft.Extensions.Resilience.IResiliencePipelineProvider.GetPipeline<TResult>(string pipelineName, string pipelineKey);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.FaultInjection.LatencyPolicyOptions : Microsoft.Extensions.Resilience.FaultInjection.ChaosPolicyOptionsBase",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.FaultInjection.LatencyPolicyOptions.LatencyPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.FaultInjection.LatencyPolicyOptions.Latency { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Resilience.PollyServiceCollectionExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Resilience.PollyServiceCollectionExtensions.ConfigureFailureResultContext<TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<TResult, Microsoft.Extensions.Resilience.FailureResultContext> configure);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.ResetActionArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.ResetActionArguments.ResetActionArguments(Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.ResetActionArguments.ResetActionArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.ResetActionArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.ResetActionArguments.Context { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Resilience.ResilienceDimensions",
+      "Stage": "Experimental",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.DependencyName",
+          "Stage": "Experimental",
+          "Value": "dep_name"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.EventName",
+          "Stage": "Experimental",
+          "Value": "event_name"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.FailureReason",
+          "Stage": "Experimental",
+          "Value": "failure_reason"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.FailureSource",
+          "Stage": "Experimental",
+          "Value": "failure_source"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.FailureSummary",
+          "Stage": "Experimental",
+          "Value": "failure_summary"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.PipelineKey",
+          "Stage": "Experimental",
+          "Value": "pipeline_key"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.PipelineName",
+          "Stage": "Experimental",
+          "Value": "pipeline_name"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.PolicyName",
+          "Stage": "Experimental",
+          "Value": "policy_name"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.RequestName",
+          "Stage": "Experimental",
+          "Value": "req_name"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Resilience.ResilienceDimensions.ResultType",
+          "Stage": "Experimental",
+          "Value": "result_type"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Resilience.ResilienceDimensions.DimensionNames { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddBulkheadPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddBulkheadPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, System.Action<Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddBulkheadPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddBulkheadPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Resilience.Options.BulkheadPolicyOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddCircuitBreakerPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddCircuitBreakerPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, System.Action<Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddCircuitBreakerPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddCircuitBreakerPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Resilience.Options.CircuitBreakerPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddFallbackPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.FallbackScenarioTaskProvider<TResult> provider);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddFallbackPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.FallbackScenarioTaskProvider<TResult> provider, System.Action<Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddFallbackPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.FallbackScenarioTaskProvider<TResult> provider, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddFallbackPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.FallbackScenarioTaskProvider<TResult> provider, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Resilience.Options.FallbackPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddHedgingPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.HedgedTaskProvider<TResult> provider);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddHedgingPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.HedgedTaskProvider<TResult> provider, System.Action<Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddHedgingPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.HedgedTaskProvider<TResult> provider, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddHedgingPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Resilience.HedgedTaskProvider<TResult> provider, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Resilience.Options.HedgingPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddRetryPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddRetryPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, System.Action<Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddRetryPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddRetryPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult>> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddTimeoutPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddTimeoutPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, System.Action<Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddTimeoutPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> Microsoft.Extensions.Resilience.ResiliencePipelineBuilderExtensions.AddTimeoutPolicy<TResult>(this Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TResult> builder, string policyName, Microsoft.Extensions.Configuration.IConfigurationSection section, System.Action<Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions> configure);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Resilience.ResilienceWrapperAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.ResilienceWrapperAttribute.ResilienceWrapperAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.RetryActionArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryActionArguments.RetryActionArguments(System.Exception exception, Polly.Context context, System.TimeSpan waitingTimeInterval, int attemptNumber, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryActionArguments.RetryActionArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.RetryActionArguments.AttemptNumber { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.RetryActionArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.RetryActionArguments.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Exception Microsoft.Extensions.Resilience.Options.RetryActionArguments.Exception { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.RetryActionArguments.WaitingTimeInterval { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult> : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments<TResult>, Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.RetryActionArguments(Polly.DelegateResult<TResult> result, Polly.Context context, System.TimeSpan waitingTimeInterval, int attemptNumber, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.RetryActionArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.AttemptNumber { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.DelegateResult<TResult> Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.Result { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>.WaitingTimeInterval { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult> : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments<TResult>, Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult>.RetryDelayArguments(Polly.DelegateResult<TResult> result, Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult>.RetryDelayArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult>.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult>.Context { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.DelegateResult<TResult> Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult>.Result { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.RetryPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.RetryPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const int Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.InfiniteRetry",
+          "Stage": "Stable",
+          "Value": "-1"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.BackoffType Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.BackoffType { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.BaseDelay { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.RetryActionArguments, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.OnRetryAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.RetryCount { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<System.Exception> Microsoft.Extensions.Resilience.Options.RetryPolicyOptions.ShouldHandleException { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult> : Microsoft.Extensions.Resilience.Options.RetryPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult>.RetryPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.RetryActionArguments<TResult>, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult>.OnRetryAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.RetryDelayArguments<TResult>, System.TimeSpan>? Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult>.RetryDelayGenerator { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Predicate<TResult> Microsoft.Extensions.Resilience.Options.RetryPolicyOptions<TResult>.ShouldHandleResultAsError { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Resilience.RetryPolicyOptionsExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static System.Collections.Generic.IEnumerable<System.TimeSpan> Microsoft.Extensions.Resilience.RetryPolicyOptionsExtensions.GetDelays(this Microsoft.Extensions.Resilience.Options.RetryPolicyOptions options);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Resilience.ServiceCollectionExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Resilience.IResiliencePipelineBuilder<TPolicyResult> Microsoft.Extensions.Resilience.ServiceCollectionExtensions.AddResiliencePipeline<TPolicyResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string pipelineName);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions.TimeoutPolicyOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Func<Microsoft.Extensions.Resilience.Options.TimeoutTaskArguments, System.Threading.Tasks.Task> Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions.OnTimedOutAsync { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions.TimeoutInterval { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Timeout.TimeoutStrategy Microsoft.Extensions.Resilience.Options.TimeoutPolicyOptions.TimeoutStrategy { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Resilience.Options.TimeoutTaskArguments : Microsoft.Extensions.Resilience.Options.IPolicyEventArguments",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.TimeoutTaskArguments.TimeoutTaskArguments(Polly.Context context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Resilience.Options.TimeoutTaskArguments.TimeoutTaskArguments();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Threading.CancellationToken Microsoft.Extensions.Resilience.Options.TimeoutTaskArguments.CancellationToken { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Polly.Context Microsoft.Extensions.Resilience.Options.TimeoutTaskArguments.Context { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Microsoft.Extensions.Telemetry.Abstractions.json
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Microsoft.Extensions.Telemetry.Abstractions.json
@@ -1,0 +1,879 @@
+{
+  "Name": "Microsoft.Extensions.Telemetry.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.Checkpoint : System.IEquatable<Microsoft.Extensions.Telemetry.Latency.Checkpoint>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.Checkpoint.Checkpoint(string name, long elapsed, long frequency);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.Checkpoint.Checkpoint();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.Telemetry.Latency.Checkpoint.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Latency.Checkpoint.Equals(Microsoft.Extensions.Telemetry.Latency.Checkpoint other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Telemetry.Latency.Checkpoint.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Telemetry.Latency.Checkpoint.operator ==(Microsoft.Extensions.Telemetry.Latency.Checkpoint left, Microsoft.Extensions.Telemetry.Latency.Checkpoint right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Telemetry.Latency.Checkpoint.operator !=(Microsoft.Extensions.Telemetry.Latency.Checkpoint left, Microsoft.Extensions.Telemetry.Latency.Checkpoint right);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "long Microsoft.Extensions.Telemetry.Latency.Checkpoint.Elapsed { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "long Microsoft.Extensions.Telemetry.Latency.Checkpoint.Frequency { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.Checkpoint.Name { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.CheckpointToken",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.CheckpointToken.CheckpointToken(string name, int position);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.CheckpointToken.CheckpointToken();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.CheckpointToken.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Latency.CheckpointToken.Position { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Metering.CounterAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.CounterAttribute.CounterAttribute(params string[] dimensions);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.CounterAttribute.CounterAttribute(System.Type type);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string[]? Microsoft.Extensions.Telemetry.Metering.CounterAttribute.Dimensions { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Metering.CounterAttribute.Name { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Type? Microsoft.Extensions.Telemetry.Metering.CounterAttribute.Type { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Metering.CounterAttribute<T> : System.Attribute where T : struct",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.CounterAttribute<T>.CounterAttribute(params string[] dimensions);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.CounterAttribute<T>.CounterAttribute(System.Type type);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string[]? Microsoft.Extensions.Telemetry.Metering.CounterAttribute<T>.Dimensions { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Metering.CounterAttribute<T>.Name { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Type? Microsoft.Extensions.Telemetry.Metering.CounterAttribute<T>.Type { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Metering.DimensionAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.DimensionAttribute.DimensionAttribute(string name);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Metering.DimensionAttribute.Name { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Enrichment.EnricherExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.EnricherExtensions.AddLogEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.EnricherExtensions.AddLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Telemetry.Enrichment.ILogEnricher enricher);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.EnricherExtensions.AddMetricEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.EnricherExtensions.AddMetricEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Telemetry.Enrichment.IMetricEnricher enricher);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Metering.GaugeAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.GaugeAttribute.GaugeAttribute(params string[] dimensions);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.GaugeAttribute.GaugeAttribute(System.Type type);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string[]? Microsoft.Extensions.Telemetry.Metering.GaugeAttribute.Dimensions { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Metering.GaugeAttribute.Name { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Type? Microsoft.Extensions.Telemetry.Metering.GaugeAttribute.Type { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Metering.HistogramAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.HistogramAttribute.HistogramAttribute(params string[] dimensions);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.HistogramAttribute.HistogramAttribute(System.Type type);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string[]? Microsoft.Extensions.Telemetry.Metering.HistogramAttribute.Dimensions { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Metering.HistogramAttribute.Name { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Type? Microsoft.Extensions.Telemetry.Metering.HistogramAttribute.Type { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Metering.HistogramAttribute<T> : System.Attribute where T : struct",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.HistogramAttribute<T>.HistogramAttribute(params string[] dimensions);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.HistogramAttribute<T>.HistogramAttribute(System.Type type);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string[]? Microsoft.Extensions.Telemetry.Metering.HistogramAttribute<T>.Dimensions { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Metering.HistogramAttribute<T>.Name { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Type? Microsoft.Extensions.Telemetry.Metering.HistogramAttribute<T>.Type { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode.HttpRouteParameterRedactionMode();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode.Loose",
+          "Stage": "Stable",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode.None",
+          "Stage": "Stable",
+          "Value": "2"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode Microsoft.Extensions.Http.Telemetry.HttpRouteParameterRedactionMode.Strict",
+          "Stage": "Stable",
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Telemetry.IDownstreamDependencyMetadata",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.Telemetry.IDownstreamDependencyMetadata.DependencyName { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<Microsoft.Extensions.Http.Telemetry.RequestMetadata> Microsoft.Extensions.Http.Telemetry.IDownstreamDependencyMetadata.RequestMetadata { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.Extensions.Http.Telemetry.IDownstreamDependencyMetadata.UniqueHostNameSuffixes { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag.Add(string key, object value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag.Add(string key, string value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag.Add(System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> properties);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag.Add(System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, string>> properties);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Latency.ILatencyContext : System.IDisposable",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Latency.ILatencyContext.AddCheckpoint(Microsoft.Extensions.Telemetry.Latency.CheckpointToken token);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Latency.ILatencyContext.AddMeasure(Microsoft.Extensions.Telemetry.Latency.MeasureToken token, long value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Latency.ILatencyContext.Freeze();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Latency.ILatencyContext.RecordMeasure(Microsoft.Extensions.Telemetry.Latency.MeasureToken token, long value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Latency.ILatencyContext.SetTag(Microsoft.Extensions.Telemetry.Latency.TagToken token, string value);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.LatencyData Microsoft.Extensions.Telemetry.Latency.ILatencyContext.LatencyData { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Latency.ILatencyContextProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.ILatencyContext Microsoft.Extensions.Telemetry.Latency.ILatencyContextProvider.CreateContext();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Latency.ILatencyContextTokenIssuer",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.CheckpointToken Microsoft.Extensions.Telemetry.Latency.ILatencyContextTokenIssuer.GetCheckpointToken(string name);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.MeasureToken Microsoft.Extensions.Telemetry.Latency.ILatencyContextTokenIssuer.GetMeasureToken(string name);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.TagToken Microsoft.Extensions.Telemetry.Latency.ILatencyContextTokenIssuer.GetTagToken(string name);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Latency.ILatencyDataExporter",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task Microsoft.Extensions.Telemetry.Latency.ILatencyDataExporter.ExportAsync(Microsoft.Extensions.Telemetry.Latency.LatencyData data, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Enrichment.ILogEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.ILogEnricher.Enrich(Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag bag);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Logging.ILogPropertyCollector",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Logging.ILogPropertyCollector.Add(string propertyName, object? propertyValue);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Enrichment.IMetricEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.IMetricEnricher.Enrich(Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag bag);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Http.Telemetry.IOutgoingRequestContext",
+      "Stage": "Stable",
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.RequestMetadata? Microsoft.Extensions.Http.Telemetry.IOutgoingRequestContext.RequestMetadata { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "interface Microsoft.Extensions.Telemetry.Enrichment.ITraceEnricher",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.ITraceEnricher.Enrich(System.Diagnostics.Activity activity);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Enrichment.ITraceEnricher.EnrichOnActivityStart(System.Diagnostics.Activity activity);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Latency.LatencyContextRegistrationOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.LatencyContextRegistrationOptions.LatencyContextRegistrationOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Telemetry.Latency.LatencyContextRegistrationOptions.CheckpointNames { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Telemetry.Latency.LatencyContextRegistrationOptions.MeasureNames { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Telemetry.Latency.LatencyContextRegistrationOptions.TagNames { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.LatencyData",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.LatencyData.LatencyData(System.ArraySegment<Microsoft.Extensions.Telemetry.Latency.Tag> tags, System.ArraySegment<Microsoft.Extensions.Telemetry.Latency.Checkpoint> checkpoints, System.ArraySegment<Microsoft.Extensions.Telemetry.Latency.Measure> measures, long durationTimestamp, long durationTimestampFrequency);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.LatencyData.LatencyData();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.ReadOnlySpan<Microsoft.Extensions.Telemetry.Latency.Checkpoint> Microsoft.Extensions.Telemetry.Latency.LatencyData.Checkpoints { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "long Microsoft.Extensions.Telemetry.Latency.LatencyData.DurationTimestamp { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "long Microsoft.Extensions.Telemetry.Latency.LatencyData.DurationTimestampFrequency { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.ReadOnlySpan<Microsoft.Extensions.Telemetry.Latency.Measure> Microsoft.Extensions.Telemetry.Latency.LatencyData.Measures { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.ReadOnlySpan<Microsoft.Extensions.Telemetry.Latency.Tag> Microsoft.Extensions.Telemetry.Latency.LatencyData.Tags { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Latency.LatencyRegistryExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.LatencyRegistryExtensions.RegisterCheckpointNames(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] names);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.LatencyRegistryExtensions.RegisterMeasureNames(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] names);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.LatencyRegistryExtensions.RegisterTagNames(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params string[] names);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(int eventId, Microsoft.Extensions.Logging.LogLevel level, string message);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(int eventId, Microsoft.Extensions.Logging.LogLevel level);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(Microsoft.Extensions.Logging.LogLevel level, string message);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(Microsoft.Extensions.Logging.LogLevel level);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(string message);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(int eventId, string message);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute(int eventId);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.LogMethodAttribute();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.EventId { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.EventName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Logging.LogLevel? Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.Level { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.Message { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LogMethodAttribute.SkipEnabledCheck { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Logging.LogMethodHelper : System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object?>>, Microsoft.Extensions.Telemetry.Logging.ILogPropertyCollector, Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag, Microsoft.Extensions.ObjectPool.IResettable",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.LogMethodHelper();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.Add(string propertyName, object? propertyValue);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Telemetry.Logging.LogMethodHelper Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.GetHelper();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static void Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.ReturnHelper(Microsoft.Extensions.Telemetry.Logging.LogMethodHelper helper);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static string Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.Stringify(System.Collections.IEnumerable? enumerable);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static string Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.Stringify<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>? enumerable);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.TryReset();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.ParameterName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.LogDefineOptions Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.SkipEnabledCheckOptions { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute.LogPropertiesAttribute();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute.LogPropertiesAttribute(System.Type providerType, string providerMethod);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute.OmitParameterName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute.ProviderMethod { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Type? Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute.ProviderType { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LogPropertiesAttribute.SkipNullProperties { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Logging.LogPropertyIgnoreAttribute : System.Attribute",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LogPropertyIgnoreAttribute.LogPropertyIgnoreAttribute();",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.Measure : System.IEquatable<Microsoft.Extensions.Telemetry.Latency.Measure>",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.Measure.Measure(string name, long value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.Measure.Measure();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override bool Microsoft.Extensions.Telemetry.Latency.Measure.Equals(object? obj);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Latency.Measure.Equals(Microsoft.Extensions.Telemetry.Latency.Measure other);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override int Microsoft.Extensions.Telemetry.Latency.Measure.GetHashCode();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Telemetry.Latency.Measure.operator ==(Microsoft.Extensions.Telemetry.Latency.Measure left, Microsoft.Extensions.Telemetry.Latency.Measure right);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static bool Microsoft.Extensions.Telemetry.Latency.Measure.operator !=(Microsoft.Extensions.Telemetry.Latency.Measure left, Microsoft.Extensions.Telemetry.Latency.Measure right);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.Measure.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "long Microsoft.Extensions.Telemetry.Latency.Measure.Value { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.MeasureToken",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.MeasureToken.MeasureToken(string name, int position);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.MeasureToken.MeasureToken();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.MeasureToken.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Latency.MeasureToken.Position { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Metering.Meter<TMeterName> : System.Diagnostics.Metrics.Meter",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.Meter<TMeterName>.Meter();",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Metering.MeteringExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Metering.MeteringExtensions.RegisterMetering(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Latency.NullLatencyContextExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.NullLatencyContextExtensions.AddNullLatencyContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Http.Telemetry.RequestMetadata",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestMetadata();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestMetadata(string methodType, string requestRoute, string requestName = \"unknown\");",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Http.Telemetry.RequestMetadata.DependencyName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.Telemetry.RequestMetadata.MethodType { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestRoute { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.Tag",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.Tag.Tag(string name, string value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.Tag.Tag();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.Tag.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.Tag.Value { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct Microsoft.Extensions.Telemetry.Latency.TagToken",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.TagToken.TagToken(string name, int position);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.TagToken.TagToken();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Latency.TagToken.Name { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Latency.TagToken.Position { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Http.Telemetry.TelemetryConstants",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.TelemetryConstants.ClientApplicationNameHeader",
+          "Stage": "Experimental",
+          "Value": "X-ClientApplication"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.TelemetryConstants.Redacted",
+          "Stage": "Stable",
+          "Value": "REDACTED"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.TelemetryConstants.RequestMetadataKey",
+          "Stage": "Stable",
+          "Value": "R9-RequestMetadata"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.TelemetryConstants.ServerApplicationNameHeader",
+          "Stage": "Experimental",
+          "Value": "X-ServerApplication"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Http.Telemetry.TelemetryConstants.Unknown",
+          "Stage": "Stable",
+          "Value": "unknown"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Console/Microsoft.Extensions.Telemetry.Console.json
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Console/Microsoft.Extensions.Telemetry.Console.json
@@ -1,0 +1,141 @@
+{
+  "Name": "Microsoft.Extensions.Telemetry.Console, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Console.LarencyConsoleOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Console.LarencyConsoleOptions.LarencyConsoleOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LarencyConsoleOptions.OutputCheckpoints { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LarencyConsoleOptions.OutputMeasures { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LarencyConsoleOptions.OutputTags { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Console.LatencyConsoleExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Console.LatencyConsoleExtensions.AddConsoleLatencyDataExporter(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Console.LatencyConsoleExtensions.AddConsoleLatencyDataExporter(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Console.LarencyConsoleOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Console.LatencyConsoleExtensions.AddConsoleLatencyDataExporter(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Console.LoggingConsoleExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Console.LoggingConsoleExtensions.AddConsoleExporter(this Microsoft.Extensions.Logging.ILoggingBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Console.LoggingConsoleExtensions.AddConsoleExporter(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions> configure);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Console.LoggingConsoleExtensions.AddConsoleExporter(this Microsoft.Extensions.Logging.ILoggingBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.LoggingConsoleOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.ColorsEnabled { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.ConsoleColor? Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.DimmedBackgroundColor { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.ConsoleColor Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.DimmedColor { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.ConsoleColor? Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.ExceptionBackgroundColor { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.ConsoleColor Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.ExceptionColor { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.ConsoleColor? Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.ExceptionStackTraceBackgroundColor { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.ConsoleColor Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.ExceptionStackTraceColor { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeCategory { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeExceptionStacktrace { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeLogLevel { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeScopes { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeSpanId { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeTimestamp { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.IncludeTraceId { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.TimestampFormat { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Console.LoggingConsoleOptions.UseUtcTimestamp { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Testing/Microsoft.Extensions.Telemetry.Testing.json
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Testing/Microsoft.Extensions.Telemetry.Testing.json
@@ -1,0 +1,433 @@
+{
+  "Name": "Microsoft.Extensions.Telemetry.Testing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.FakeLogCollector(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions> options);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.FakeLogCollector();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.Clear();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.Create(Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions options);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord> Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.GetSnapshot();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.Count { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector.LatestRecord { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.FakeLogCollectorOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.CollectRecordsForDisabledLogLevels { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<string> Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.FilteredCategories { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.ISet<Microsoft.Extensions.Logging.LogLevel> Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.FilteredLevels { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Func<Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord, string> Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.OutputFormatter { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Action<string>? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.OutputSink { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeProvider Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions.TimeProvider { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger : Microsoft.Extensions.Logging.ILogger",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.FakeLogger(Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector? collector = null, string? category = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.FakeLogger(System.Action<string> outputSink, string? category = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.IDisposable? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.BeginScope<TState>(TState state);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.ControlLevel(Microsoft.Extensions.Logging.LogLevel logLevel, bool enabled);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.Category { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.Collector { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger.LatestRecord { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger<T> : Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger, Microsoft.Extensions.Logging.ILogger<T>, Microsoft.Extensions.Logging.ILogger",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger<T>.FakeLogger(Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector? collector = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger<T>.FakeLogger(System.Action<string> outputSink);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.AddFakeLogging(this Microsoft.Extensions.Logging.ILoggingBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.AddFakeLogging(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.AddFakeLogging(this Microsoft.Extensions.Logging.ILoggingBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.AddFakeLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.AddFakeLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollectorOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.AddFakeLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerExtensions.GetFakeLogCollector(this System.IServiceProvider services);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable, Microsoft.Extensions.Logging.ISupportExternalScope",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.FakeLoggerProvider(Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector? collector = null);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.CreateLogger(string? categoryName);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.Dispose();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "virtual void Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.Dispose(bool disposing);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.~FakeLoggerProvider();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider);",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogCollector Microsoft.Extensions.Telemetry.Testing.Logging.FakeLoggerProvider.Collector { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.FakeLogRecord(Microsoft.Extensions.Logging.LogLevel level, Microsoft.Extensions.Logging.EventId id, object? state, System.Exception? exception, string message, System.Collections.Generic.IReadOnlyList<object?> scopes, string? category, bool enabled, System.DateTimeOffset timestamp);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.ToString();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Category { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Exception? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Exception { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Logging.EventId Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Id { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Logging.LogLevel Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Level { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.LevelEnabled { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Message { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<object?> Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Scopes { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "object? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.State { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, string?>>? Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.StructuredState { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.DateTimeOffset Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogRecord.Timestamp { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector : System.IDisposable",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.MetricCollector(System.Collections.Generic.IEnumerable<string> meterNames, System.TimeProvider? timeProvider = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.MetricCollector(System.TimeProvider? timeProvider = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.MetricCollector(System.Diagnostics.Metrics.Meter meter, System.TimeProvider? timeProvider = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.Clear();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.CollectObservableInstruments();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.Dispose();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual void Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.Dispose(bool disposing);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetAllCounters<T>();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetAllHistograms<T>();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetAllObservableCounters<T>();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetAllObservableGauges<T>();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetAllObservableUpDownCounters<T>();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetAllUpDownCounters<T>();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetCounterValue<T>(string counterName, params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetCounterValues<T>(string counterName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetHistogramValue<T>(string histogramName, params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetHistogramValues<T>(string histogramName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetObservableCounterValue<T>(string observableCounterName, params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetObservableCounterValues<T>(string observableCounterName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetObservableGaugeValue<T>(string observableGaugeName, params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetObservableGaugeValues<T>(string observableGaugeName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetObservableUpDownCounterValue<T>(string observableUpDownCounterName, params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetObservableUpDownCounterValues<T>(string observableUpDownCounterName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetUpDownCounterValue<T>(string updownCounterName, params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector.GetUpDownCounterValues<T>(string updownCounterName);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector<TMeterName> : Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector<TMeterName>.MetricCollector();",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T> where T : struct",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "object? Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T>.GetDimension(string dimensionName);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object?>> Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T>.Tags { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.DateTimeOffset Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T>.Timestamp { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T>.Value { get; internal set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T> where T : struct",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "void Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>.Clear();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>.GetValue(params System.Collections.Generic.KeyValuePair<string, object?>[] tags);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyCollection<Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T>> Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>.AllValues { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Testing.Metering.MetricValue<T>? Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>.LatestWritten { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>.LatestWrittenValue { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string Microsoft.Extensions.Telemetry.Testing.Metering.MetricValuesHolder<T>.MetricName { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.json
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.json
@@ -1,0 +1,567 @@
+{
+  "Name": "Microsoft.Extensions.Telemetry, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Metering.EventCountersCollectorOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.EventCountersCollectorOptions.EventCountersCollectorOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, System.Collections.Generic.ISet<string>> Microsoft.Extensions.Telemetry.Metering.EventCountersCollectorOptions.Counters { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Telemetry.Metering.EventCountersCollectorOptions.EventListenerRecyclingInterval { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "System.TimeSpan Microsoft.Extensions.Telemetry.Metering.EventCountersCollectorOptions.SamplingInterval { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Metering.EventCountersExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Metering.EventCountersExtensions.AddEventCounterCollector(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Metering.EventCountersCollectorOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Metering.EventCountersExtensions.AddEventCounterCollector(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Latency.LatencyContextExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.LatencyContextExtensions.AddLatencyContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.LatencyContextExtensions.AddLatencyContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Latency.LatencyContextOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Latency.LatencyContextExtensions.AddLatencyContext(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Latency.LatencyContextOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Latency.LatencyContextOptions.LatencyContextOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Latency.LatencyContextOptions.ThrowOnUnregisteredNames { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Logging.LoggingExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Logging.LoggingExtensions.AddOpenTelemetryLogging(this Microsoft.Extensions.Logging.ILoggingBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Logging.LoggingExtensions.AddOpenTelemetryLogging(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Telemetry.Logging.LoggingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Logging.LoggingExtensions.AddOpenTelemetryLogging(this Microsoft.Extensions.Logging.ILoggingBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Logging.LoggingExtensions.AddProcessor(this Microsoft.Extensions.Logging.ILoggingBuilder builder, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord> processor);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Logging.ILoggingBuilder Microsoft.Extensions.Telemetry.Logging.LoggingExtensions.AddProcessor<T>(this Microsoft.Extensions.Logging.ILoggingBuilder builder);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Logging.LoggingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Logging.LoggingOptions.LoggingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LoggingOptions.IncludeScopes { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LoggingOptions.IncludeStackTrace { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Logging.LoggingOptions.MaxStackTraceLength { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Logging.LoggingOptions.UseFormattedMessage { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Metering.MeteringOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.MeteringOptions.MeteringOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Metering.MeteringOptions.MaxMetricPointsPerStream { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int Microsoft.Extensions.Telemetry.Metering.MeteringOptions.MaxMetricStreams { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.MeteringState Microsoft.Extensions.Telemetry.Metering.MeteringOptions.MeterState { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Telemetry.Metering.MeteringState> Microsoft.Extensions.Telemetry.Metering.MeteringOptions.MeterStateOverrides { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Telemetry.Metering.MeteringState",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Metering.MeteringState.MeteringState();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Telemetry.Metering.MeteringState Microsoft.Extensions.Telemetry.Metering.MeteringState.Disabled",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Telemetry.Metering.MeteringState Microsoft.Extensions.Telemetry.Metering.MeteringState.Enabled",
+          "Stage": "Stable",
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Metering.OTelMeteringExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static OpenTelemetry.Metrics.MeterProviderBuilder Microsoft.Extensions.Telemetry.Metering.OTelMeteringExtensions.AddMetering(this OpenTelemetry.Metrics.MeterProviderBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection configurationSection);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static OpenTelemetry.Metrics.MeterProviderBuilder Microsoft.Extensions.Telemetry.Metering.OTelMeteringExtensions.AddMetering(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Microsoft.Extensions.Telemetry.Metering.MeteringOptions>? configure = null);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Tracing.ParentBasedSamplerOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.ParentBasedSamplerOptions.ParentBasedSamplerOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.SamplerType Microsoft.Extensions.Telemetry.Tracing.ParentBasedSamplerOptions.RootSamplerType { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherDimensions",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherDimensions.ProcessId",
+          "Stage": "Stable",
+          "Value": "pid"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherDimensions.ThreadId",
+          "Stage": "Stable",
+          "Value": "tid"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherDimensions.DimensionNames { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherExtensions.AddProcessLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherExtensions.AddProcessLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Enrichment.ProcessLogEnricherOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ProcessEnricherExtensions.AddProcessLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Enrichment.ProcessLogEnricherOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Enrichment.ProcessLogEnricherOptions.ProcessLogEnricherOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ProcessLogEnricherOptions.ProcessId { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ProcessLogEnricherOptions.ThreadId { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "enum Microsoft.Extensions.Telemetry.Tracing.SamplerType",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.SamplerType.SamplerType();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Telemetry.Tracing.SamplerType Microsoft.Extensions.Telemetry.Tracing.SamplerType.AlwaysOff",
+          "Stage": "Stable",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Telemetry.Tracing.SamplerType Microsoft.Extensions.Telemetry.Tracing.SamplerType.AlwaysOn",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Telemetry.Tracing.SamplerType Microsoft.Extensions.Telemetry.Tracing.SamplerType.ParentBased",
+          "Stage": "Stable",
+          "Value": "3"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Telemetry.Tracing.SamplerType Microsoft.Extensions.Telemetry.Tracing.SamplerType.TraceIdRatioBased",
+          "Stage": "Stable",
+          "Value": "2"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Tracing.SamplingExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Tracing.SamplingExtensions.AddSampling(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Microsoft.Extensions.Telemetry.Tracing.SamplingOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Tracing.SamplingExtensions.AddSampling(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Tracing.SamplingOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.SamplingOptions.SamplingOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.ParentBasedSamplerOptions? Microsoft.Extensions.Telemetry.Tracing.SamplingOptions.ParentBasedSamplerOptions { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.SamplerType Microsoft.Extensions.Telemetry.Tracing.SamplingOptions.SamplerType { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.TraceIdRatioBasedSamplerOptions? Microsoft.Extensions.Telemetry.Tracing.SamplingOptions.TraceIdRatioBasedSamplerOptions { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherDimensions",
+      "Stage": "Stable",
+      "Fields": [
+        {
+          "Member": "const string Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherDimensions.ApplicationName",
+          "Stage": "Stable",
+          "Value": "env_app_name"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherDimensions.BuildVersion",
+          "Stage": "Stable",
+          "Value": "env_cloud_roleVer"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherDimensions.DeploymentRing",
+          "Stage": "Stable",
+          "Value": "env_cloud_deploymentRing"
+        },
+        {
+          "Member": "const string Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherDimensions.EnvironmentName",
+          "Stage": "Stable",
+          "Value": "env_cloud_env"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "static System.Collections.Generic.IReadOnlyList<string> Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherDimensions.DimensionNames { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceLogEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceMetricEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceMetricEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceMetricEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions> configure);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Enrichment.ServiceEnricherExtensions.AddServiceTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.Extensions.Configuration.IConfigurationSection section);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions.ServiceLogEnricherOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions.ApplicationName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions.BuildVersion { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions.DeploymentRing { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceLogEnricherOptions.EnvironmentName { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions.ServiceMetricEnricherOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions.ApplicationName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions.BuildVersion { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions.DeploymentRing { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceMetricEnricherOptions.EnvironmentName { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions.ServiceTraceEnricherOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions.ApplicationName { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions.BuildVersion { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions.DeploymentRing { get; set; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "bool Microsoft.Extensions.Telemetry.Enrichment.ServiceTraceEnricherOptions.EnvironmentName { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.TelemetryExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.TelemetryExtensions.AddDownstreamDependencyMetadata(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Http.Telemetry.IDownstreamDependencyMetadata downstreamDependencyMetadata);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.TelemetryExtensions.AddDownstreamDependencyMetadata<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Telemetry.RequestMetadata? Microsoft.Extensions.Telemetry.TelemetryExtensions.GetRequestMetadata(this System.Net.HttpWebRequest request);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.Http.Telemetry.RequestMetadata? Microsoft.Extensions.Telemetry.TelemetryExtensions.GetRequestMetadata(this System.Net.Http.HttpRequestMessage request);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static void Microsoft.Extensions.Telemetry.TelemetryExtensions.SetRequestMetadata(this System.Net.HttpWebRequest request, Microsoft.Extensions.Http.Telemetry.RequestMetadata metadata);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void Microsoft.Extensions.Telemetry.TelemetryExtensions.SetRequestMetadata(this System.Net.Http.HttpRequestMessage request, Microsoft.Extensions.Http.Telemetry.RequestMetadata metadata);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "class Microsoft.Extensions.Telemetry.Tracing.TraceIdRatioBasedSamplerOptions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Telemetry.Tracing.TraceIdRatioBasedSamplerOptions.TraceIdRatioBasedSamplerOptions();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "double Microsoft.Extensions.Telemetry.Tracing.TraceIdRatioBasedSamplerOptions.Probability { get; set; }",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
+      "Type": "static class Microsoft.Extensions.Telemetry.Enrichment.TracingEnricherExtensions",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Enrichment.TracingEnricherExtensions.AddTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder builder);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static OpenTelemetry.Trace.TracerProviderBuilder Microsoft.Extensions.Telemetry.Enrichment.TracingEnricherExtensions.AddTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder builder, Microsoft.Extensions.Telemetry.Enrichment.ITraceEnricher enricher);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.TracingEnricherExtensions.AddTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection Microsoft.Extensions.Telemetry.Enrichment.TracingEnricherExtensions.AddTraceEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Telemetry.Enrichment.ITraceEnricher enricher);",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/Microsoft.Extensions.TimeProvider.Testing.json
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/Microsoft.Extensions.TimeProvider.Testing.json
@@ -1,0 +1,61 @@
+{
+  "Name": "Microsoft.Extensions.TimeProvider.Testing, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "class Microsoft.Extensions.Time.Testing.FakeTimeProvider : System.TimeProvider",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Time.Testing.FakeTimeProvider.FakeTimeProvider();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "Microsoft.Extensions.Time.Testing.FakeTimeProvider.FakeTimeProvider(System.DateTimeOffset startTime);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.Advance(System.TimeSpan delta);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.Advance();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override System.Threading.ITimer Microsoft.Extensions.Time.Testing.FakeTimeProvider.CreateTimer(System.Threading.TimerCallback callback, object? state, System.TimeSpan dueTime, System.TimeSpan period);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override long Microsoft.Extensions.Time.Testing.FakeTimeProvider.GetTimestamp();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override System.DateTimeOffset Microsoft.Extensions.Time.Testing.FakeTimeProvider.GetUtcNow();",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.SetLocalTimeZone(System.TimeZoneInfo localTimeZone);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.SetUtcNow(System.DateTimeOffset value);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override string Microsoft.Extensions.Time.Testing.FakeTimeProvider.ToString();",
+          "Stage": "Stable"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "override System.TimeZoneInfo Microsoft.Extensions.Time.Testing.FakeTimeProvider.LocalTimeZone { get; }",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "override long Microsoft.Extensions.Time.Testing.FakeTimeProvider.TimestampFrequency { get; }",
+          "Stage": "Stable"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/System.Cloud.DocumentDb.Abstractions/System.Cloud.DocumentDb.Abstractions.json
+++ b/src/Libraries/System.Cloud.DocumentDb.Abstractions/System.Cloud.DocumentDb.Abstractions.json
@@ -1,0 +1,825 @@
+{
+  "Name": "System.Cloud.DocumentDb.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "readonly struct System.Cloud.DocumentDb.BatchItem<T>",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.BatchItem<T>.BatchItem(System.Cloud.DocumentDb.BatchOperation operation, T? item = default(T?), string? id = null, string? itemVersion = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.BatchItem<T>.BatchItem();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? System.Cloud.DocumentDb.BatchItem<T>.Id { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "T? System.Cloud.DocumentDb.BatchItem<T>.Item { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.BatchItem<T>.ItemVersion { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.BatchOperation System.Cloud.DocumentDb.BatchItem<T>.Operation { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum System.Cloud.DocumentDb.BatchOperation",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.BatchOperation.BatchOperation();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const System.Cloud.DocumentDb.BatchOperation System.Cloud.DocumentDb.BatchOperation.Create",
+          "Stage": "Experimental",
+          "Value": "0"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.BatchOperation System.Cloud.DocumentDb.BatchOperation.Delete",
+          "Stage": "Experimental",
+          "Value": "3"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.BatchOperation System.Cloud.DocumentDb.BatchOperation.Read",
+          "Stage": "Experimental",
+          "Value": "1"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.BatchOperation System.Cloud.DocumentDb.BatchOperation.Replace",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.BatchOperation System.Cloud.DocumentDb.BatchOperation.Upsert",
+          "Stage": "Experimental",
+          "Value": "4"
+        }
+      ]
+    },
+    {
+      "Type": "enum System.Cloud.DocumentDb.ConsistencyLevel",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.ConsistencyLevel.ConsistencyLevel();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const System.Cloud.DocumentDb.ConsistencyLevel System.Cloud.DocumentDb.ConsistencyLevel.BoundedStaleness",
+          "Stage": "Experimental",
+          "Value": "1"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.ConsistencyLevel System.Cloud.DocumentDb.ConsistencyLevel.ConsistentPrefix",
+          "Stage": "Experimental",
+          "Value": "4"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.ConsistencyLevel System.Cloud.DocumentDb.ConsistencyLevel.Eventual",
+          "Stage": "Experimental",
+          "Value": "3"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.ConsistencyLevel System.Cloud.DocumentDb.ConsistencyLevel.Session",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.ConsistencyLevel System.Cloud.DocumentDb.ConsistencyLevel.Strong",
+          "Stage": "Experimental",
+          "Value": "0"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.DatabaseClientException : System.Cloud.DocumentDb.DatabaseException",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseClientException.DatabaseClientException();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseClientException.DatabaseClientException(string message);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseClientException.DatabaseClientException(string message, System.Exception innerException);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.DatabaseException : System.Exception",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseException.DatabaseException();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseException.DatabaseException(string message);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseException.DatabaseException(string message, System.Exception innerException);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseException.DatabaseException(string message, int statusCode, int subStatusCode, System.Cloud.DocumentDb.RequestInfo requestInfo);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseException.DatabaseException(string message, System.Exception innerException, int statusCode, int subStatusCode, System.Cloud.DocumentDb.RequestInfo requestInfo);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Net.HttpStatusCode System.Cloud.DocumentDb.DatabaseException.HttpStatusCode { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.RequestInfo System.Cloud.DocumentDb.DatabaseException.RequestInfo { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int System.Cloud.DocumentDb.DatabaseException.StatusCode { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int System.Cloud.DocumentDb.DatabaseException.SubStatusCode { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.DatabaseOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseOptions.DatabaseOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string System.Cloud.DocumentDb.DatabaseOptions.DatabaseName { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.DatabaseOptions.DefaultRegionalDatabaseName { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Uri? System.Cloud.DocumentDb.DatabaseOptions.Endpoint { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IList<string> System.Cloud.DocumentDb.DatabaseOptions.FailoverRegions { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan? System.Cloud.DocumentDb.DatabaseOptions.IdleTcpConnectionTimeout { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Text.Json.JsonSerializerOptions System.Cloud.DocumentDb.DatabaseOptions.JsonSerializerOptions { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.DatabaseOptions.PrimaryKey { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IDictionary<string, System.Cloud.DocumentDb.RegionalDatabaseOptions> System.Cloud.DocumentDb.DatabaseOptions.RegionalDatabaseOptions { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.Throughput System.Cloud.DocumentDb.DatabaseOptions.Throughput { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.DatabaseRetryableException : System.Cloud.DocumentDb.DatabaseException",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseRetryableException.DatabaseRetryableException();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseRetryableException.DatabaseRetryableException(string message);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseRetryableException.DatabaseRetryableException(string message, System.Exception innerException);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseRetryableException.DatabaseRetryableException(string message, System.Exception innerException, int statusCode, int subStatusCode, System.TimeSpan? retryAfter, System.Cloud.DocumentDb.RequestInfo requestInfo);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.TimeSpan System.Cloud.DocumentDb.DatabaseRetryableException.RetryAfter { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.DatabaseServerException : System.Cloud.DocumentDb.DatabaseException",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseServerException.DatabaseServerException();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseServerException.DatabaseServerException(string message);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseServerException.DatabaseServerException(string message, System.Exception innerException);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseServerException.DatabaseServerException(string message, System.Exception innerException, int statusCode, int subStatusCode, System.Cloud.DocumentDb.RequestInfo requestInfo);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.DatabaseServerException.DatabaseServerException(string message, int statusCode, int subStatusCode, System.Cloud.DocumentDb.RequestInfo requestInfo);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum System.Cloud.DocumentDb.FetchMode",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.FetchMode.FetchMode();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const System.Cloud.DocumentDb.FetchMode System.Cloud.DocumentDb.FetchMode.FetchAll",
+          "Stage": "Experimental",
+          "Value": "0"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.FetchMode System.Cloud.DocumentDb.FetchMode.FetchMaxResults",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.FetchMode System.Cloud.DocumentDb.FetchMode.FetchSinglePage",
+          "Stage": "Experimental",
+          "Value": "1"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.IDatabaseResponse",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "string? System.Cloud.DocumentDb.IDatabaseResponse.ContinuationToken { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int System.Cloud.DocumentDb.IDatabaseResponse.ItemCount { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.IDatabaseResponse.ItemVersion { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.RequestInfo System.Cloud.DocumentDb.IDatabaseResponse.RequestInfo { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int System.Cloud.DocumentDb.IDatabaseResponse.Status { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool System.Cloud.DocumentDb.IDatabaseResponse.Succeeded { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.IDatabaseResponse<out T> : System.Cloud.DocumentDb.IDatabaseResponse where T : notnull",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "T? System.Cloud.DocumentDb.IDatabaseResponse<T>.Item { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.IDocumentDatabase",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task System.Cloud.DocumentDb.IDocumentDatabase.ConnectAsync(bool createIfNotExists, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<System.Cloud.DocumentDb.TableOptions>> System.Cloud.DocumentDb.IDocumentDatabase.CreateTableAsync(System.Cloud.DocumentDb.TableOptions tableOptions, System.Cloud.DocumentDb.RequestOptions requestOptions, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<bool>> System.Cloud.DocumentDb.IDocumentDatabase.DeleteDatabaseAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<System.Cloud.DocumentDb.TableOptions>> System.Cloud.DocumentDb.IDocumentDatabase.DeleteTableAsync(System.Cloud.DocumentDb.TableOptions tableOptions, System.Cloud.DocumentDb.RequestOptions requestOptions, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.IDocumentReader<TDocument> System.Cloud.DocumentDb.IDocumentDatabase.GetDocumentReader<TDocument>(System.Cloud.DocumentDb.TableOptions options);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.IDocumentWriter<TDocument> System.Cloud.DocumentDb.IDocumentDatabase.GetDocumentWriter<TDocument>(System.Cloud.DocumentDb.TableOptions options);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<System.Cloud.DocumentDb.TableOptions>> System.Cloud.DocumentDb.IDocumentDatabase.ReadTableSettingsAsync(System.Cloud.DocumentDb.TableOptions tableOptions, System.Cloud.DocumentDb.RequestOptions requestOptions, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<bool>> System.Cloud.DocumentDb.IDocumentDatabase.UpdateTableSettingsAsync(System.Cloud.DocumentDb.TableOptions tableOptions, System.Cloud.DocumentDb.RequestOptions requestOptions, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.IDocumentDatabase<TContext> : System.Cloud.DocumentDb.IDocumentDatabase where TContext : class",
+      "Stage": "Experimental"
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.IDocumentReader<TDocument> where TDocument : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<int>> System.Cloud.DocumentDb.IDocumentReader<TDocument>.CountDocumentsAsync(System.Cloud.DocumentDb.QueryRequestOptions<TDocument> options, System.Func<System.Linq.IQueryable<TDocument>, System.Linq.IQueryable<TDocument>>? condition, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<System.Collections.Generic.IReadOnlyList<TOutputDocument>>> System.Cloud.DocumentDb.IDocumentReader<TDocument>.FetchDocumentsAsync<TOutputDocument>(System.Cloud.DocumentDb.QueryRequestOptions<TDocument> options, System.Func<System.Linq.IQueryable<TDocument>, System.Linq.IQueryable<TOutputDocument>>? condition, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<System.Collections.Generic.IReadOnlyList<TDocument>>> System.Cloud.DocumentDb.IDocumentReader<TDocument>.QueryDocumentsAsync(System.Cloud.DocumentDb.QueryRequestOptions<TDocument> options, System.Cloud.DocumentDb.Query query, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>> System.Cloud.DocumentDb.IDocumentReader<TDocument>.ReadDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> requestOptions, string id, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.IDocumentWriter<TDocument> where TDocument : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.CreateDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> options, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<bool>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.DeleteDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> options, string id, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<System.Collections.Generic.IReadOnlyList<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>>>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.ExecuteTransactionalBatchAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> requestOptions, System.Collections.Generic.IReadOnlyList<System.Cloud.DocumentDb.BatchItem<TDocument>> itemsToPerformTransactionalBatch, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.InsertOrUpdateDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> options, string id, System.Func<TDocument, TDocument> conflictResolveFunc, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.PatchDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> options, string id, System.Collections.Generic.IReadOnlyList<System.Cloud.DocumentDb.PatchOperation> patchOperations, string? filter, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.ReplaceDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> options, string id, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.Tasks.Task<System.Cloud.DocumentDb.IDatabaseResponse<TDocument>> System.Cloud.DocumentDb.IDocumentWriter<TDocument>.UpsertDocumentAsync(System.Cloud.DocumentDb.RequestOptions<TDocument> options, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.DocumentDb.ITableLocator",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.TableInfo? System.Cloud.DocumentDb.ITableLocator.LocateTable(in System.Cloud.DocumentDb.TableInfo options, System.Cloud.DocumentDb.RequestOptions request);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct System.Cloud.DocumentDb.PatchOperation",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.PatchOperation.PatchOperation();",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.DocumentDb.PatchOperation System.Cloud.DocumentDb.PatchOperation.Add<T>(string path, T value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.DocumentDb.PatchOperation System.Cloud.DocumentDb.PatchOperation.Increment(string path, long value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.DocumentDb.PatchOperation System.Cloud.DocumentDb.PatchOperation.Increment(string path, double value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.DocumentDb.PatchOperation System.Cloud.DocumentDb.PatchOperation.Remove(string path);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.DocumentDb.PatchOperation System.Cloud.DocumentDb.PatchOperation.Replace<T>(string path, T value);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.DocumentDb.PatchOperation System.Cloud.DocumentDb.PatchOperation.Set<T>(string path, T value);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Cloud.DocumentDb.PatchOperationType System.Cloud.DocumentDb.PatchOperation.OperationType { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string System.Cloud.DocumentDb.PatchOperation.Path { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "object System.Cloud.DocumentDb.PatchOperation.Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "enum System.Cloud.DocumentDb.PatchOperationType",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.PatchOperationType.PatchOperationType();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const System.Cloud.DocumentDb.PatchOperationType System.Cloud.DocumentDb.PatchOperationType.Add",
+          "Stage": "Experimental",
+          "Value": "0"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.PatchOperationType System.Cloud.DocumentDb.PatchOperationType.Increment",
+          "Stage": "Experimental",
+          "Value": "4"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.PatchOperationType System.Cloud.DocumentDb.PatchOperationType.Remove",
+          "Stage": "Experimental",
+          "Value": "1"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.PatchOperationType System.Cloud.DocumentDb.PatchOperationType.Replace",
+          "Stage": "Experimental",
+          "Value": "2"
+        },
+        {
+          "Member": "const System.Cloud.DocumentDb.PatchOperationType System.Cloud.DocumentDb.PatchOperationType.Set",
+          "Stage": "Experimental",
+          "Value": "3"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct System.Cloud.DocumentDb.Query",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.Query.Query(string queryText, System.Collections.Generic.IReadOnlyDictionary<string, string> parameters);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.Query.Query(string queryText);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.Query.Query();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Collections.Generic.IReadOnlyDictionary<string, string> System.Cloud.DocumentDb.Query.Parameters { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string System.Cloud.DocumentDb.Query.QueryText { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.QueryRequestOptions<TDocument> : System.Cloud.DocumentDb.RequestOptions<TDocument> where TDocument : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.QueryRequestOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.ContinuationToken { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.EnableLowPrecisionOrderBy { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.EnableScan { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.FetchMode System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.FetchCondition { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.MaxBufferedItemCount { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.MaxConcurrency { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.MaxResults { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "int? System.Cloud.DocumentDb.QueryRequestOptions<TDocument>.ResponseContinuationTokenLimitInKb { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.RegionalDatabaseOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.RegionalDatabaseOptions.RegionalDatabaseOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "string? System.Cloud.DocumentDb.RegionalDatabaseOptions.DatabaseName { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Uri? System.Cloud.DocumentDb.RegionalDatabaseOptions.Endpoint { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IList<string> System.Cloud.DocumentDb.RegionalDatabaseOptions.FailoverRegions { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.RegionalDatabaseOptions.PrimaryKey { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct System.Cloud.DocumentDb.RequestInfo",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.RequestInfo.RequestInfo(string? region = null, string? tableName = null, double? cost = null, System.Uri? endpoint = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.RequestInfo.RequestInfo();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "double? System.Cloud.DocumentDb.RequestInfo.Cost { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Uri? System.Cloud.DocumentDb.RequestInfo.Endpoint { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.RequestInfo.Region { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.RequestInfo.TableName { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.RequestOptions<TDocument> : System.Cloud.DocumentDb.RequestOptions where TDocument : notnull",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.RequestOptions<TDocument>.RequestOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "TDocument? System.Cloud.DocumentDb.RequestOptions<TDocument>.Document { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.RequestOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.RequestOptions.RequestOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "System.Cloud.DocumentDb.ConsistencyLevel? System.Cloud.DocumentDb.RequestOptions.ConsistencyLevel { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool System.Cloud.DocumentDb.RequestOptions.ContentResponseOnWrite { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.RequestOptions.ItemVersion { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Collections.Generic.IReadOnlyList<object?>? System.Cloud.DocumentDb.RequestOptions.PartitionKey { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.RequestOptions.Region { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.RequestOptions.SessionToken { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct System.Cloud.DocumentDb.TableInfo",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.TableInfo.TableInfo(System.Cloud.DocumentDb.TableOptions options);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.TableInfo.TableInfo(in System.Cloud.DocumentDb.TableInfo info, string? tableNameOverride = null, bool? isRegionalOverride = null);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.TableInfo.TableInfo();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool System.Cloud.DocumentDb.TableInfo.IsLocatorRequired { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool System.Cloud.DocumentDb.TableInfo.IsRegional { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.TableInfo.PartitionIdPath { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string System.Cloud.DocumentDb.TableInfo.TableName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.Throughput System.Cloud.DocumentDb.TableInfo.Throughput { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan System.Cloud.DocumentDb.TableInfo.TimeToLive { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.DocumentDb.TableOptions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.TableOptions.TableOptions();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "bool System.Cloud.DocumentDb.TableOptions.IsLocatorRequired { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "bool System.Cloud.DocumentDb.TableOptions.IsRegional { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string? System.Cloud.DocumentDb.TableOptions.PartitionIdPath { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "string System.Cloud.DocumentDb.TableOptions.TableName { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.Throughput System.Cloud.DocumentDb.TableOptions.Throughput { get; set; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.TimeSpan System.Cloud.DocumentDb.TableOptions.TimeToLive { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "readonly struct System.Cloud.DocumentDb.Throughput",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.DocumentDb.Throughput.Throughput(int? throughput);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.DocumentDb.Throughput.Throughput();",
+          "Stage": "Experimental"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "static readonly System.Cloud.DocumentDb.Throughput System.Cloud.DocumentDb.Throughput.Unlimited",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "int? System.Cloud.DocumentDb.Throughput.Value { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Libraries/System.Cloud.Messaging.Abstractions/System.Cloud.Messaging.Abstractions.json
+++ b/src/Libraries/System.Cloud.Messaging.Abstractions/System.Cloud.Messaging.Abstractions.json
@@ -1,0 +1,495 @@
+{
+  "Name": "System.Cloud.Messaging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+  "Types": [
+    {
+      "Type": "static class System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.AddMessageMiddleware<TMiddleware>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.AddMessageMiddleware<TMiddleware>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, TMiddleware> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.AddNamedSingleton<T>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.AddNamedSingleton<T>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, T> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.AddNamedSingleton<T>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, string pipelineName, System.Func<System.IServiceProvider, T> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageConsumer<TConsumer>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageConsumer<TConsumer>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, TConsumer> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageDestination<TDestination>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageDestination<TDestination>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, TDestination> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageDestination<TDestination>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, string pipelineName, System.Func<System.IServiceProvider, TDestination> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageSource<TSource>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureMessageSource<TSource>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, TSource> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureTerminalMessageDelegate<TDelegate>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.ConfigureTerminalMessageDelegate<TDelegate>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, TDelegate> implementationFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.AsyncProcessingPipelineBuilderExtensions.RunConsumerAsBackgroundService(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "class System.Cloud.Messaging.BaseMessageConsumer : System.Cloud.Messaging.IMessageConsumer",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.Messaging.BaseMessageConsumer.BaseMessageConsumer(System.Cloud.Messaging.IMessageSource messageSource, System.Cloud.Messaging.IMessageDelegate messageDelegate, Microsoft.Extensions.Logging.ILogger logger);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask System.Cloud.Messaging.BaseMessageConsumer.ExecuteAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask System.Cloud.Messaging.BaseMessageConsumer.FetchAndProcessMessageAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask<System.Cloud.Messaging.MessageContext> System.Cloud.Messaging.BaseMessageConsumer.FetchMessageAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask System.Cloud.Messaging.BaseMessageConsumer.OnMessageProcessingCompletionAsync(System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask System.Cloud.Messaging.BaseMessageConsumer.OnMessageProcessingFailureAsync(System.Cloud.Messaging.MessageContext context, System.Exception exception);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask System.Cloud.Messaging.BaseMessageConsumer.ProcessingStepAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual System.Threading.Tasks.ValueTask System.Cloud.Messaging.BaseMessageConsumer.ProcessMessageAsync(System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "virtual void System.Cloud.Messaging.BaseMessageConsumer.ReleaseContext(System.Cloud.Messaging.MessageContext messageContext);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.Extensions.Logging.ILogger System.Cloud.Messaging.BaseMessageConsumer.Logger { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.Messaging.IMessageDelegate System.Cloud.Messaging.BaseMessageConsumer.MessageDelegate { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Cloud.Messaging.IMessageSource System.Cloud.Messaging.BaseMessageConsumer.MessageSource { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IAsyncProcessingPipelineBuilder",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "string System.Cloud.Messaging.IAsyncProcessingPipelineBuilder.PipelineName { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "Microsoft.Extensions.DependencyInjection.IServiceCollection System.Cloud.Messaging.IAsyncProcessingPipelineBuilder.Services { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageCompleteActionFeature",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask System.Cloud.Messaging.IMessageCompleteActionFeature.MarkCompleteAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageConsumer",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask System.Cloud.Messaging.IMessageConsumer.ExecuteAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageDelegate",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask System.Cloud.Messaging.IMessageDelegate.InvokeAsync(System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageDestination",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask System.Cloud.Messaging.IMessageDestination.WriteAsync(System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageDestinationFeatures",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "Microsoft.AspNetCore.Http.Features.IFeatureCollection System.Cloud.Messaging.IMessageDestinationFeatures.Features { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageMiddleware",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask System.Cloud.Messaging.IMessageMiddleware.InvokeAsync(System.Cloud.Messaging.MessageContext context, System.Cloud.Messaging.IMessageDelegate nextHandler);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessagePayloadFeature",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "System.ReadOnlyMemory<byte> System.Cloud.Messaging.IMessagePayloadFeature.Payload { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessagePostponeActionFeature",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask System.Cloud.Messaging.IMessagePostponeActionFeature.PostponeAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageSource",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Threading.Tasks.ValueTask<System.Cloud.Messaging.MessageContext> System.Cloud.Messaging.IMessageSource.ReadAsync(System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "void System.Cloud.Messaging.IMessageSource.Release(System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageSourceFeatures",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "Microsoft.AspNetCore.Http.Features.IFeatureCollection System.Cloud.Messaging.IMessageSourceFeatures.Features { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IMessageVisibilityDelayFeature",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "System.TimeSpan System.Cloud.Messaging.IMessageVisibilityDelayFeature.VisibilityDelay { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.IPipelineDelegateFactory",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.Messaging.IMessageDelegate System.Cloud.Messaging.IPipelineDelegateFactory.Create(string pipelineName);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "interface System.Cloud.Messaging.ISerializedMessagePayloadFeature<out T> where T : notnull",
+      "Stage": "Experimental",
+      "Properties": [
+        {
+          "Member": "T System.Cloud.Messaging.ISerializedMessagePayloadFeature<T>.Payload { get; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.LatencyRecorderMiddlewareExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.LatencyRecorderMiddlewareExtensions.AddLatencyContextMiddleware(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.LatencyRecorderMiddlewareExtensions.AddLatencyContextMiddleware<T>(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, System.Func<System.IServiceProvider, T> implementationFactory, System.Func<System.IServiceProvider, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Telemetry.Latency.ILatencyDataExporter>> exporterFactory);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.LatencyRecorderMiddlewareExtensions.AddLatencyRecorderMessageMiddleware(this System.Cloud.Messaging.IAsyncProcessingPipelineBuilder pipelineBuilder, Microsoft.Extensions.Telemetry.Latency.MeasureToken successMeasureToken, Microsoft.Extensions.Telemetry.Latency.MeasureToken failureMeasureToken);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageCancelledTokenFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static void System.Cloud.Messaging.MessageCancelledTokenFeatureExtensions.SetMessageCancelledTokenSource(this System.Cloud.Messaging.MessageContext context, System.Threading.CancellationTokenSource cancellationTokenSource);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageCancelledTokenFeatureExtensions.TryGetMessageCancelledTokenSource(this System.Cloud.Messaging.MessageContext context, out System.Threading.CancellationTokenSource? cancellationTokenSource);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageCompleteActionFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Threading.Tasks.ValueTask System.Cloud.Messaging.MessageCompleteActionFeatureExtensions.MarkCompleteAsync(this System.Cloud.Messaging.MessageContext context, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.MessageCompleteActionFeatureExtensions.SetMessageCompleteActionFeature(this System.Cloud.Messaging.MessageContext context, System.Cloud.Messaging.IMessageCompleteActionFeature messageCompleteActionFeature);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "sealed class System.Cloud.Messaging.MessageContext",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "System.Cloud.Messaging.MessageContext.MessageContext(Microsoft.AspNetCore.Http.Features.IFeatureCollection features);",
+          "Stage": "Experimental"
+        }
+      ],
+      "Properties": [
+        {
+          "Member": "Microsoft.AspNetCore.Http.Features.IFeatureCollection System.Cloud.Messaging.MessageContext.Features { get; }",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "System.Threading.CancellationToken System.Cloud.Messaging.MessageContext.MessageCancelledToken { get; set; }",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageDestinationFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static void System.Cloud.Messaging.MessageDestinationFeatureExtensions.SetMessageDestinationFeatures(this System.Cloud.Messaging.MessageContext context, Microsoft.AspNetCore.Http.Features.IFeatureCollection destinationFeatures);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageDestinationFeatureExtensions.TryGetMessageDestinationFeatures(this System.Cloud.Messaging.MessageContext context, out Microsoft.AspNetCore.Http.Features.IFeatureCollection? destinationFeatures);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageDestinationPayloadFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.ReadOnlyMemory<byte> System.Cloud.Messaging.MessageDestinationPayloadFeatureExtensions.GetDestinationPayload(this System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.MessageDestinationPayloadFeatureExtensions.SetDestinationPayload(this System.Cloud.Messaging.MessageContext context, System.ReadOnlyMemory<byte> payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.MessageDestinationPayloadFeatureExtensions.SetDestinationPayload(this System.Cloud.Messaging.MessageContext context, byte[] payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageDestinationPayloadFeatureExtensions.TryGetDestinationPayload(this System.Cloud.Messaging.MessageContext context, out System.ReadOnlyMemory<byte>? payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageDestinationPayloadFeatureExtensions.TryGetDestinationPayloadAsUTF8String(this System.Cloud.Messaging.MessageContext context, out string utf8StringPayload);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageLatencyContextFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static void System.Cloud.Messaging.MessageLatencyContextFeatureExtensions.SetLatencyContext(this System.Cloud.Messaging.MessageContext context, Microsoft.Extensions.Telemetry.Latency.ILatencyContext latencyContext);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageLatencyContextFeatureExtensions.TryGetLatencyContext(this System.Cloud.Messaging.MessageContext context, out Microsoft.Extensions.Telemetry.Latency.ILatencyContext? latencyContext);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessagePostponeActionFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Threading.Tasks.ValueTask System.Cloud.Messaging.MessagePostponeActionFeatureExtensions.PostponeAsync(this System.Cloud.Messaging.MessageContext context, System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.MessagePostponeActionFeatureExtensions.SetMessagePostponeActionFeature(this System.Cloud.Messaging.MessageContext context, System.Cloud.Messaging.IMessagePostponeActionFeature messagePostponeActionFeature);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageSourceFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static void System.Cloud.Messaging.MessageSourceFeatureExtensions.SetMessageSourceFeatures(this System.Cloud.Messaging.MessageContext context, Microsoft.AspNetCore.Http.Features.IFeatureCollection sourceFeatures);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageSourceFeatureExtensions.TryGetMessageSourceFeatures(this System.Cloud.Messaging.MessageContext context, out Microsoft.AspNetCore.Http.Features.IFeatureCollection? sourceFeatures);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageSourcePayloadFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.ReadOnlyMemory<byte> System.Cloud.Messaging.MessageSourcePayloadFeatureExtensions.GetSourcePayload(this System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.MessageSourcePayloadFeatureExtensions.SetSourcePayload(this System.Cloud.Messaging.MessageContext context, System.ReadOnlyMemory<byte> payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.MessageSourcePayloadFeatureExtensions.SetSourcePayload(this System.Cloud.Messaging.MessageContext context, byte[] payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageSourcePayloadFeatureExtensions.TryGetSourcePayload(this System.Cloud.Messaging.MessageContext context, out System.ReadOnlyMemory<byte>? payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageSourcePayloadFeatureExtensions.TryGetSourcePayloadAsUTF8String(this System.Cloud.Messaging.MessageContext context, out string utf8StringPayload);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.MessageVisibilityDelayFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static void System.Cloud.Messaging.MessageVisibilityDelayFeatureExtensions.SetVisibilityDelay(this System.Cloud.Messaging.MessageContext context, System.TimeSpan visibilityDelay);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.MessageVisibilityDelayFeatureExtensions.TryGetVisibilityDelay(this System.Cloud.Messaging.MessageContext context, out System.Cloud.Messaging.IMessageVisibilityDelayFeature? visibilityDelay);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.SerializedMessagePayloadFeatureExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static T System.Cloud.Messaging.SerializedMessagePayloadFeatureExtensions.GetSerializedPayload<T>(this System.Cloud.Messaging.MessageContext context);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static void System.Cloud.Messaging.SerializedMessagePayloadFeatureExtensions.SetSerializedPayload<T>(this System.Cloud.Messaging.MessageContext context, T payload);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static bool System.Cloud.Messaging.SerializedMessagePayloadFeatureExtensions.TryGetSerializedPayload<T>(this System.Cloud.Messaging.MessageContext context, out T? payload);",
+          "Stage": "Experimental"
+        }
+      ]
+    },
+    {
+      "Type": "static class System.Cloud.Messaging.ServiceCollectionExtensions",
+      "Stage": "Experimental",
+      "Methods": [
+        {
+          "Member": "static System.Cloud.Messaging.IAsyncProcessingPipelineBuilder System.Cloud.Messaging.ServiceCollectionExtensions.AddAsyncPipeline(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string pipelineName);",
+          "Stage": "Experimental"
+        },
+        {
+          "Member": "static Microsoft.Extensions.DependencyInjection.IServiceCollection System.Cloud.Messaging.ServiceCollectionExtensions.WithPipelineDelegateFactory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, System.Cloud.Messaging.IPipelineDelegateFactory> factory);",
+          "Stage": "Experimental"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Packages/Directory.Build.props
+++ b/src/Packages/Directory.Build.props
@@ -4,8 +4,8 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>n/a</GenerateDocumentationFile>
     <SkipAnalyzers>true</SkipAnalyzers>
-    <SkipR9Analyzers>true</SkipR9Analyzers>
     <DisableNETStandardCompatErrors>true</DisableNETStandardCompatErrors>
+    <Api>false</Api>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/Microsoft.Extensions.StaticAnalysis.props
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/Microsoft.Extensions.StaticAnalysis.props
@@ -1,0 +1,44 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'ProdExe'" Include="$(MSBuildThisFileDirectory)config/ProdExe.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'ProdLib'" Include="$(MSBuildThisFileDirectory)config/ProdLib.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'NonProdExe'" Include="$(MSBuildThisFileDirectory)config/NonProdExe.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'NonProdLib'" Include="$(MSBuildThisFileDirectory)config/NonProdLib.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'Benchmark'" Include="$(MSBuildThisFileDirectory)config/Benchmark.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'Test'" Include="$(MSBuildThisFileDirectory)config/Test.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'General'" Include="$(MSBuildThisFileDirectory)config/General.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == ''" Include="$(MSBuildThisFileDirectory)config/General.globalconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'ProdExe-Tier1'" Include="$(MSBuildThisFileDirectory)config/ProdExe-Tier1.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'ProdLib-Tier1'" Include="$(MSBuildThisFileDirectory)config/ProdLib-Tier1.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'NonProdExe-Tier1'" Include="$(MSBuildThisFileDirectory)config/NonProdExe-Tier1.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'NonProdLib-Tier1'" Include="$(MSBuildThisFileDirectory)config/NonProdLib-Tier1.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'Benchmark-Tier1'" Include="$(MSBuildThisFileDirectory)config/Benchmark-Tier1.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'Test-Tier1'" Include="$(MSBuildThisFileDirectory)config/Test-Tier1.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'General-Tier1'" Include="$(MSBuildThisFileDirectory)config/General-Tier1.globalconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'ProdExe-Tier2'" Include="$(MSBuildThisFileDirectory)config/ProdExe-Tier2.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'ProdLib-Tier2'" Include="$(MSBuildThisFileDirectory)config/ProdLib-Tier2.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'NonProdExe-Tier2'" Include="$(MSBuildThisFileDirectory)config/NonProdExe-Tier2.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'NonProdLib-Tier2'" Include="$(MSBuildThisFileDirectory)config/NonProdLib-Tier2.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'Benchmark-Tier2'" Include="$(MSBuildThisFileDirectory)config/Benchmark-Tier2.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'Test-Tier2'" Include="$(MSBuildThisFileDirectory)config/Test-Tier2.globalconfig" />
+    <EditorConfigFiles Condition="'$(StaticAnalysisCodeType)' == 'General-Tier2'" Include="$(MSBuildThisFileDirectory)config/General-Tier2.globalconfig" />
+  </ItemGroup>
+
+  <Target Name="_CheckForMissingCodeType" BeforeTargets="BeforeCompile" Condition="'$(StaticAnalysisCodeType)' == ''" >
+    <Warning Code="R9M000" Text="The StaticAnalysisCodeType property is not defined, assuming type 'General'" HelpLink="https://TODO" />
+  </Target>
+</Project>

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier1.globalconfig
@@ -1,0 +1,4267 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:55Z
+# Max Tier  : 1
+# Attributes: general, general_externalonly, performance
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier2.globalconfig
@@ -1,0 +1,4309 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:57Z
+# Max Tier  : 2
+# Attributes: general, general_externalonly, performance
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark.globalconfig
@@ -1,0 +1,4335 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:59Z
+# Max Tier  : 3
+# Attributes: general, general_externalonly, performance
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier1.globalconfig
@@ -1,0 +1,4267 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:53Z
+# Max Tier  : 1
+# Attributes: general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier2.globalconfig
@@ -1,0 +1,4309 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:55Z
+# Max Tier  : 2
+# Attributes: general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General.globalconfig
@@ -1,0 +1,4333 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:58Z
+# Max Tier  : 3
+# Attributes: general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = suggestion
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier1.globalconfig
@@ -1,0 +1,4267 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:54Z
+# Max Tier  : 1
+# Attributes: general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier2.globalconfig
@@ -1,0 +1,4309 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:56Z
+# Max Tier  : 2
+# Attributes: general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe.globalconfig
@@ -1,10 +1,11 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2023-05-23 23:01:34Z
-# Max Tier  : 2147483647
-# Attributes: api, general, performance, production
-# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+# Generated : 2023-05-24 21:09:59Z
+# Max Tier  : 3
+# Attributes: general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
 
-[*.cs]
+is_global = true
+global_level = -1
 
 # Title    : Do not use model binding attributes with route handlers
 # Category : Usage
@@ -97,8 +98,7 @@ dotnet_diagnostic.BL0007.severity = warning
 # Title    : Do not declare static members on generic types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
-dotnet_diagnostic.CA1000.severity = warning
-dotnet_code_quality.CA1000.api_surface = public
+dotnet_diagnostic.CA1000.severity = none
 
 # Title    : Types that own disposable fields should be disposable
 # Category : Design
@@ -108,33 +108,27 @@ dotnet_diagnostic.CA1001.severity = warning
 # Title    : Do not expose generic lists
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
-dotnet_diagnostic.CA1002.severity = warning
-dotnet_code_quality.CA1002.api_surface = public
+dotnet_diagnostic.CA1002.severity = none
 
 # Title    : Use generic event handler instances
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
-dotnet_diagnostic.CA1003.severity = warning
-dotnet_code_quality.CA1003.api_surface = all
+dotnet_diagnostic.CA1003.severity = none
 
 # Title    : Avoid excessive parameters on generic types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
-dotnet_diagnostic.CA1005.severity = warning
-dotnet_code_quality.CA1005.api_surface = public
+dotnet_diagnostic.CA1005.severity = none
 
 # Title    : Enums should have zero value
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
-dotnet_diagnostic.CA1008.severity = warning
-dotnet_code_quality.CA1008.api_surface = public
+dotnet_diagnostic.CA1008.severity = none
 
 # Title    : Generic interface should also be implemented
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
-dotnet_diagnostic.CA1010.severity = warning
-dotnet_code_quality.CA1010.api_surface = public
-dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+dotnet_diagnostic.CA1010.severity = none
 
 # Title    : Abstract types should not have public constructors
 # Category : Design
@@ -165,7 +159,7 @@ dotnet_diagnostic.CA1018.severity = warning
 # Title    : Define accessors for attribute arguments
 # Category : Design
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
-dotnet_diagnostic.CA1019.severity = warning
+dotnet_diagnostic.CA1019.severity = suggestion
 
 # Title    : Define accessors for attribute arguments
 # Category : Design
@@ -180,8 +174,7 @@ dotnet_diagnostic.CA1021.severity = none
 # Title    : Use properties where appropriate
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
-dotnet_diagnostic.CA1024.severity = warning
-dotnet_code_quality.CA1024.api_surface = public
+dotnet_diagnostic.CA1024.severity = none
 
 # Title    : Mark enums with FlagsAttribute
 # Category : Design
@@ -207,7 +200,7 @@ dotnet_diagnostic.CA1031.severity = warning
 # Title    : Implement standard exception constructors
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
-dotnet_diagnostic.CA1032.severity = warning
+dotnet_diagnostic.CA1032.severity = none
 
 # Title    : Interface methods should be callable by child types
 # Category : Design
@@ -217,12 +210,12 @@ dotnet_diagnostic.CA1033.severity = warning
 # Title    : Nested types should not be visible
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
-dotnet_diagnostic.CA1034.severity = warning
+dotnet_diagnostic.CA1034.severity = none
 
 # Title    : Override methods on comparable types
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
-dotnet_diagnostic.CA1036.severity = warning
+dotnet_diagnostic.CA1036.severity = none
 
 # Title    : Avoid empty interfaces
 # Category : Design
@@ -239,8 +232,7 @@ dotnet_code_quality.CA1041.api_surface = all
 # Title    : Use Integral Or String Argument For Indexers
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
-dotnet_diagnostic.CA1043.severity = warning
-dotnet_code_quality.CA1043.api_surface = public, protected
+dotnet_diagnostic.CA1043.severity = none
 
 # Title    : Properties should not be write only
 # Category : Design
@@ -250,8 +242,7 @@ dotnet_diagnostic.CA1044.severity = warning
 # Title    : Do not pass types by reference
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
-dotnet_diagnostic.CA1045.severity = suggestion
-dotnet_code_quality.CA1045.api_surface = public
+dotnet_diagnostic.CA1045.severity = none
 
 # Title    : Do not overload equality operator on reference types
 # Category : Design
@@ -268,14 +259,12 @@ dotnet_code_quality.CA1047.api_surface = all
 # Title    : Declare types in namespaces
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
-dotnet_diagnostic.CA1050.severity = warning
-dotnet_code_quality.CA1050.api_surface = public
+dotnet_diagnostic.CA1050.severity = none
 
 # Title    : Do not declare visible instance fields
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
-dotnet_diagnostic.CA1051.severity = warning
-dotnet_code_quality.CA1051.api_surface = public
+dotnet_diagnostic.CA1051.severity = none
 
 # Title    : Static holder types should be Static or NotInheritable
 # Category : Design
@@ -285,17 +274,17 @@ dotnet_diagnostic.CA1052.severity = warning
 # Title    : URI-like parameters should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
-dotnet_diagnostic.CA1054.severity = warning
+dotnet_diagnostic.CA1054.severity = none
 
 # Title    : URI-like return values should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
-dotnet_diagnostic.CA1055.severity = warning
+dotnet_diagnostic.CA1055.severity = none
 
 # Title    : URI-like properties should not be strings
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
-dotnet_diagnostic.CA1056.severity = warning
+dotnet_diagnostic.CA1056.severity = none
 
 # Title    : Types should not extend certain base types
 # Category : Design
@@ -317,10 +306,7 @@ dotnet_code_quality.CA1061.api_surface = all
 # Title    : Validate arguments of public methods
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
-dotnet_diagnostic.CA1062.severity = warning
-dotnet_code_quality.CA1062.api_surface = public, protected
-dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
-dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+dotnet_diagnostic.CA1062.severity = none
 
 # Title    : Implement IDisposable Correctly
 # Category : Design
@@ -330,7 +316,7 @@ dotnet_diagnostic.CA1063.severity = warning
 # Title    : Exceptions should be public
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
-dotnet_diagnostic.CA1064.severity = warning
+dotnet_diagnostic.CA1064.severity = none
 
 # Title    : Do not raise exceptions in unexpected locations
 # Category : Design
@@ -355,8 +341,7 @@ dotnet_diagnostic.CA1067.severity = warning
 # Title    : CancellationToken parameters must come last
 # Category : Design
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
-dotnet_diagnostic.CA1068.severity = warning
-dotnet_code_quality.CA1068.api_surface = public, protected
+dotnet_diagnostic.CA1068.severity = none
 
 # Title    : Enums values should not be duplicated
 # Category : Design
@@ -377,37 +362,37 @@ dotnet_diagnostic.CA1200.severity = warning
 # Title    : Do not pass literals as localized parameters
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
-dotnet_diagnostic.CA1303.severity = warning
+dotnet_diagnostic.CA1303.severity = none
 
 # Title    : Specify CultureInfo
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
-dotnet_diagnostic.CA1304.severity = warning
+dotnet_diagnostic.CA1304.severity = none
 
 # Title    : Specify IFormatProvider
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
-dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1305.severity = none
 
 # Title    : Specify StringComparison for clarity
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
-dotnet_diagnostic.CA1307.severity = warning
+dotnet_diagnostic.CA1307.severity = none
 
 # Title    : Normalize strings to uppercase
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
-dotnet_diagnostic.CA1308.severity = warning
+dotnet_diagnostic.CA1308.severity = none
 
 # Title    : Use ordinal string comparison
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
-dotnet_diagnostic.CA1309.severity = warning
+dotnet_diagnostic.CA1309.severity = suggestion
 
 # Title    : Specify StringComparison for correctness
 # Category : Globalization
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
-dotnet_diagnostic.CA1310.severity = warning
+dotnet_diagnostic.CA1310.severity = none
 
 # Title    : Specify a culture or use an invariant version
 # Category : Globalization
@@ -417,7 +402,7 @@ dotnet_diagnostic.CA1311.severity = warning
 # Title    : P/Invokes should not be visible
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
-dotnet_diagnostic.CA1401.severity = warning
+dotnet_diagnostic.CA1401.severity = none
 
 # Title    : Validate platform compatibility
 # Category : Interoperability
@@ -437,7 +422,7 @@ dotnet_diagnostic.CA1418.severity = warning
 # Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 # Category : Interoperability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
-dotnet_diagnostic.CA1419.severity = warning
+dotnet_diagnostic.CA1419.severity = none
 
 # Title    : Property, type, or attribute requires runtime marshalling
 # Category : Interoperability
@@ -515,8 +500,7 @@ dotnet_diagnostic.CA1513.severity = suggestion
 # Title    : Do not name enum values 'Reserved'
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
-dotnet_diagnostic.CA1700.severity = warning
-dotnet_code_quality.CA1700.api_surface = public
+dotnet_diagnostic.CA1700.severity = none
 
 # Title    : Identifiers should not contain underscores
 # Category : Naming
@@ -527,20 +511,17 @@ dotnet_diagnostic.CA1707.severity = none
 # Title    : Identifiers should differ by more than case
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
-dotnet_diagnostic.CA1708.severity = warning
-dotnet_code_quality.CA1708.api_surface = public
+dotnet_diagnostic.CA1708.severity = silent
 
 # Title    : Identifiers should have correct suffix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
-dotnet_diagnostic.CA1710.severity = warning
-dotnet_code_quality.CA1710.api_surface = public
+dotnet_diagnostic.CA1710.severity = silent
 
 # Title    : Identifiers should not have incorrect suffix
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
-dotnet_diagnostic.CA1711.severity = warning
-dotnet_code_quality.CA1711.api_surface = public
+dotnet_diagnostic.CA1711.severity = silent
 
 # Title    : Do not prefix enum values with type name
 # Category : Naming
@@ -568,20 +549,17 @@ dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
 # Title    : Identifier contains type name
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
-dotnet_diagnostic.CA1720.severity = warning
-dotnet_code_quality.CA1720.api_surface = public
+dotnet_diagnostic.CA1720.severity = silent
 
 # Title    : Property names should not match get methods
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
-dotnet_diagnostic.CA1721.severity = warning
-dotnet_code_quality.CA1721.api_surface = public
+dotnet_diagnostic.CA1721.severity = none
 
 # Title    : Type names should not match namespaces
 # Category : Naming
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
-dotnet_diagnostic.CA1724.severity = warning
-dotnet_code_quality.CA1724.api_surface = public
+dotnet_diagnostic.CA1724.severity = none
 
 # Title    : Parameter names should match base declaration
 # Category : Naming
@@ -608,12 +586,12 @@ dotnet_diagnostic.CA1801.severity = none
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-dotnet_diagnostic.CA1802.severity = warning
+dotnet_diagnostic.CA1802.severity = none
 
 # Title    : Use literals where appropriate
 # Category : Performance
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
-dotnet_diagnostic.CA1802.severity = warning
+dotnet_diagnostic.CA1802.severity = none
 
 # Title    : Do not initialize unnecessarily
 # Category : Performance
@@ -633,7 +611,7 @@ dotnet_diagnostic.CA1806.severity = warning
 # Title    : Initialize reference type static fields inline
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
-dotnet_diagnostic.CA1810.severity = warning
+dotnet_diagnostic.CA1810.severity = none
 
 # Title    : Avoid uninstantiated internal classes
 # Category : Performance
@@ -645,17 +623,17 @@ dotnet_diagnostic.CA1812.severity = none
 # Title    : Avoid unsealed attributes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
-dotnet_diagnostic.CA1813.severity = warning
+dotnet_diagnostic.CA1813.severity = none
 
 # Title    : Prefer jagged arrays over multidimensional
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
-dotnet_diagnostic.CA1814.severity = warning
+dotnet_diagnostic.CA1814.severity = none
 
 # Title    : Override equals and operator equals on value types
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
-dotnet_diagnostic.CA1815.severity = warning
+dotnet_diagnostic.CA1815.severity = none
 
 # Title    : Dispose methods should call SuppressFinalize
 # Category : Usage
@@ -665,17 +643,17 @@ dotnet_diagnostic.CA1816.severity = warning
 # Title    : Properties should not return arrays
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
-dotnet_diagnostic.CA1819.severity = warning
+dotnet_diagnostic.CA1819.severity = none
 
 # Title    : Test for empty strings using string length
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
-dotnet_diagnostic.CA1820.severity = warning
+dotnet_diagnostic.CA1820.severity = none
 
 # Title    : Remove empty Finalizers
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
-dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1821.severity = none
 
 # Title    : Mark members as static
 # Category : Performance
@@ -685,98 +663,97 @@ dotnet_diagnostic.CA1822.severity = warning
 # Title    : Avoid unused private fields
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
-# Redundant: S1144
 dotnet_diagnostic.CA1823.severity = none
 
 # Title    : Mark assemblies with NeutralResourcesLanguageAttribute
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
-dotnet_diagnostic.CA1824.severity = warning
+dotnet_diagnostic.CA1824.severity = suggestion
 
 # Title    : Avoid zero-length array allocations
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
-dotnet_diagnostic.CA1825.severity = warning
+dotnet_diagnostic.CA1825.severity = none
 
 # Title    : Do not use Enumerable methods on indexable collections
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
-dotnet_diagnostic.CA1826.severity = warning
+dotnet_diagnostic.CA1826.severity = none
 
 # Title    : Do not use Count() or LongCount() when Any() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
-dotnet_diagnostic.CA1827.severity = warning
+dotnet_diagnostic.CA1827.severity = none
 
 # Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
-dotnet_diagnostic.CA1828.severity = warning
+dotnet_diagnostic.CA1828.severity = none
 
 # Title    : Use Length/Count property instead of Count() when available
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
-dotnet_diagnostic.CA1829.severity = warning
+dotnet_diagnostic.CA1829.severity = none
 
 # Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
-dotnet_diagnostic.CA1830.severity = warning
+dotnet_diagnostic.CA1830.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
-dotnet_diagnostic.CA1831.severity = warning
+dotnet_diagnostic.CA1831.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
-dotnet_diagnostic.CA1832.severity = warning
+dotnet_diagnostic.CA1832.severity = none
 
 # Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
-dotnet_diagnostic.CA1833.severity = warning
+dotnet_diagnostic.CA1833.severity = none
 
 # Title    : Consider using 'StringBuilder.Append(char)' when applicable
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
-dotnet_diagnostic.CA1834.severity = warning
+dotnet_diagnostic.CA1834.severity = none
 
 # Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
-dotnet_diagnostic.CA1835.severity = warning
+dotnet_diagnostic.CA1835.severity = none
 
 # Title    : Prefer IsEmpty over Count
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
-dotnet_diagnostic.CA1836.severity = warning
+dotnet_diagnostic.CA1836.severity = none
 
 # Title    : Use 'Environment.ProcessId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
-dotnet_diagnostic.CA1837.severity = warning
+dotnet_diagnostic.CA1837.severity = none
 
 # Title    : Avoid 'StringBuilder' parameters for P/Invokes
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
-dotnet_diagnostic.CA1838.severity = warning
+dotnet_diagnostic.CA1838.severity = none
 
 # Title    : Use 'Environment.ProcessPath'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
-dotnet_diagnostic.CA1839.severity = warning
+dotnet_diagnostic.CA1839.severity = none
 
 # Title    : Use 'Environment.CurrentManagedThreadId'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
-dotnet_diagnostic.CA1840.severity = warning
+dotnet_diagnostic.CA1840.severity = none
 
 # Title    : Prefer Dictionary.Contains methods
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
-dotnet_diagnostic.CA1841.severity = warning
+dotnet_diagnostic.CA1841.severity = none
 
 # Title    : Do not use 'WhenAll' with a single task
 # Category : Performance
@@ -786,27 +763,27 @@ dotnet_diagnostic.CA1842.severity = suggestion
 # Title    : Do not use 'WaitAll' with a single task
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
-dotnet_diagnostic.CA1843.severity = warning
+dotnet_diagnostic.CA1843.severity = none
 
 # Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
-dotnet_diagnostic.CA1844.severity = warning
+dotnet_diagnostic.CA1844.severity = none
 
 # Title    : Use span-based 'string.Concat'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
-dotnet_diagnostic.CA1845.severity = warning
+dotnet_diagnostic.CA1845.severity = none
 
 # Title    : Prefer 'AsSpan' over 'Substring'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
-dotnet_diagnostic.CA1846.severity = warning
+dotnet_diagnostic.CA1846.severity = none
 
 # Title    : Use char literal for a single character lookup
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
-dotnet_diagnostic.CA1847.severity = warning
+dotnet_diagnostic.CA1847.severity = none
 
 # Title    : Use the LoggerMessage delegates
 # Category : Performance
@@ -817,12 +794,12 @@ dotnet_diagnostic.CA1848.severity = none
 # Title    : Call async methods when in an async method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
-dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1849.severity = none
 
 # Title    : Prefer static 'HashData' method over 'ComputeHash'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
-dotnet_diagnostic.CA1850.severity = suggestion
+dotnet_diagnostic.CA1850.severity = none
 
 # Title    : Possible multiple enumerations of 'IEnumerable' collection
 # Category : Performance
@@ -838,17 +815,17 @@ dotnet_diagnostic.CA1852.severity = none
 # Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
-dotnet_diagnostic.CA1853.severity = suggestion
+dotnet_diagnostic.CA1853.severity = none
 
 # Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
-dotnet_diagnostic.CA1854.severity = warning
+dotnet_diagnostic.CA1854.severity = none
 
 # Title    : Prefer 'Clear' over 'Fill'
 # Category : Performance
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
-dotnet_diagnostic.CA1855.severity = warning
+dotnet_diagnostic.CA1855.severity = none
 
 # Title    : Incorrect usage of ConstantExpected attribute
 # Category : Performance
@@ -893,7 +870,7 @@ dotnet_diagnostic.CA2002.severity = warning
 # Title    : Consider calling ConfigureAwait on the awaited task
 # Category : Reliability
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
-dotnet_diagnostic.CA2007.severity = warning
+dotnet_diagnostic.CA2007.severity = none
 
 # Title    : Do not create tasks without passing a TaskScheduler
 # Category : Reliability
@@ -968,7 +945,7 @@ dotnet_diagnostic.CA2021.severity = warning
 # Title    : Review SQL queries for security vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
-dotnet_diagnostic.CA2100.severity = warning
+dotnet_diagnostic.CA2100.severity = none
 
 # Title    : Specify marshaling for P/Invoke string arguments
 # Category : Globalization
@@ -978,8 +955,7 @@ dotnet_diagnostic.CA2101.severity = warning
 # Title    : Review visible event handlers
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
-dotnet_diagnostic.CA2109.severity = warning
-dotnet_code_quality.CA2109.api_surface = public
+dotnet_diagnostic.CA2109.severity = none
 
 # Title    : Seal methods that satisfy private interfaces
 # Category : Security
@@ -1009,7 +985,7 @@ dotnet_diagnostic.CA2201.severity = warning
 # Title    : Initialize value type static fields inline
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
-dotnet_diagnostic.CA2207.severity = warning
+dotnet_diagnostic.CA2207.severity = none
 
 # Title    : Instantiate argument exceptions correctly
 # Category : Usage
@@ -1019,7 +995,7 @@ dotnet_diagnostic.CA2208.severity = warning
 # Title    : Non-constant fields should not be visible
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
-dotnet_diagnostic.CA2211.severity = warning
+dotnet_diagnostic.CA2211.severity = none
 
 # Title    : Disposable fields should be disposed
 # Category : Usage
@@ -1055,8 +1031,7 @@ dotnet_diagnostic.CA2219.severity = warning
 # Title    : Operator overloads have named alternates
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
-dotnet_diagnostic.CA2225.severity = warning
-dotnet_code_quality.CA2225.api_surface = public
+dotnet_diagnostic.CA2225.severity = none
 
 # Title    : Operators should have symmetrical overloads
 # Category : Usage
@@ -1067,7 +1042,7 @@ dotnet_diagnostic.CA2226.severity = none
 # Title    : Collection properties should be read only
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
-dotnet_diagnostic.CA2227.severity = warning
+dotnet_diagnostic.CA2227.severity = none
 
 # Title    : Implement serialization constructors
 # Category : Usage
@@ -1083,7 +1058,7 @@ dotnet_diagnostic.CA2231.severity = error
 # Title    : Pass system uri objects instead of strings
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
-dotnet_diagnostic.CA2234.severity = warning
+dotnet_diagnostic.CA2234.severity = none
 
 # Title    : Mark all non-serializable fields
 # Category : Usage
@@ -1165,7 +1140,7 @@ dotnet_diagnostic.CA2253.severity = warning
 # Title    : Template should be a static expression
 # Category : Usage
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
-dotnet_diagnostic.CA2254.severity = suggestion
+dotnet_diagnostic.CA2254.severity = none
 
 # Title    : The 'ModuleInitializer' attribute should not be used in libraries
 # Category : Usage
@@ -1200,1234 +1175,497 @@ dotnet_diagnostic.CA2260.severity = warning
 # Title    : Do not use insecure deserializer BinaryFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
-dotnet_diagnostic.CA2300.severity = warning
+dotnet_diagnostic.CA2300.severity = none
 
 # Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
-dotnet_diagnostic.CA2301.severity = warning
+dotnet_diagnostic.CA2301.severity = none
 
 # Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
-dotnet_diagnostic.CA2302.severity = warning
+dotnet_diagnostic.CA2302.severity = none
 
 # Title    : Do not use insecure deserializer LosFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
-dotnet_diagnostic.CA2305.severity = warning
+dotnet_diagnostic.CA2305.severity = none
 
 # Title    : Do not use insecure deserializer NetDataContractSerializer
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
-dotnet_diagnostic.CA2310.severity = warning
+dotnet_diagnostic.CA2310.severity = none
 
 # Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
-dotnet_diagnostic.CA2311.severity = warning
+dotnet_diagnostic.CA2311.severity = none
 
 # Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
-dotnet_diagnostic.CA2312.severity = warning
+dotnet_diagnostic.CA2312.severity = none
 
 # Title    : Do not use insecure deserializer ObjectStateFormatter
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
-dotnet_diagnostic.CA2315.severity = warning
+dotnet_diagnostic.CA2315.severity = none
 
 # Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
-dotnet_diagnostic.CA2321.severity = warning
+dotnet_diagnostic.CA2321.severity = none
 
 # Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
-dotnet_diagnostic.CA2322.severity = warning
+dotnet_diagnostic.CA2322.severity = none
 
 # Title    : Do not use TypeNameHandling values other than None
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
-dotnet_diagnostic.CA2326.severity = warning
+dotnet_diagnostic.CA2326.severity = none
 
 # Title    : Do not use insecure JsonSerializerSettings
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
-dotnet_diagnostic.CA2327.severity = warning
+dotnet_diagnostic.CA2327.severity = none
 
 # Title    : Ensure that JsonSerializerSettings are secure
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
-dotnet_diagnostic.CA2328.severity = warning
+dotnet_diagnostic.CA2328.severity = none
 
 # Title    : Do not deserialize with JsonSerializer using an insecure configuration
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
-dotnet_diagnostic.CA2329.severity = warning
+dotnet_diagnostic.CA2329.severity = none
 
 # Title    : Ensure that JsonSerializer has a secure configuration when deserializing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
-dotnet_diagnostic.CA2330.severity = warning
+dotnet_diagnostic.CA2330.severity = none
 
 # Title    : Do not use DataTable.ReadXml() with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
-dotnet_diagnostic.CA2350.severity = warning
+dotnet_diagnostic.CA2350.severity = none
 
 # Title    : Do not use DataSet.ReadXml() with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
-dotnet_diagnostic.CA2351.severity = warning
+dotnet_diagnostic.CA2351.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
-dotnet_diagnostic.CA2352.severity = warning
+dotnet_diagnostic.CA2352.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
-dotnet_diagnostic.CA2352.severity = warning
+dotnet_diagnostic.CA2352.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
-dotnet_diagnostic.CA2353.severity = warning
+dotnet_diagnostic.CA2353.severity = none
 
 # Title    : Unsafe DataSet or DataTable in serializable type
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
-dotnet_diagnostic.CA2353.severity = warning
+dotnet_diagnostic.CA2353.severity = none
 
 # Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
-dotnet_diagnostic.CA2354.severity = warning
+dotnet_diagnostic.CA2354.severity = none
 
 # Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
-dotnet_diagnostic.CA2354.severity = warning
+dotnet_diagnostic.CA2354.severity = none
 
 # Title    : Unsafe DataSet or DataTable type found in deserializable object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
-dotnet_diagnostic.CA2355.severity = warning
+dotnet_diagnostic.CA2355.severity = none
 
 # Title    : Unsafe DataSet or DataTable type found in deserializable object graph
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
-dotnet_diagnostic.CA2355.severity = warning
+dotnet_diagnostic.CA2355.severity = none
 
 # Title    : Unsafe DataSet or DataTable type in web deserializable object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
-dotnet_diagnostic.CA2356.severity = warning
+dotnet_diagnostic.CA2356.severity = none
 
 # Title    : Unsafe DataSet or DataTable type in web deserializable object graph
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
-dotnet_diagnostic.CA2356.severity = warning
+dotnet_diagnostic.CA2356.severity = none
 
 # Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
-dotnet_diagnostic.CA2361.severity = warning
+dotnet_diagnostic.CA2361.severity = none
 
 # Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
-dotnet_diagnostic.CA2362.severity = warning
+dotnet_diagnostic.CA2362.severity = none
 
 # Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
-dotnet_diagnostic.CA2362.severity = warning
+dotnet_diagnostic.CA2362.severity = none
 
 # Title    : Review code for SQL injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
-dotnet_diagnostic.CA3001.severity = warning
+dotnet_diagnostic.CA3001.severity = none
 
 # Title    : Review code for XSS vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
-dotnet_diagnostic.CA3002.severity = warning
+dotnet_diagnostic.CA3002.severity = none
 
 # Title    : Review code for file path injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
-dotnet_diagnostic.CA3003.severity = warning
+dotnet_diagnostic.CA3003.severity = none
 
 # Title    : Review code for information disclosure vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
-dotnet_diagnostic.CA3004.severity = warning
+dotnet_diagnostic.CA3004.severity = none
 
 # Title    : Review code for LDAP injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
-dotnet_diagnostic.CA3005.severity = warning
+dotnet_diagnostic.CA3005.severity = none
 
 # Title    : Review code for process command injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
-dotnet_diagnostic.CA3006.severity = warning
+dotnet_diagnostic.CA3006.severity = none
 
 # Title    : Review code for open redirect vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
-dotnet_diagnostic.CA3007.severity = warning
+dotnet_diagnostic.CA3007.severity = none
 
 # Title    : Review code for XPath injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
-dotnet_diagnostic.CA3008.severity = warning
+dotnet_diagnostic.CA3008.severity = none
 
 # Title    : Review code for XML injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
-dotnet_diagnostic.CA3009.severity = warning
+dotnet_diagnostic.CA3009.severity = none
 
 # Title    : Review code for XAML injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
-dotnet_diagnostic.CA3010.severity = warning
+dotnet_diagnostic.CA3010.severity = none
 
 # Title    : Review code for DLL injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
-dotnet_diagnostic.CA3011.severity = warning
+dotnet_diagnostic.CA3011.severity = none
 
 # Title    : Review code for regex injection vulnerabilities
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
-dotnet_diagnostic.CA3012.severity = warning
+dotnet_diagnostic.CA3012.severity = none
 
 # Title    : Do Not Add Schema By URL
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
-dotnet_diagnostic.CA3061.severity = silent
+dotnet_diagnostic.CA3061.severity = none
 
 # Title    : Insecure DTD processing in XML
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
-dotnet_diagnostic.CA3075.severity = warning
+dotnet_diagnostic.CA3075.severity = none
 
 # Title    : Insecure XSLT script processing.
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
-dotnet_diagnostic.CA3076.severity = warning
+dotnet_diagnostic.CA3076.severity = none
 
 # Title    : Insecure XSLT script processing
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
-dotnet_diagnostic.CA3076.severity = warning
+dotnet_diagnostic.CA3076.severity = none
 
 # Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
 # Category : Security
 # Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
-dotnet_diagnostic.CA3077.severity = warning
+dotnet_diagnostic.CA3077.severity = none
 
 # Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
-dotnet_diagnostic.CA3077.severity = warning
+dotnet_diagnostic.CA3077.severity = none
 
 # Title    : Mark Verb Handlers With Validate Antiforgery Token
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
-dotnet_diagnostic.CA3147.severity = warning
+dotnet_diagnostic.CA3147.severity = none
 
 # Title    : Do Not Use Weak Cryptographic Algorithms
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
-dotnet_diagnostic.CA5350.severity = error
+dotnet_diagnostic.CA5350.severity = none
 
 # Title    : Do Not Use Broken Cryptographic Algorithms
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
-dotnet_diagnostic.CA5351.severity = error
+dotnet_diagnostic.CA5351.severity = none
 
 # Title    : Review cipher mode usage with cryptography experts
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
-dotnet_diagnostic.CA5358.severity = warning
+dotnet_diagnostic.CA5358.severity = none
 
 # Title    : Do Not Disable Certificate Validation
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
-dotnet_diagnostic.CA5359.severity = warning
+dotnet_diagnostic.CA5359.severity = none
 
 # Title    : Do Not Call Dangerous Methods In Deserialization
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
-dotnet_diagnostic.CA5360.severity = warning
+dotnet_diagnostic.CA5360.severity = none
 
 # Title    : Do Not Disable SChannel Use of Strong Crypto
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
-dotnet_diagnostic.CA5361.severity = warning
+dotnet_diagnostic.CA5361.severity = none
 
 # Title    : Potential reference cycle in deserialized object graph
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
-dotnet_diagnostic.CA5362.severity = warning
+dotnet_diagnostic.CA5362.severity = none
 
 # Title    : Do Not Disable Request Validation
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
-dotnet_diagnostic.CA5363.severity = warning
+dotnet_diagnostic.CA5363.severity = none
 
 # Title    : Do Not Use Deprecated Security Protocols
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
-dotnet_diagnostic.CA5364.severity = warning
+dotnet_diagnostic.CA5364.severity = none
 
 # Title    : Do Not Disable HTTP Header Checking
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
-dotnet_diagnostic.CA5365.severity = warning
+dotnet_diagnostic.CA5365.severity = none
 
 # Title    : Use XmlReader for 'DataSet.ReadXml()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
-dotnet_diagnostic.CA5366.severity = warning
+dotnet_diagnostic.CA5366.severity = none
 
 # Title    : Do Not Serialize Types With Pointer Fields
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
-dotnet_diagnostic.CA5367.severity = warning
+dotnet_diagnostic.CA5367.severity = none
 
 # Title    : Set ViewStateUserKey For Classes Derived From Page
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
-dotnet_diagnostic.CA5368.severity = warning
+dotnet_diagnostic.CA5368.severity = none
 
 # Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
-dotnet_diagnostic.CA5369.severity = warning
+dotnet_diagnostic.CA5369.severity = none
 
 # Title    : Use XmlReader for XmlValidatingReader constructor
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
-dotnet_diagnostic.CA5370.severity = warning
+dotnet_diagnostic.CA5370.severity = none
 
 # Title    : Use XmlReader for 'XmlSchema.Read()'
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
-dotnet_diagnostic.CA5371.severity = warning
+dotnet_diagnostic.CA5371.severity = none
 
 # Title    : Use XmlReader for XPathDocument constructor
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
-dotnet_diagnostic.CA5372.severity = warning
+dotnet_diagnostic.CA5372.severity = none
 
 # Title    : Do not use obsolete key derivation function
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
-dotnet_diagnostic.CA5373.severity = warning
+dotnet_diagnostic.CA5373.severity = none
 
 # Title    : Do Not Use XslTransform
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
-dotnet_diagnostic.CA5374.severity = warning
+dotnet_diagnostic.CA5374.severity = none
 
 # Title    : Do Not Use Account Shared Access Signature
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
-dotnet_diagnostic.CA5375.severity = warning
+dotnet_diagnostic.CA5375.severity = none
 
 # Title    : Use SharedAccessProtocol HttpsOnly
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
-dotnet_diagnostic.CA5376.severity = warning
+dotnet_diagnostic.CA5376.severity = none
 
 # Title    : Use Container Level Access Policy
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
-dotnet_diagnostic.CA5377.severity = warning
+dotnet_diagnostic.CA5377.severity = none
 
 # Title    : Do not disable ServicePointManagerSecurityProtocols
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
-dotnet_diagnostic.CA5378.severity = warning
+dotnet_diagnostic.CA5378.severity = none
 
 # Title    : Ensure Key Derivation Function algorithm is sufficiently strong
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
-dotnet_diagnostic.CA5379.severity = warning
+dotnet_diagnostic.CA5379.severity = none
 
 # Title    : Do Not Add Certificates To Root Store
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
-dotnet_diagnostic.CA5380.severity = warning
+dotnet_diagnostic.CA5380.severity = none
 
 # Title    : Ensure Certificates Are Not Added To Root Store
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
-dotnet_diagnostic.CA5381.severity = warning
+dotnet_diagnostic.CA5381.severity = none
 
 # Title    : Use Secure Cookies In ASP.NET Core
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
-dotnet_diagnostic.CA5382.severity = warning
+dotnet_diagnostic.CA5382.severity = none
 
 # Title    : Ensure Use Secure Cookies In ASP.NET Core
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
-dotnet_diagnostic.CA5383.severity = warning
+dotnet_diagnostic.CA5383.severity = none
 
 # Title    : Do Not Use Digital Signature Algorithm (DSA)
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
-dotnet_diagnostic.CA5384.severity = warning
+dotnet_diagnostic.CA5384.severity = none
 
 # Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
-dotnet_diagnostic.CA5385.severity = warning
+dotnet_diagnostic.CA5385.severity = none
 
 # Title    : Avoid hardcoding SecurityProtocolType value
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
-dotnet_diagnostic.CA5386.severity = warning
+dotnet_diagnostic.CA5386.severity = none
 
 # Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
-dotnet_diagnostic.CA5387.severity = warning
+dotnet_diagnostic.CA5387.severity = none
 
 # Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
-dotnet_diagnostic.CA5388.severity = warning
+dotnet_diagnostic.CA5388.severity = none
 
 # Title    : Do Not Add Archive Item's Path To The Target File System Path
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
-dotnet_diagnostic.CA5389.severity = warning
+dotnet_diagnostic.CA5389.severity = none
 
 # Title    : Do not hard-code encryption key
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
-dotnet_diagnostic.CA5390.severity = warning
+dotnet_diagnostic.CA5390.severity = none
 
 # Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
-dotnet_diagnostic.CA5391.severity = warning
+dotnet_diagnostic.CA5391.severity = none
 
 # Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
-dotnet_diagnostic.CA5392.severity = warning
+dotnet_diagnostic.CA5392.severity = none
 
 # Title    : Do not use unsafe DllImportSearchPath value
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
-dotnet_diagnostic.CA5393.severity = warning
+dotnet_diagnostic.CA5393.severity = none
 
 # Title    : Do not use insecure randomness
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
-dotnet_diagnostic.CA5394.severity = warning
+dotnet_diagnostic.CA5394.severity = none
 
 # Title    : Miss HttpVerb attribute for action methods
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
-dotnet_diagnostic.CA5395.severity = warning
+dotnet_diagnostic.CA5395.severity = none
 
 # Title    : Set HttpOnly to true for HttpCookie
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
-dotnet_diagnostic.CA5396.severity = warning
+dotnet_diagnostic.CA5396.severity = none
 
 # Title    : Do not use deprecated SslProtocols values
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
-dotnet_diagnostic.CA5397.severity = warning
+dotnet_diagnostic.CA5397.severity = none
 
 # Title    : Avoid hardcoded SslProtocols values
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
-dotnet_diagnostic.CA5398.severity = warning
+dotnet_diagnostic.CA5398.severity = none
 
 # Title    : HttpClients should enable certificate revocation list checks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
-dotnet_diagnostic.CA5399.severity = warning
+dotnet_diagnostic.CA5399.severity = none
 
 # Title    : Ensure HttpClient certificate revocation list check is not disabled
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
-dotnet_diagnostic.CA5400.severity = warning
+dotnet_diagnostic.CA5400.severity = none
 
 # Title    : Do not use CreateEncryptor with non-default IV
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
-dotnet_diagnostic.CA5401.severity = warning
+dotnet_diagnostic.CA5401.severity = none
 
 # Title    : Use CreateEncryptor with the default IV 
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
-dotnet_diagnostic.CA5402.severity = warning
+dotnet_diagnostic.CA5402.severity = none
 
 # Title    : Do not hard-code certificate
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
-dotnet_diagnostic.CA5403.severity = warning
+dotnet_diagnostic.CA5403.severity = none
 
 # Title    : Do not disable token validation checks
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
-dotnet_diagnostic.CA5404.severity = warning
+dotnet_diagnostic.CA5404.severity = none
 
 # Title    : Do not always skip token validation in delegates
 # Category : Security
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
-dotnet_diagnostic.CA5405.severity = warning
-
-# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
-# Category : Style
-# Help Link: https://github.com/dotnet/roslyn/issues/41640
-dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
-
-# Title    : Simplify name
-# Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
-dotnet_diagnostic.IDE0001.severity = silent
-
-# Title    : Simplify name
-# Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
-dotnet_diagnostic.IDE0002.severity = silent
-
-# Title    : Remove this or Me qualification
-# Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
-dotnet_diagnostic.IDE0003.severity = silent
-dotnet_style_qualification_for_event = false
-dotnet_style_qualification_for_field = false
-dotnet_style_qualification_for_method = false
-dotnet_style_qualification_for_property = false
-
-# Title    : Remove Unnecessary Cast
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
-dotnet_diagnostic.IDE0004.severity = warning
-
-# Title    : Using directive is unnecessary.
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
-# Redundant: S1128
-dotnet_diagnostic.IDE0005.severity = none
-
-# Title    : Using directive is unnecessary.
-# Category : Style
-# Redundant: S1128
-dotnet_diagnostic.IDE0005_gen.severity = none
-
-# Title    : Use implicit type
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
-dotnet_diagnostic.IDE0007.severity = silent
-csharp_style_var_elsewhere = true
-csharp_style_var_for_built_in_types = false
-csharp_style_var_when_type_is_apparent = true
-
-# Title    : Use explicit type
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
-dotnet_diagnostic.IDE0008.severity = silent
-
-# Title    : Member access should be qualified.
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
-dotnet_diagnostic.IDE0009.severity = none
-
-# Title    : Add missing cases
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
-dotnet_diagnostic.IDE0010.severity = silent
-
-# Title    : Add braces
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
-dotnet_diagnostic.IDE0011.severity = warning
-csharp_prefer_braces = true
-
-# Title    : Use 'throw' expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
-dotnet_diagnostic.IDE0016.severity = warning
-csharp_style_throw_expression = true
-
-# Title    : Simplify object initialization
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
-dotnet_diagnostic.IDE0017.severity = warning
-dotnet_style_object_initializer = true
-
-# Title    : Inline variable declaration
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
-dotnet_diagnostic.IDE0018.severity = warning
-csharp_style_inlined_variable_declaration = true
-
-# Title    : Use pattern matching
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
-dotnet_diagnostic.IDE0019.severity = silent
-csharp_style_pattern_matching_over_is_with_cast_check = true
-
-# Title    : Use pattern matching
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
-dotnet_diagnostic.IDE0020.severity = silent
-csharp_style_pattern_matching_over_is_with_cast_check
-
-# Title    : Use expression body for constructor
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
-dotnet_diagnostic.IDE0021.severity = warning
-csharp_style_expression_bodied_constructors = false
-
-# Title    : Use expression body for method
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
-dotnet_diagnostic.IDE0022.severity = silent
-csharp_style_expression_bodied_methods = when_on_single_line
-
-# Title    : Use expression body for conversion operator
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
-dotnet_diagnostic.IDE0023.severity = warning
-csharp_style_expression_bodied_operators = false
-
-# Title    : Use expression body for operator
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
-dotnet_diagnostic.IDE0024.severity = warning
-csharp_style_expression_bodied_operators = false
-
-# Title    : Use expression body for property
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
-dotnet_diagnostic.IDE0025.severity = warning
-csharp_style_expression_bodied_properties = true
-
-# Title    : Use expression body for indexer
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
-dotnet_diagnostic.IDE0026.severity = warning
-csharp_style_expression_bodied_indexers = true
-
-# Title    : Use expression body for accessor
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
-dotnet_diagnostic.IDE0027.severity = warning
-csharp_style_expression_bodied_accessors = true
-
-# Title    : Simplify collection initialization
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
-dotnet_diagnostic.IDE0028.severity = warning
-dotnet_style_collection_initializer = true
-
-# Title    : Use coalesce expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
-dotnet_diagnostic.IDE0029.severity = warning
-dotnet_style_coalesce_expression = true
-
-# Title    : Use coalesce expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
-dotnet_diagnostic.IDE0030.severity = warning
-dotnet_style_coalesce_expression = true
-
-# Title    : Use null propagation
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
-dotnet_diagnostic.IDE0031.severity = warning
-dotnet_style_null_propagation = true
-
-# Title    : Use auto property
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
-dotnet_diagnostic.IDE0032.severity = warning
-dotnet_style_prefer_auto_properties = true
-
-# Title    : Use explicitly provided tuple name
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
-dotnet_diagnostic.IDE0033.severity = warning
-dotnet_style_explicit_tuple_names = true
-
-# Title    : Simplify 'default' expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
-dotnet_diagnostic.IDE0034.severity = warning
-csharp_prefer_simple_default_expression = true
-
-# Title    : Unreachable code detected
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
-dotnet_diagnostic.IDE0035.severity = warning
-
-# Title    : Order modifiers
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
-dotnet_diagnostic.IDE0036.severity = silent
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
-
-# Title    : Use inferred member name
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
-dotnet_diagnostic.IDE0037.severity = silent
-dotnet_style_prefer_inferred_anonymous_type_member_names = true
-dotnet_style_prefer_inferred_tuple_names = true
-
-# Title    : Use local function
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
-dotnet_diagnostic.IDE0039.severity = silent
-csharp_style_prefer_local_over_anonymous_function = false
-
-# Title    : Add accessibility modifiers
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
-dotnet_diagnostic.IDE0040.severity = warning
-dotnet_style_require_accessibility_modifiers = for_non_interface_members
-
-# Title    : Use 'is null' check
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
-dotnet_diagnostic.IDE0041.severity = warning
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true
-
-# Title    : Deconstruct variable declaration
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
-dotnet_diagnostic.IDE0042.severity = silent
-csharp_style_deconstructed_variable_declaration = true
-
-# Title    : Invalid format string
-# Category : Compiler
-dotnet_diagnostic.IDE0043.severity = warning
-
-# Title    : Add readonly modifier
-# Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
-dotnet_diagnostic.IDE0044.severity = warning
-dotnet_style_readonly_field = true:warning
-
-# Title    : Add readonly modifier
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
-dotnet_diagnostic.IDE0044.severity = silent
-
-# Title    : Convert to conditional expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
-dotnet_diagnostic.IDE0045.severity = silent
-dotnet_style_prefer_conditional_expression_over_assignment = true
-
-# Title    : Convert to conditional expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
-dotnet_diagnostic.IDE0046.severity = silent
-dotnet_style_prefer_conditional_expression_over_return = true
-
-# Title    : Remove unnecessary parentheses
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
-dotnet_diagnostic.IDE0047.severity = silent
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
-
-# Title    : Add parentheses for clarity
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
-dotnet_diagnostic.IDE0048.severity = silent
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
-dotnet_style_predefined_type_for_locals_parameters_members = true
-dotnet_style_predefined_type_for_member_access = true
-
-# Title    : Use language keywords instead of framework type names for type references
-# Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
-dotnet_diagnostic.IDE0049.severity = none
-
-# Title    : Convert to tuple
-# Category : Style
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
-dotnet_diagnostic.IDE0050.severity = silent
-
-# Title    : Remove unused private members
-# Category : CodeQuality
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
-dotnet_diagnostic.IDE0051.severity = warning
-
-# Title    : Remove unread private members
-# Category : CodeQuality
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
-dotnet_diagnostic.IDE0052.severity = warning
-
-# Title    : Use block body for lambda expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
-# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
-dotnet_diagnostic.IDE0053.severity = suggestion
-csharp_style_expression_bodied_lambdas = when_on_single_line
-
-# Title    : Use compound assignment
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
-dotnet_diagnostic.IDE0054.severity = warning
-dotnet_style_prefer_compound_assignment = true
-
-# Title    : Fix formatting
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
-dotnet_diagnostic.IDE0055.severity = warning
-dotnet_style_namespace_match_folder = true
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_open_brace = all
-csharp_new_line_between_query_expression_clauses = true
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = false
-csharp_indent_labels = flush_left
-csharp_indent_switch_labels = true
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_between_square_brackets = false
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = false
-
-# Title    : Use index operator
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
-dotnet_diagnostic.IDE0056.severity = silent
-csharp_style_prefer_index_operator = true
-
-# Title    : Use range operator
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
-dotnet_diagnostic.IDE0057.severity = silent
-csharp_style_prefer_range_operator = true:warning
-
-# Title    : Expression value is never used
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
-dotnet_diagnostic.IDE0058.severity = warning
-csharp_style_unused_value_expression_statement_preference = discard_variable
-
-# Title    : Unnecessary assignment of a value
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
-# Redundant: CS0219
-dotnet_diagnostic.IDE0059.severity = none
-
-# Title    : Remove unused parameter
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
-dotnet_diagnostic.IDE0060.severity = warning
-dotnet_code_quality_unused_parameters = all
-
-# Title    : Use expression body for local function
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
-dotnet_diagnostic.IDE0061.severity = warning
-csharp_style_expression_bodied_local_functions = true
-
-# Title    : Make local function 'static'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
-dotnet_diagnostic.IDE0062.severity = warning
-csharp_prefer_static_local_function = true
-
-# Title    : Use simple 'using' statement
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
-dotnet_diagnostic.IDE0063.severity = warning
-csharp_prefer_simple_using_statement = true
-
-# Title    : Make readonly fields writable
-# Category : CodeQuality
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
-dotnet_diagnostic.IDE0064.severity = warning
-
-# Title    : Misplaced using directive
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
-dotnet_diagnostic.IDE0065.severity = warning
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = true
-csharp_using_directive_placement = outside_namespace:suggestion
-
-# Title    : Convert switch statement to expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
-dotnet_diagnostic.IDE0066.severity = warning
-csharp_style_prefer_switch_expression = true:warning
-
-# Title    : Use 'System.HashCode'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
-dotnet_diagnostic.IDE0070.severity = warning
-
-# Title    : Simplify interpolation
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
-dotnet_diagnostic.IDE0071.severity = warning
-dotnet_style_prefer_simplified_interpolation = true
-
-# Title    : Add missing cases
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
-dotnet_diagnostic.IDE0072.severity = silent
-
-# Title    : The file header does not match the required text
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
-dotnet_diagnostic.IDE0073.severity = warning
-
-# Title    : Use compound assignment
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
-dotnet_diagnostic.IDE0074.severity = suggestion
-dotnet_style_prefer_compound_assignment = true
-
-# Title    : Simplify conditional expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
-dotnet_diagnostic.IDE0075.severity = warning
-dotnet_style_prefer_simplified_boolean_expressions = true
-
-# Title    : Invalid global 'SuppressMessageAttribute'
-# Category : CodeQuality
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
-dotnet_diagnostic.IDE0076.severity = warning
-
-# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
-# Category : CodeQuality
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
-dotnet_diagnostic.IDE0077.severity = warning
-
-# Title    : Use pattern matching
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
-dotnet_diagnostic.IDE0078.severity = silent
-csharp_style_prefer_pattern_matching = true
-
-# Title    : Remove unnecessary suppression
-# Category : Style
-# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
-dotnet_diagnostic.IDE0079.severity = suggestion
-dotnet_remove_unnecessary_suppression_exclusions = CS0618
-
-# Title    : Remove unnecessary suppression operator
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
-dotnet_diagnostic.IDE0080.severity = warning
-
-# Title    : 'typeof' can be converted  to 'nameof'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
-dotnet_diagnostic.IDE0082.severity = warning
-
-# Title    : Use pattern matching
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
-dotnet_diagnostic.IDE0083.severity = silent
-csharp_style_prefer_not_pattern = true
-
-# Title    : Use 'new(...)'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
-dotnet_diagnostic.IDE0090.severity = warning
-csharp_style_implicit_object_creation_when_type_is_apparent = true
-
-# Title    : Remove redundant equality
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
-# Comment  : S1125 triggers in more cases
-# Redundant: S1125
-dotnet_diagnostic.IDE0100.severity = none
-
-# Title    : Remove unnecessary discard
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
-dotnet_diagnostic.IDE0110.severity = warning
-
-# Title    : Simplify LINQ expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
-dotnet_diagnostic.IDE0120.severity = silent
-
-# Title    : Namespace does not match folder structure
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
-dotnet_diagnostic.IDE0130.severity = silent
-
-# Title    : Prefer 'null' check over type check
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
-dotnet_diagnostic.IDE0150.severity = warning
-csharp_style_prefer_null_check_over_type_check = true
-
-# Title    : Convert to block scoped namespace
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
-dotnet_diagnostic.IDE0160.severity = silent
-csharp_style_namespace_declarations = file_scoped
-
-# Title    : Convert to file-scoped namespace
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
-dotnet_diagnostic.IDE0161.severity = silent
-csharp_style_namespace_declarations = file_scoped
-
-# Title    : Property pattern can be simplified
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
-dotnet_diagnostic.IDE0170.severity = silent
-csharp_style_prefer_extended_property_pattern = true
-
-# Title    : Use tuple to swap values
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
-dotnet_diagnostic.IDE0180.severity = silent
-csharp_style_prefer_tuple_swap = true
-
-# Title    : Null check can be simplified
-# Category : Style
-# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
-dotnet_diagnostic.IDE0190.severity = silent
-
-# Title    : Remove unnecessary lambda expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
-dotnet_diagnostic.IDE0200.severity = silent
-
-# Title    : Convert to top-level statements
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
-dotnet_diagnostic.IDE0210.severity = silent
-
-# Title    : Convert to 'Program.Main' style program
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
-dotnet_diagnostic.IDE0211.severity = silent
-
-# Title    : Add explicit cast
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
-dotnet_diagnostic.IDE0220.severity = silent
-
-# Title    : Use UTF-8 string literal
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
-dotnet_diagnostic.IDE0230.severity = silent
-
-# Title    : Remove redundant nullable directive
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
-dotnet_diagnostic.IDE0240.severity = warning
-
-# Title    : Remove unnecessary nullable directive
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
-dotnet_diagnostic.IDE0241.severity = warning
-
-# Title    : Make struct 'readonly'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
-dotnet_diagnostic.IDE0250.severity = warning
-
-# Title    : Make member 'readonly'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
-dotnet_diagnostic.IDE0251.severity = none
-
-# Title    : Use pattern matching
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
-dotnet_diagnostic.IDE0260.severity = silent
-
-# Title    : Use coalesce expression
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
-dotnet_diagnostic.IDE0270.severity = silent
-
-# Title    : Use 'nameof'
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
-dotnet_diagnostic.IDE0280.severity = silent
-
-# Title    : Delegate invocation can be simplified.
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
-dotnet_diagnostic.IDE1005.severity = warning
-csharp_style_conditional_delegate_call = true
-
-# Title    : Naming Styles
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
-dotnet_diagnostic.IDE1006.severity = warning
-dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
-dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
-dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
-dotnet_naming_rule.types_should_be_pascalcase.severity = warning
-dotnet_naming_rule.types_should_be_pascalcase.symbols = types
-dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
-dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
-dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
-dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
-dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
-dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
-dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
-dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
-dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
-dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
-dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
-dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
-dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
-dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
-dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
-dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
-dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
-dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
-dotnet_naming_rule.field_should_be_pascalcase.severity = warning
-dotnet_naming_rule.field_should_be_pascalcase.symbols = field
-dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers =
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers =
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers =
-dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
-dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
-dotnet_naming_symbols.method_parameter.required_modifiers =
-dotnet_naming_symbols.local_variable.applicable_kinds = local
-dotnet_naming_symbols.local_variable.applicable_accessibilities = local
-dotnet_naming_symbols.local_variable.required_modifiers =
-dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
-dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
-dotnet_naming_symbols.type_parameter.required_modifiers =
-dotnet_naming_symbols.constant.applicable_kinds = field, local
-dotnet_naming_symbols.constant.applicable_accessibilities = *
-dotnet_naming_symbols.constant.required_modifiers = const
-dotnet_naming_symbols.private_field.applicable_kinds = field
-dotnet_naming_symbols.private_field.applicable_accessibilities = private
-dotnet_naming_symbols.private_field.required_modifiers =
-dotnet_naming_symbols.field.applicable_kinds = field
-dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
-dotnet_naming_symbols.field.required_modifiers =
-dotnet_naming_style.pascalcase.required_prefix =
-dotnet_naming_style.pascalcase.required_suffix =
-dotnet_naming_style.pascalcase.word_separator =
-dotnet_naming_style.pascalcase.capitalization = pascal_case
-dotnet_naming_style.ipascalcase.required_prefix = I
-dotnet_naming_style.ipascalcase.required_suffix =
-dotnet_naming_style.ipascalcase.word_separator =
-dotnet_naming_style.ipascalcase.capitalization = pascal_case
-dotnet_naming_style.camelcase.required_prefix =
-dotnet_naming_style.camelcase.required_suffix =
-dotnet_naming_style.camelcase.word_separator =
-dotnet_naming_style.camelcase.capitalization = camel_case
-dotnet_naming_style._camelcase.required_prefix = _
-dotnet_naming_style._camelcase.required_suffix =
-dotnet_naming_style._camelcase.word_separator =
-dotnet_naming_style._camelcase.capitalization = camel_case
-dotnet_naming_style.tpascalcase.required_prefix = T
-dotnet_naming_style.tpascalcase.required_suffix =
-dotnet_naming_style.tpascalcase.word_separator =
-dotnet_naming_style.tpascalcase.capitalization = pascal_case
-
-# Title    : Avoid multiple blank lines
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
-dotnet_diagnostic.IDE2000.severity = warning
-dotnet_style_allow_multiple_blank_lines_experimental = false
-
-# Title    : Embedded statements must be on their own line
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
-dotnet_diagnostic.IDE2001.severity = warning
-
-# Title    : Consecutive braces must not have blank line between them
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
-dotnet_diagnostic.IDE2002.severity = warning
-
-# Title    : Blank line required between block and subsequent statement
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
-dotnet_diagnostic.IDE2003.severity = silent
-
-# Title    : Blank line not allowed after constructor initializer colon
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
-dotnet_diagnostic.IDE2004.severity = warning
-
-# Title    : Blank line not allowed after conditional expression token
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
-dotnet_diagnostic.IDE2005.severity = silent
-
-# Title    : Blank line not allowed after arrow expression clause token
-# Category : Style
-# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
-dotnet_diagnostic.IDE2006.severity = silent
+dotnet_diagnostic.CA5405.severity = none
 
 # Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 # Category : Trimming
@@ -2694,57 +1932,57 @@ dotnet_diagnostic.IL3056.severity = warning
 # Title    : Use source generated logging methods for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a000
-dotnet_diagnostic.R9A000.severity = warning
+dotnet_diagnostic.R9A000.severity = none
 
 # Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a014
-dotnet_diagnostic.R9A014.severity = warning
+dotnet_diagnostic.R9A014.severity = none
 
 # Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a015
-dotnet_diagnostic.R9A015.severity = warning
+dotnet_diagnostic.R9A015.severity = none
 
 # Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a018
-dotnet_diagnostic.R9A018.severity = warning
+dotnet_diagnostic.R9A018.severity = none
 
 # Title    : Remove unnecessary dictionary lookups
 # Category : Performance
 # Help Link: https://TODO/r9a019
-dotnet_diagnostic.R9A019.severity = warning
+dotnet_diagnostic.R9A019.severity = none
 
 # Title    : Remove unnecessary set lookups
 # Category : Performance
 # Help Link: https://TODO/r9a020
-dotnet_diagnostic.R9A020.severity = warning
+dotnet_diagnostic.R9A020.severity = none
 
 # Title    : Perform message formatting in the body of the logging method
 # Category : Performance
 # Help Link: https://TODO/r9a021
-dotnet_diagnostic.R9A021.severity = warning
+dotnet_diagnostic.R9A021.severity = none
 
 # Title    : Use 'System.TimeProvider' to make the code easier to test
 # Category : Reliability
 # Help Link: https://TODO/r9a022
-dotnet_diagnostic.R9A022.severity = warning
+dotnet_diagnostic.R9A022.severity = none
 
 # Title    : Using experimental API
 # Category : Reliability
 # Help Link: https://TODO/r9a029
-dotnet_diagnostic.R9A029.severity = none
+dotnet_diagnostic.R9A029.severity = warning
 
 # Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
 # Category : Performance
 # Help Link: https://TODO/r9a030
-dotnet_diagnostic.R9A030.severity = warning
+dotnet_diagnostic.R9A030.severity = none
 
 # Title    : Make types declared in an executable internal
 # Category : Performance
 # Help Link: https://TODO/r9a031
-dotnet_diagnostic.R9A031.severity = warning
+dotnet_diagnostic.R9A031.severity = none
 
 # Title    : Consider using an array instead of a collection
 # Category : Performance
@@ -2754,67 +1992,67 @@ dotnet_diagnostic.R9A032.severity = none
 # Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a033
-dotnet_diagnostic.R9A033.severity = warning
+dotnet_diagnostic.R9A033.severity = none
 
 # Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a036
-dotnet_diagnostic.R9A036.severity = warning
+dotnet_diagnostic.R9A036.severity = none
 
 # Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a037
-dotnet_diagnostic.R9A037.severity = warning
+dotnet_diagnostic.R9A037.severity = none
 
 # Title    : Use generic collections instead of legacy collections for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a040
-dotnet_diagnostic.R9A040.severity = warning
+dotnet_diagnostic.R9A040.severity = none
 
 # Title    : Use 'System.MemoryExtensions.Split' for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a043
-dotnet_diagnostic.R9A043.severity = warning
+dotnet_diagnostic.R9A043.severity = none
 
 # Title    : Assign array of literal values to a static field for improved performance
 # Category : Performance
 # Help Link: https://TODO/r9a044
-dotnet_diagnostic.R9A044.severity = warning
+dotnet_diagnostic.R9A044.severity = none
 
 # Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a049
-dotnet_diagnostic.R9A049.severity = warning
+dotnet_diagnostic.R9A049.severity = none
 
 # Title    : Experimental symbols cannot be marked as obsolete
 # Category : Correctness
 # Help Link: https://TODO/r9a050
-dotnet_diagnostic.R9A050.severity = warning
+dotnet_diagnostic.R9A050.severity = none
 
 # Title    : Published symbols cannot be marked experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a051
-dotnet_diagnostic.R9A051.severity = warning
+dotnet_diagnostic.R9A051.severity = none
 
 # Title    : Published symbols cannot be deleted to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a052
-dotnet_diagnostic.R9A052.severity = warning
+dotnet_diagnostic.R9A052.severity = none
 
 # Title    : A deprecated API is not annotated with the obsolete attribute
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
-dotnet_diagnostic.R9A053.severity = warning
+dotnet_diagnostic.R9A053.severity = none
 
 # Title    : A deprecated API is marked as experimental
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
-dotnet_diagnostic.R9A054.severity = warning
+dotnet_diagnostic.R9A054.severity = none
 
 # Title    : Published symbols cannot be changed to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a055
-dotnet_diagnostic.R9A055.severity = warning
+dotnet_diagnostic.R9A055.severity = none
 
 # Title    : Fire-and-forget async call inside a 'using' block
 # Category : Correctness
@@ -2839,11 +2077,7 @@ dotnet_diagnostic.R9A060.severity = suggestion
 # Title    : The async method doesn't support cancellation
 # Category : Resilience
 # Help Link: https://TODO/r9a061
-dotnet_diagnostic.R9A061.severity = warning
-
-# Title    : 
-# Category : Style
-dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+dotnet_diagnostic.R9A061.severity = none
 
 # Title    : Methods and properties should be named in PascalCase
 # Category : Minor Code Smell
@@ -2887,7 +2121,7 @@ dotnet_diagnostic.S105.severity = none
 # Title    : Standard outputs should not be used directly to log anything
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
-dotnet_diagnostic.S106.severity = warning
+dotnet_diagnostic.S106.severity = none
 
 # Title    : Collapsible "if" statements should be merged
 # Category : Major Code Smell
@@ -3089,7 +2323,7 @@ dotnet_diagnostic.S1210.severity = none
 # Title    : "GC.Collect" should not be called
 # Category : Critical Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
-dotnet_diagnostic.S1215.severity = warning
+dotnet_diagnostic.S1215.severity = none
 
 # Title    : Statements should be on separate lines
 # Category : Major Code Smell
@@ -3422,7 +2656,7 @@ dotnet_diagnostic.S2225.severity = warning
 # Title    : Console logging should not be used
 # Category : Minor Vulnerability
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
-dotnet_diagnostic.S2228.severity = warning
+dotnet_diagnostic.S2228.severity = none
 
 # Title    : Parameters should be passed in the correct order
 # Category : Major Code Smell
@@ -4214,7 +3448,7 @@ dotnet_diagnostic.S3876.severity = warning
 # Title    : Exceptions should not be thrown from unexpected methods
 # Category : Blocker Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
-dotnet_diagnostic.S3877.severity = warning
+dotnet_diagnostic.S3877.severity = none
 
 # Title    : Finalizers should not be empty
 # Category : Major Code Smell
@@ -4318,7 +3552,7 @@ dotnet_diagnostic.S3927.severity = warning
 # Title    : Parameter names used into ArgumentException constructors should match an existing one 
 # Category : Major Code Smell
 # Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
-dotnet_diagnostic.S3928.severity = warning
+dotnet_diagnostic.S3928.severity = none
 
 # Title    : Number patterns should be regular
 # Category : Critical Code Smell
@@ -4975,1047 +4209,6 @@ dotnet_diagnostic.S9999-symbolRef.severity = warning
 # Category : 
 dotnet_diagnostic.S9999-token-type.severity = warning
 
-# Title    : XML comment analysis disabled
-# Category : StyleCop.CSharp.SpecialRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
-dotnet_diagnostic.SA0001.severity = none
-
-# Title    : Invalid settings file
-# Category : StyleCop.CSharp.SpecialRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
-dotnet_diagnostic.SA0002.severity = warning
-
-# Title    : Keywords should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1000.severity = none
-
-# Title    : Commas should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1001.severity = none
-
-# Title    : Semicolons should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1002.severity = none
-
-# Title    : Symbols should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1003.severity = none
-
-# Title    : Documentation lines should begin with single space
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
-dotnet_diagnostic.SA1004.severity = warning
-
-# Title    : Single line comments should begin with single space
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
-dotnet_diagnostic.SA1005.severity = warning
-
-# Title    : Preprocessor keywords should not be preceded by space
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
-dotnet_diagnostic.SA1006.severity = warning
-
-# Title    : Operator keyword should be followed by space
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1007.severity = none
-
-# Title    : Opening parenthesis should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1008.severity = none
-
-# Title    : Closing parenthesis should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1009.severity = none
-
-# Title    : Opening square brackets should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1010.severity = none
-
-# Title    : Closing square brackets should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1011.severity = none
-
-# Title    : Opening braces should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1012.severity = none
-
-# Title    : Closing braces should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1013.severity = none
-
-# Title    : Opening generic brackets should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1014.severity = none
-
-# Title    : Closing generic brackets should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1015.severity = none
-
-# Title    : Opening attribute brackets should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1016.severity = none
-
-# Title    : Closing attribute brackets should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1017.severity = none
-
-# Title    : Nullable type symbols should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1018.severity = none
-
-# Title    : Member access symbols should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1019.severity = none
-
-# Title    : Increment decrement symbols should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1020.severity = none
-
-# Title    : Negative signs should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1021.severity = none
-
-# Title    : Positive signs should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1022.severity = none
-
-# Title    : Dereference and access of symbols should be spaced correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1023.severity = none
-
-# Title    : Colons Should Be Spaced Correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1024.severity = none
-
-# Title    : Code should not contain multiple whitespace in a row
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1025.severity = none
-
-# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1026.severity = none
-
-# Title    : Use tabs correctly
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
-dotnet_diagnostic.SA1027.severity = warning
-
-# Title    : Code should not contain trailing whitespace
-# Category : StyleCop.CSharp.SpacingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1028.severity = none
-
-# Title    : Do not prefix calls with base unless local implementation exists
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
-dotnet_diagnostic.SA1100.severity = warning
-
-# Title    : Prefix local calls with this
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
-dotnet_diagnostic.SA1101.severity = none
-
-# Title    : Query clause should follow previous clause
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
-dotnet_diagnostic.SA1102.severity = warning
-
-# Title    : Query clauses should be on separate lines or all on one line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
-dotnet_diagnostic.SA1103.severity = warning
-
-# Title    : Query clause should begin on new line when previous clause spans multiple lines
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
-dotnet_diagnostic.SA1104.severity = warning
-
-# Title    : Query clauses spanning multiple lines should begin on own line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
-dotnet_diagnostic.SA1105.severity = warning
-
-# Title    : Code should not contain empty statements
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
-dotnet_diagnostic.SA1106.severity = warning
-
-# Title    : Code should not contain multiple statements on one line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
-# Redundant: IDE2001
-dotnet_diagnostic.SA1107.severity = none
-
-# Title    : Block statements should not contain embedded comments
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
-dotnet_diagnostic.SA1108.severity = warning
-
-# Title    : Block statements should not contain embedded regions
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
-dotnet_diagnostic.SA1109.severity = warning
-
-# Title    : Opening parenthesis or bracket should be on declaration line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
-dotnet_diagnostic.SA1110.severity = warning
-
-# Title    : Closing parenthesis should be on line of last parameter
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
-dotnet_diagnostic.SA1111.severity = warning
-
-# Title    : Closing parenthesis should be on line of opening parenthesis
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
-dotnet_diagnostic.SA1112.severity = warning
-
-# Title    : Comma should be on the same line as previous parameter
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
-dotnet_diagnostic.SA1113.severity = warning
-
-# Title    : Parameter list should follow declaration
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
-dotnet_diagnostic.SA1114.severity = warning
-
-# Title    : Parameter should follow comma
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
-dotnet_diagnostic.SA1115.severity = none
-
-# Title    : Split parameters should start on line after declaration
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
-dotnet_diagnostic.SA1116.severity = none
-
-# Title    : Parameters should be on same line or separate lines
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
-dotnet_diagnostic.SA1117.severity = none
-
-# Title    : Parameter should not span multiple lines
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
-dotnet_diagnostic.SA1118.severity = warning
-
-# Title    : Statement should not use unnecessary parenthesis
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
-dotnet_diagnostic.SA1119.severity = warning
-
-# Title    : Statement should not use unnecessary parenthesis
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
-dotnet_diagnostic.SA1119_p.severity = none
-
-# Title    : Comments should contain text
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
-dotnet_diagnostic.SA1120.severity = warning
-
-# Title    : Use built-in type alias
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
-dotnet_diagnostic.SA1121.severity = warning
-
-# Title    : Use string.Empty for empty strings
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
-dotnet_diagnostic.SA1122.severity = warning
-
-# Title    : Do not place regions within elements
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
-dotnet_diagnostic.SA1123.severity = warning
-
-# Title    : Do not use regions
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
-dotnet_diagnostic.SA1124.severity = none
-
-# Title    : Use shorthand for nullable types
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
-dotnet_diagnostic.SA1125.severity = warning
-
-# Title    : Prefix calls correctly
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
-dotnet_diagnostic.SA1126.severity = none
-
-# Title    : Generic type constraints should be on their own line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
-dotnet_diagnostic.SA1127.severity = warning
-
-# Title    : Put constructor initializers on their own line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
-dotnet_diagnostic.SA1128.severity = warning
-
-# Title    : Do not use default value type constructor
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
-dotnet_diagnostic.SA1129.severity = warning
-
-# Title    : Use lambda syntax
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
-dotnet_diagnostic.SA1130.severity = warning
-
-# Title    : Use readable conditions
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
-dotnet_diagnostic.SA1131.severity = warning
-
-# Title    : Do not combine fields
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
-# Comment  : S1169 handles fields and variables
-# Redundant: S1169
-dotnet_diagnostic.SA1132.severity = none
-
-# Title    : Do not combine attributes
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
-dotnet_diagnostic.SA1133.severity = warning
-
-# Title    : Attributes should not share line
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
-# Redundant: IDE0055
-dotnet_diagnostic.SA1134.severity = none
-
-# Title    : Using directives should be qualified
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
-dotnet_diagnostic.SA1135.severity = warning
-
-# Title    : Enum values should be on separate lines
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
-dotnet_diagnostic.SA1136.severity = warning
-
-# Title    : Elements should have the same indentation
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
-# Comment  : Doesn't work with file-scoped namespaces
-dotnet_diagnostic.SA1137.severity = none
-
-# Title    : Use literal suffix notation instead of casting
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
-dotnet_diagnostic.SA1139.severity = warning
-
-# Title    : Use tuple syntax
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
-dotnet_diagnostic.SA1141.severity = warning
-
-# Title    : Refer to tuple fields by name
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
-# Redundant: IDE0033
-dotnet_diagnostic.SA1142.severity = none
-
-# Title    : Using directives should be placed correctly
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
-# Redundant: IDE0065
-dotnet_diagnostic.SA1200.severity = none
-
-# Title    : Elements should appear in the correct order
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
-dotnet_diagnostic.SA1201.severity = none
-
-# Title    : Elements should be ordered by access
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
-dotnet_diagnostic.SA1202.severity = warning
-
-# Title    : Constants should appear before fields
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
-dotnet_diagnostic.SA1203.severity = warning
-
-# Title    : Static elements should appear before instance elements
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
-dotnet_diagnostic.SA1204.severity = warning
-
-# Title    : Partial elements should declare access
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
-dotnet_diagnostic.SA1205.severity = warning
-
-# Title    : Declaration keywords should follow order
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
-dotnet_diagnostic.SA1206.severity = warning
-
-# Title    : Protected should come before internal
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
-dotnet_diagnostic.SA1207.severity = warning
-
-# Title    : System using directives should be placed before other using directives
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
-dotnet_diagnostic.SA1208.severity = warning
-
-# Title    : Using alias directives should be placed after other using directives
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
-dotnet_diagnostic.SA1209.severity = warning
-
-# Title    : Using directives should be ordered alphabetically by namespace
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
-dotnet_diagnostic.SA1210.severity = warning
-
-# Title    : Using alias directives should be ordered alphabetically by alias name
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
-dotnet_diagnostic.SA1211.severity = warning
-
-# Title    : Property accessors should follow order
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
-dotnet_diagnostic.SA1212.severity = warning
-
-# Title    : Event accessors should follow order
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
-dotnet_diagnostic.SA1213.severity = warning
-
-# Title    : Readonly fields should appear before non-readonly fields
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
-dotnet_diagnostic.SA1214.severity = warning
-
-# Title    : Using static directives should be placed at the correct location
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
-dotnet_diagnostic.SA1216.severity = warning
-
-# Title    : Using static directives should be ordered alphabetically
-# Category : StyleCop.CSharp.OrderingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
-dotnet_diagnostic.SA1217.severity = warning
-
-# Title    : Element should begin with upper-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1300.severity = none
-
-# Title    : Element should begin with lower-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1301.severity = none
-
-# Title    : Interface names should begin with I
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1302.severity = none
-
-# Title    : Const field names should begin with upper-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1303.severity = none
-
-# Title    : Non-private readonly fields should begin with upper-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1304.severity = none
-
-# Title    : Field names should not use Hungarian notation
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1305.severity = none
-
-# Title    : Field names should begin with lower-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1306.severity = none
-
-# Title    : Accessible fields should begin with upper-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1307.severity = none
-
-# Title    : Variable names should not be prefixed
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1308.severity = none
-
-# Title    : Field names should not begin with underscore
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1309.severity = none
-
-# Title    : Field names should not contain underscore
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
-dotnet_diagnostic.SA1310.severity = warning
-
-# Title    : Static readonly fields should begin with upper-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1311.severity = none
-
-# Title    : Variable names should begin with lower-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1312.severity = none
-
-# Title    : Parameter names should begin with lower-case letter
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1313.severity = none
-
-# Title    : Type parameter names should begin with T
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
-# Redundant: IDE1006
-dotnet_diagnostic.SA1314.severity = none
-
-# Title    : Tuple element names should use correct casing
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
-dotnet_diagnostic.SA1316.severity = warning
-
-# Title    : Access modifier should be declared
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
-dotnet_diagnostic.SA1400.severity = warning
-
-# Title    : Fields should be private
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
-# Redundant: CA1051
-dotnet_diagnostic.SA1401.severity = none
-
-# Title    : File may only contain a single type
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
-dotnet_diagnostic.SA1402.severity = warning
-
-# Title    : File may only contain a single namespace
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
-dotnet_diagnostic.SA1403.severity = warning
-
-# Title    : Code analysis suppression should have justification
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
-dotnet_diagnostic.SA1404.severity = warning
-
-# Title    : Debug.Assert should provide message text
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
-dotnet_diagnostic.SA1405.severity = warning
-
-# Title    : Debug.Fail should provide message text
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
-dotnet_diagnostic.SA1406.severity = warning
-
-# Title    : Arithmetic expressions should declare precedence
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
-dotnet_diagnostic.SA1407.severity = warning
-
-# Title    : Conditional expressions should declare precedence
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
-dotnet_diagnostic.SA1408.severity = warning
-
-# Title    : Remove unnecessary code
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
-dotnet_diagnostic.SA1409.severity = warning
-
-# Title    : Remove delegate parenthesis when possible
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
-dotnet_diagnostic.SA1410.severity = warning
-
-# Title    : Attribute constructor should not use unnecessary parenthesis
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
-dotnet_diagnostic.SA1411.severity = warning
-
-# Title    : Store files as UTF-8 with byte order mark
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
-# Comment  : Pedantic
-dotnet_diagnostic.SA1412.severity = none
-
-# Title    : Use trailing comma in multi-line initializers
-# Category : StyleCop.CSharp.MaintainabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
-dotnet_diagnostic.SA1413.severity = none
-
-# Title    : Tuple types in signatures should have element names
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
-dotnet_diagnostic.SA1414.severity = warning
-
-# Title    : Braces for multi-line statements should not share line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
-dotnet_diagnostic.SA1500.severity = warning
-
-# Title    : Statement should not be on a single line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
-dotnet_diagnostic.SA1501.severity = warning
-
-# Title    : Element should not be on a single line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
-dotnet_diagnostic.SA1502.severity = warning
-
-# Title    : Braces should not be omitted
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
-# Redundant: IDE0011
-dotnet_diagnostic.SA1503.severity = none
-
-# Title    : All accessors should be single-line or multi-line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
-dotnet_diagnostic.SA1504.severity = warning
-
-# Title    : Opening braces should not be followed by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
-dotnet_diagnostic.SA1505.severity = warning
-
-# Title    : Element documentation headers should not be followed by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
-dotnet_diagnostic.SA1506.severity = warning
-
-# Title    : Code should not contain multiple blank lines in a row
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
-# Redundant: IDE2000
-dotnet_diagnostic.SA1507.severity = none
-
-# Title    : Closing braces should not be preceded by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
-# Redundant: IDE2002
-dotnet_diagnostic.SA1508.severity = none
-
-# Title    : Opening braces should not be preceded by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
-dotnet_diagnostic.SA1509.severity = warning
-
-# Title    : Chained statement blocks should not be preceded by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
-dotnet_diagnostic.SA1510.severity = warning
-
-# Title    : While-do footer should not be preceded by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
-dotnet_diagnostic.SA1511.severity = warning
-
-# Title    : Single-line comments should not be followed by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
-dotnet_diagnostic.SA1512.severity = none
-
-# Title    : Closing brace should be followed by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
-dotnet_diagnostic.SA1513.severity = warning
-
-# Title    : Element documentation header should be preceded by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
-dotnet_diagnostic.SA1514.severity = warning
-
-# Title    : Single-line comment should be preceded by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
-dotnet_diagnostic.SA1515.severity = warning
-
-# Title    : Elements should be separated by blank line
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
-dotnet_diagnostic.SA1516.severity = none
-
-# Title    : Code should not contain blank lines at start of file
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
-dotnet_diagnostic.SA1517.severity = warning
-
-# Title    : Use line endings correctly at end of file
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
-dotnet_diagnostic.SA1518.severity = none
-
-# Title    : Braces should not be omitted from multi-line child statement
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
-dotnet_diagnostic.SA1519.severity = warning
-
-# Title    : Use braces consistently
-# Category : StyleCop.CSharp.LayoutRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
-dotnet_diagnostic.SA1520.severity = warning
-
-# Title    : Elements should be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
-dotnet_diagnostic.SA1600.severity = warning
-
-# Title    : Partial elements should be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
-dotnet_diagnostic.SA1601.severity = none
-
-# Title    : Enumeration items should be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
-dotnet_diagnostic.SA1602.severity = warning
-
-# Title    : Documentation should contain valid XML
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
-dotnet_diagnostic.SA1603.severity = warning
-
-# Title    : Element documentation should have summary
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
-dotnet_diagnostic.SA1604.severity = warning
-
-# Title    : Partial element documentation should have summary
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
-dotnet_diagnostic.SA1605.severity = warning
-
-# Title    : Element documentation should have summary text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
-dotnet_diagnostic.SA1606.severity = warning
-
-# Title    : Partial element documentation should have summary text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
-dotnet_diagnostic.SA1607.severity = warning
-
-# Title    : Element documentation should not have default summary
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
-dotnet_diagnostic.SA1608.severity = warning
-
-# Title    : Property documentation should have value
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
-dotnet_diagnostic.SA1609.severity = none
-
-# Title    : Property documentation should have value text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
-dotnet_diagnostic.SA1610.severity = none
-
-# Title    : Element parameters should be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
-# Redundant: CS1573
-dotnet_diagnostic.SA1611.severity = none
-
-# Title    : Element parameter documentation should match element parameters
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
-dotnet_diagnostic.SA1612.severity = warning
-
-# Title    : Element parameter documentation should declare parameter name
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
-dotnet_diagnostic.SA1613.severity = warning
-
-# Title    : Element parameter documentation should have text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
-dotnet_diagnostic.SA1614.severity = warning
-
-# Title    : Element return value should be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
-dotnet_diagnostic.SA1615.severity = warning
-
-# Title    : Element return value documentation should have text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
-dotnet_diagnostic.SA1616.severity = warning
-
-# Title    : Void return value should not be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
-dotnet_diagnostic.SA1617.severity = warning
-
-# Title    : Generic type parameters should be documented
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
-dotnet_diagnostic.SA1618.severity = warning
-
-# Title    : Generic type parameters should be documented partial class
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
-dotnet_diagnostic.SA1619.severity = warning
-
-# Title    : Generic type parameter documentation should match type parameters
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
-dotnet_diagnostic.SA1620.severity = warning
-
-# Title    : Generic type parameter documentation should declare parameter name
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
-dotnet_diagnostic.SA1621.severity = warning
-
-# Title    : Generic type parameter documentation should have text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
-dotnet_diagnostic.SA1622.severity = warning
-
-# Title    : Property summary documentation should match accessors
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
-dotnet_diagnostic.SA1623.severity = warning
-
-# Title    : Property summary documentation should omit accessor with restricted access
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
-dotnet_diagnostic.SA1624.severity = warning
-
-# Title    : Element documentation should not be copied and pasted
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
-dotnet_diagnostic.SA1625.severity = warning
-
-# Title    : Single-line comments should not use documentation style slashes
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
-dotnet_diagnostic.SA1626.severity = warning
-
-# Title    : Documentation text should not be empty
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
-dotnet_diagnostic.SA1627.severity = warning
-
-# Title    : Documentation text should begin with a capital letter
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
-dotnet_diagnostic.SA1628.severity = warning
-
-# Title    : Documentation text should end with a period
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
-dotnet_diagnostic.SA1629.severity = warning
-
-# Title    : Documentation text should contain whitespace
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
-dotnet_diagnostic.SA1630.severity = warning
-
-# Title    : Documentation should meet character percentage
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
-dotnet_diagnostic.SA1631.severity = warning
-
-# Title    : Documentation text should meet minimum character length
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
-dotnet_diagnostic.SA1632.severity = warning
-
-# Title    : File should have header
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
-# Redundant: IDE0073
-dotnet_diagnostic.SA1633.severity = none
-
-# Title    : File header should show copyright
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
-dotnet_diagnostic.SA1634.severity = none
-
-# Title    : File header should have copyright text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
-dotnet_diagnostic.SA1635.severity = none
-
-# Title    : File header copyright text should match
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
-dotnet_diagnostic.SA1636.severity = none
-
-# Title    : File header should contain file name
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
-dotnet_diagnostic.SA1637.severity = none
-
-# Title    : File header file name documentation should match file name
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
-dotnet_diagnostic.SA1638.severity = none
-
-# Title    : File header should have summary
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
-dotnet_diagnostic.SA1639.severity = none
-
-# Title    : File header should have valid company text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
-dotnet_diagnostic.SA1640.severity = none
-
-# Title    : File header company name text should match
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
-dotnet_diagnostic.SA1641.severity = none
-
-# Title    : Constructor summary documentation should begin with standard text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
-dotnet_diagnostic.SA1642.severity = warning
-
-# Title    : Destructor summary documentation should begin with standard text
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
-dotnet_diagnostic.SA1643.severity = warning
-
-# Title    : Documentation headers should not contain blank lines
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
-dotnet_diagnostic.SA1644.severity = warning
-
-# Title    : Included documentation file does not exist
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
-dotnet_diagnostic.SA1645.severity = warning
-
-# Title    : Included documentation XPath does not exist
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
-dotnet_diagnostic.SA1646.severity = warning
-
-# Title    : Include node does not contain valid file and path
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
-dotnet_diagnostic.SA1647.severity = warning
-
-# Title    : inheritdoc should be used with inheriting class
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
-dotnet_diagnostic.SA1648.severity = warning
-
-# Title    : File name should match first type name
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
-dotnet_diagnostic.SA1649.severity = warning
-
-# Title    : Element documentation should be spelled correctly
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
-# Comment  : Deprecated
-dotnet_diagnostic.SA1650.severity = none
-
-# Title    : Do not use placeholder elements
-# Category : StyleCop.CSharp.DocumentationRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
-dotnet_diagnostic.SA1651.severity = warning
-
-# Title    : Do not prefix local calls with 'this.'
-# Category : StyleCop.CSharp.ReadabilityRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
-dotnet_diagnostic.SX1101.severity = warning
-
-# Title    : Field names should begin with underscore
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
-# Redundant: IDE1006
-dotnet_diagnostic.SX1309.severity = none
-
-# Title    : Static field names should begin with underscore
-# Category : StyleCop.CSharp.NamingRules
-# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
-# Redundant: IDE1006
-dotnet_diagnostic.SX1309S.severity = none
-
 # Title    : Avoid legacy thread switching APIs
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
@@ -6069,12 +4262,12 @@ dotnet_diagnostic.VSTHRD102.severity = suggestion
 # Title    : Call async methods when in an async method
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
-dotnet_diagnostic.VSTHRD103.severity = warning
+dotnet_diagnostic.VSTHRD103.severity = none
 
 # Title    : Offer async methods
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
-dotnet_diagnostic.VSTHRD104.severity = warning
+dotnet_diagnostic.VSTHRD104.severity = none
 
 # Title    : Avoid method overloads that assume TaskScheduler.Current
 # Category : Usage
@@ -6136,5 +4329,5 @@ dotnet_diagnostic.VSTHRD114.severity = error
 # Title    : Use "Async" suffix for async methods
 # Category : Style
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
-dotnet_diagnostic.VSTHRD200.severity = warning
+dotnet_diagnostic.VSTHRD200.severity = none
 

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier1.globalconfig
@@ -1,0 +1,4267 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:54Z
+# Max Tier  : 1
+# Attributes: api, general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier2.globalconfig
@@ -1,0 +1,4319 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:57Z
+# Max Tier  : 2
+# Attributes: api, general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = warning
+dotnet_code_quality.CA1008.api_surface = public
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = warning
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = suggestion
+dotnet_code_quality.CA1045.api_surface = public
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = warning
+dotnet_code_quality.CA1050.api_surface = public
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = warning
+dotnet_code_quality.CA1051.api_surface = public
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = warning
+dotnet_code_quality.CA1062.api_surface = public, protected
+dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
+dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = warning
+dotnet_code_quality.CA1068.api_surface = public, protected
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = warning
+dotnet_code_quality.CA2109.api_surface = public
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = warning
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = warning
+dotnet_code_quality.CA2225.api_surface = public
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = warning
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = warning
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib.globalconfig
@@ -1,0 +1,4358 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:59Z
+# Max Tier  : 3
+# Attributes: api, general, general_externalonly
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = warning
+dotnet_code_quality.CA1000.api_surface = public
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = warning
+dotnet_code_quality.CA1002.api_surface = public
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = warning
+dotnet_code_quality.CA1003.api_surface = all
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = warning
+dotnet_code_quality.CA1005.api_surface = public
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = warning
+dotnet_code_quality.CA1008.api_surface = public
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = public
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = warning
+dotnet_code_quality.CA1024.api_surface = public
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = warning
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = warning
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = warning
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = warning
+dotnet_code_quality.CA1043.api_surface = public, protected
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = suggestion
+dotnet_code_quality.CA1045.api_surface = public
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = warning
+dotnet_code_quality.CA1050.api_surface = public
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = warning
+dotnet_code_quality.CA1051.api_surface = public
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = warning
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = warning
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = warning
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = warning
+dotnet_code_quality.CA1062.api_surface = public, protected
+dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
+dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = warning
+dotnet_code_quality.CA1068.api_surface = public, protected
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = warning
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = warning
+dotnet_code_quality.CA1700.api_surface = public
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = warning
+dotnet_code_quality.CA1708.api_surface = public
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = warning
+dotnet_code_quality.CA1710.api_surface = public
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = warning
+dotnet_code_quality.CA1711.api_surface = public
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = warning
+dotnet_code_quality.CA1720.api_surface = public
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = warning
+dotnet_code_quality.CA1721.api_surface = public
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = warning
+dotnet_code_quality.CA1724.api_surface = public
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = suggestion
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = warning
+dotnet_code_quality.CA2109.api_surface = public
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = warning
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = warning
+dotnet_code_quality.CA2225.api_surface = public
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = warning
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = warning
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier1.globalconfig
@@ -1,0 +1,4267 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:53Z
+# Max Tier  : 1
+# Attributes: general, general_externalonly, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier2.globalconfig
@@ -1,0 +1,4310 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:56Z
+# Max Tier  : 2
+# Attributes: general, general_externalonly, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe.globalconfig
@@ -1,0 +1,4336 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:58Z
+# Max Tier  : 3
+# Attributes: general, general_externalonly, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier1.globalconfig
@@ -1,0 +1,4267 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:54Z
+# Max Tier  : 1
+# Attributes: api, general, general_externalonly, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier2.globalconfig
@@ -1,0 +1,4319 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:56Z
+# Max Tier  : 2
+# Attributes: api, general, general_externalonly, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = warning
+dotnet_code_quality.CA1008.api_surface = public
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = warning
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = suggestion
+dotnet_code_quality.CA1045.api_surface = public
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = warning
+dotnet_code_quality.CA1050.api_surface = public
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = warning
+dotnet_code_quality.CA1051.api_surface = public
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = warning
+dotnet_code_quality.CA1062.api_surface = public, protected
+dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
+dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = warning
+dotnet_code_quality.CA1068.api_surface = public, protected
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = warning
+dotnet_code_quality.CA2109.api_surface = public
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = warning
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = warning
+dotnet_code_quality.CA2225.api_surface = public
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = warning
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = warning
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib.globalconfig
@@ -1,0 +1,4358 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:58Z
+# Max Tier  : 3
+# Attributes: api, general, general_externalonly, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = warning
+dotnet_code_quality.CA1000.api_surface = public
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = warning
+dotnet_code_quality.CA1002.api_surface = public
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = warning
+dotnet_code_quality.CA1003.api_surface = all
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = warning
+dotnet_code_quality.CA1005.api_surface = public
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = warning
+dotnet_code_quality.CA1008.api_surface = public
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = public
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = warning
+dotnet_code_quality.CA1024.api_surface = public
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = warning
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = warning
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = warning
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = warning
+dotnet_code_quality.CA1043.api_surface = public, protected
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = suggestion
+dotnet_code_quality.CA1045.api_surface = public
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = warning
+dotnet_code_quality.CA1050.api_surface = public
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = warning
+dotnet_code_quality.CA1051.api_surface = public
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = warning
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = warning
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = warning
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = warning
+dotnet_code_quality.CA1062.api_surface = public, protected
+dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = false
+dotnet_code_quality.CA1062.null_check_validation_methods = IfNull|IfNullOrEmpty|IfNullOrWhitespace|IfNullOrMemberNull
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = warning
+dotnet_code_quality.CA1068.api_surface = public, protected
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = warning
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = warning
+dotnet_code_quality.CA1700.api_surface = public
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = warning
+dotnet_code_quality.CA1708.api_surface = public
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = warning
+dotnet_code_quality.CA1710.api_surface = public
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = warning
+dotnet_code_quality.CA1711.api_surface = public
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = warning
+dotnet_code_quality.CA1720.api_surface = public
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = warning
+dotnet_code_quality.CA1721.api_surface = public
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = warning
+dotnet_code_quality.CA1724.api_surface = public
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = warning
+dotnet_code_quality.CA2109.api_surface = public
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = warning
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = warning
+dotnet_code_quality.CA2225.api_surface = public
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = warning
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = warning
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = warning
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = warning
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = warning
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = warning
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = warning
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = warning
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = warning
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = warning
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier1.globalconfig
@@ -1,0 +1,4522 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:55Z
+# Max Tier  : 1
+# Attributes: general, general_externalonly, test
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, xunit.analyzers
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = none
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = none
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = none
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = none
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = none
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = none
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = none
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = none
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = none
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = none
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = none
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = none
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = none
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = none
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = none
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = none
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = none
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = none
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = none
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = none
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = none
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = none
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = none
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = none
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = none
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = none
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = none
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = none
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = none
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = none
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = none
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = none
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = none
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = none
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = none
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = none
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = none
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = none
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = none
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = none
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = none
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = none
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = none
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = none
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = none
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = none
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = none
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = none
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = none
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = none
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = none
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = none
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = none
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = none
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = none
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = none
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = none
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = none
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = none
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = none
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = none
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = none
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = none
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = none
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = none
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = none
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = none
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = none
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = none
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = none
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = none
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = none
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = none
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = none
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = none
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = none
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = none
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = none
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = none
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = none
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = none
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = none
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = none
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = none
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = none
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = none
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = none
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = none
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = none
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = none
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = none
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = none
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = none
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = none
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = none
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = none
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = none
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = none
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = none
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = none
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = none
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = none
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = none
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = none
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = none
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = none
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = none
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = none
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = none
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = none
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = none
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = none
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = none
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = none
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = none
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = none
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = none
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = none
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = none
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = none
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = none
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = none
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = none
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = none
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = none
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = none
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = none
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = none
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = none
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = none
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = none
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = none
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = none
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = none
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = none
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = none
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = none
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = none
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = none
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = none
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = none
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = none
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = none
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = none
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = none
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = none
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = none
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = none
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = none
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = none
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = none
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = none
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = none
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = none
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = none
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = none
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = none
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = none
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = none
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = none
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = none
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = none
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = none
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = none
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = none
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = none
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = none
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = none
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = none
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = none
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# Title    : Test classes must be public
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1000
+dotnet_diagnostic.xUnit1000.severity = error
+
+# Title    : Fact methods cannot have parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1001
+dotnet_diagnostic.xUnit1001.severity = error
+
+# Title    : Test methods cannot have multiple Fact or Theory attributes
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1002
+dotnet_diagnostic.xUnit1002.severity = error
+
+# Title    : Theory methods must have test data
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1003
+dotnet_diagnostic.xUnit1003.severity = error
+
+# Title    : Test methods should not be skipped
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1004
+dotnet_diagnostic.xUnit1004.severity = none
+
+# Title    : Fact methods should not have test data
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1005
+dotnet_diagnostic.xUnit1005.severity = none
+
+# Title    : Theory methods should have parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1006
+dotnet_diagnostic.xUnit1006.severity = none
+
+# Title    : ClassData must point at a valid class
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1007
+dotnet_diagnostic.xUnit1007.severity = error
+
+# Title    : Test data attribute should only be used on a Theory
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1008
+dotnet_diagnostic.xUnit1008.severity = none
+
+# Title    : InlineData values must match the number of method parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1009
+dotnet_diagnostic.xUnit1009.severity = error
+
+# Title    : The value is not convertible to the method parameter type
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1010
+dotnet_diagnostic.xUnit1010.severity = error
+
+# Title    : There is no matching method parameter
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1011
+dotnet_diagnostic.xUnit1011.severity = error
+
+# Title    : Null should not be used for value type parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1012
+dotnet_diagnostic.xUnit1012.severity = none
+
+# Title    : Public method should be marked as test
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1013
+dotnet_diagnostic.xUnit1013.severity = none
+
+# Title    : MemberData should use nameof operator for member name
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1014
+dotnet_diagnostic.xUnit1014.severity = none
+
+# Title    : MemberData must reference an existing member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1015
+dotnet_diagnostic.xUnit1015.severity = error
+
+# Title    : MemberData must reference a public member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1016
+dotnet_diagnostic.xUnit1016.severity = error
+
+# Title    : MemberData must reference a static member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1017
+dotnet_diagnostic.xUnit1017.severity = error
+
+# Title    : MemberData must reference a valid member kind
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1018
+dotnet_diagnostic.xUnit1018.severity = error
+
+# Title    : MemberData must reference a member providing a valid data type
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1019
+dotnet_diagnostic.xUnit1019.severity = error
+
+# Title    : MemberData must reference a property with a public getter
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1020
+dotnet_diagnostic.xUnit1020.severity = error
+
+# Title    : MemberData should not have parameters if the referenced member is not a method
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1021
+dotnet_diagnostic.xUnit1021.severity = none
+
+# Title    : Theory methods cannot have a parameter array
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1022
+dotnet_diagnostic.xUnit1022.severity = error
+
+# Title    : Theory methods cannot have default parameter values
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1023
+dotnet_diagnostic.xUnit1023.severity = error
+
+# Title    : Test methods cannot have overloads
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1024
+dotnet_diagnostic.xUnit1024.severity = error
+
+# Title    : InlineData should be unique within the Theory it belongs to
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1025
+dotnet_diagnostic.xUnit1025.severity = none
+
+# Title    : Theory methods should use all of their parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1026
+dotnet_diagnostic.xUnit1026.severity = none
+
+# Title    : Collection definition classes must be public
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1027
+dotnet_diagnostic.xUnit1027.severity = error
+
+# Title    : Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1033
+dotnet_diagnostic.xUnit1033.severity = suggestion
+
+# Title    : Constants and literals should be the expected argument
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2000
+dotnet_diagnostic.xUnit2000.severity = none
+
+# Title    : Do not use invalid equality check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2001
+dotnet_diagnostic.xUnit2001.severity = silent
+
+# Title    : Do not use null check on value type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2002
+dotnet_diagnostic.xUnit2002.severity = none
+
+# Title    : Do not use equality check to test for null value
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2003
+dotnet_diagnostic.xUnit2003.severity = none
+
+# Title    : Do not use equality check to test for boolean conditions
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2004
+dotnet_diagnostic.xUnit2004.severity = none
+
+# Title    : Do not use identity check on value type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2005
+dotnet_diagnostic.xUnit2005.severity = none
+
+# Title    : Do not use invalid string equality check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2006
+dotnet_diagnostic.xUnit2006.severity = none
+
+# Title    : Do not use typeof expression to check the type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2007
+dotnet_diagnostic.xUnit2007.severity = none
+
+# Title    : Do not use boolean check to match on regular expressions
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2008
+dotnet_diagnostic.xUnit2008.severity = none
+
+# Title    : Do not use boolean check to check for substrings
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2009
+dotnet_diagnostic.xUnit2009.severity = none
+
+# Title    : Do not use boolean check to check for string equality
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2010
+dotnet_diagnostic.xUnit2010.severity = none
+
+# Title    : Do not use empty collection check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2011
+dotnet_diagnostic.xUnit2011.severity = none
+
+# Title    : Do not use boolean check to check if a value exists in a collection
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2012
+dotnet_diagnostic.xUnit2012.severity = none
+
+# Title    : Do not use equality check to check for collection size.
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2013
+dotnet_diagnostic.xUnit2013.severity = none
+
+# Title    : Do not use throws check to check for asynchronously thrown exception
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2014
+dotnet_diagnostic.xUnit2014.severity = error
+
+# Title    : Do not use typeof expression to check the exception type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2015
+dotnet_diagnostic.xUnit2015.severity = none
+
+# Title    : Keep precision in the allowed range when asserting equality of doubles or decimals.
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2016
+dotnet_diagnostic.xUnit2016.severity = error
+
+# Title    : Do not use Contains() to check if a value exists in a collection
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2017
+dotnet_diagnostic.xUnit2017.severity = none
+
+# Title    : Do not compare an object's exact type to an abstract class or interface
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2018
+dotnet_diagnostic.xUnit2018.severity = none
+
+# Title    : Do not use obsolete throws check to check for asynchronously thrown exception
+# Category : Assertions
+# Help Link: https://xunit.github.io/xunit.analyzers/rules/xUnit2019
+dotnet_diagnostic.xUnit2019.severity = none
+
+# Title    : Test case classes must derive directly or indirectly from Xunit.LongLivedMarshalByRefObject
+# Category : Extensibility
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit3000
+dotnet_diagnostic.xUnit3000.severity = error
+
+# Title    : Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
+# Category : Extensibility
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit3001
+dotnet_diagnostic.xUnit3001.severity = error
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier2.globalconfig
@@ -1,0 +1,4564 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:57Z
+# Max Tier  : 2
+# Attributes: general, general_externalonly, test
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, xunit.analyzers
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = none
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = none
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = none
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = none
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = none
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = none
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = none
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = none
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = none
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = none
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = none
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = none
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = none
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = none
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = none
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = none
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = none
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = none
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = none
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = none
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = none
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = none
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = none
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = none
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = none
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = none
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = none
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = none
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = none
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = none
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = none
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = none
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = none
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = none
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = none
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = none
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = none
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = none
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = none
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = none
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = none
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = none
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = none
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = none
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = none
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = none
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = none
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = none
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = none
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = none
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = none
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = none
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = none
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = none
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = none
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = none
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = none
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = none
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = none
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = none
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = none
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = none
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = none
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = none
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = none
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = none
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = none
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = none
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = none
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = none
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = none
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = none
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = none
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = none
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = none
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = none
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = none
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = none
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = none
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = none
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = none
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# Title    : Test classes must be public
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1000
+dotnet_diagnostic.xUnit1000.severity = error
+
+# Title    : Fact methods cannot have parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1001
+dotnet_diagnostic.xUnit1001.severity = error
+
+# Title    : Test methods cannot have multiple Fact or Theory attributes
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1002
+dotnet_diagnostic.xUnit1002.severity = error
+
+# Title    : Theory methods must have test data
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1003
+dotnet_diagnostic.xUnit1003.severity = error
+
+# Title    : Test methods should not be skipped
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1004
+dotnet_diagnostic.xUnit1004.severity = none
+
+# Title    : Fact methods should not have test data
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1005
+dotnet_diagnostic.xUnit1005.severity = error
+
+# Title    : Theory methods should have parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1006
+dotnet_diagnostic.xUnit1006.severity = warning
+
+# Title    : ClassData must point at a valid class
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1007
+dotnet_diagnostic.xUnit1007.severity = error
+
+# Title    : Test data attribute should only be used on a Theory
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1008
+dotnet_diagnostic.xUnit1008.severity = error
+
+# Title    : InlineData values must match the number of method parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1009
+dotnet_diagnostic.xUnit1009.severity = error
+
+# Title    : The value is not convertible to the method parameter type
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1010
+dotnet_diagnostic.xUnit1010.severity = error
+
+# Title    : There is no matching method parameter
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1011
+dotnet_diagnostic.xUnit1011.severity = error
+
+# Title    : Null should not be used for value type parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1012
+dotnet_diagnostic.xUnit1012.severity = warning
+
+# Title    : Public method should be marked as test
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1013
+dotnet_diagnostic.xUnit1013.severity = warning
+
+# Title    : MemberData should use nameof operator for member name
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1014
+dotnet_diagnostic.xUnit1014.severity = warning
+
+# Title    : MemberData must reference an existing member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1015
+dotnet_diagnostic.xUnit1015.severity = error
+
+# Title    : MemberData must reference a public member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1016
+dotnet_diagnostic.xUnit1016.severity = error
+
+# Title    : MemberData must reference a static member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1017
+dotnet_diagnostic.xUnit1017.severity = error
+
+# Title    : MemberData must reference a valid member kind
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1018
+dotnet_diagnostic.xUnit1018.severity = error
+
+# Title    : MemberData must reference a member providing a valid data type
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1019
+dotnet_diagnostic.xUnit1019.severity = error
+
+# Title    : MemberData must reference a property with a public getter
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1020
+dotnet_diagnostic.xUnit1020.severity = error
+
+# Title    : MemberData should not have parameters if the referenced member is not a method
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1021
+dotnet_diagnostic.xUnit1021.severity = error
+
+# Title    : Theory methods cannot have a parameter array
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1022
+dotnet_diagnostic.xUnit1022.severity = error
+
+# Title    : Theory methods cannot have default parameter values
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1023
+dotnet_diagnostic.xUnit1023.severity = error
+
+# Title    : Test methods cannot have overloads
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1024
+dotnet_diagnostic.xUnit1024.severity = error
+
+# Title    : InlineData should be unique within the Theory it belongs to
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1025
+dotnet_diagnostic.xUnit1025.severity = warning
+
+# Title    : Theory methods should use all of their parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1026
+dotnet_diagnostic.xUnit1026.severity = warning
+
+# Title    : Collection definition classes must be public
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1027
+dotnet_diagnostic.xUnit1027.severity = error
+
+# Title    : Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1033
+dotnet_diagnostic.xUnit1033.severity = suggestion
+
+# Title    : Constants and literals should be the expected argument
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2000
+dotnet_diagnostic.xUnit2000.severity = warning
+
+# Title    : Do not use invalid equality check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2001
+dotnet_diagnostic.xUnit2001.severity = silent
+
+# Title    : Do not use null check on value type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2002
+dotnet_diagnostic.xUnit2002.severity = warning
+
+# Title    : Do not use equality check to test for null value
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2003
+dotnet_diagnostic.xUnit2003.severity = warning
+
+# Title    : Do not use equality check to test for boolean conditions
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2004
+dotnet_diagnostic.xUnit2004.severity = warning
+
+# Title    : Do not use identity check on value type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2005
+dotnet_diagnostic.xUnit2005.severity = warning
+
+# Title    : Do not use invalid string equality check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2006
+dotnet_diagnostic.xUnit2006.severity = warning
+
+# Title    : Do not use typeof expression to check the type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2007
+dotnet_diagnostic.xUnit2007.severity = warning
+
+# Title    : Do not use boolean check to match on regular expressions
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2008
+dotnet_diagnostic.xUnit2008.severity = warning
+
+# Title    : Do not use boolean check to check for substrings
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2009
+dotnet_diagnostic.xUnit2009.severity = warning
+
+# Title    : Do not use boolean check to check for string equality
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2010
+dotnet_diagnostic.xUnit2010.severity = warning
+
+# Title    : Do not use empty collection check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2011
+dotnet_diagnostic.xUnit2011.severity = warning
+
+# Title    : Do not use boolean check to check if a value exists in a collection
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2012
+dotnet_diagnostic.xUnit2012.severity = warning
+
+# Title    : Do not use equality check to check for collection size.
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2013
+dotnet_diagnostic.xUnit2013.severity = warning
+
+# Title    : Do not use throws check to check for asynchronously thrown exception
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2014
+dotnet_diagnostic.xUnit2014.severity = error
+
+# Title    : Do not use typeof expression to check the exception type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2015
+dotnet_diagnostic.xUnit2015.severity = warning
+
+# Title    : Keep precision in the allowed range when asserting equality of doubles or decimals.
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2016
+dotnet_diagnostic.xUnit2016.severity = error
+
+# Title    : Do not use Contains() to check if a value exists in a collection
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2017
+dotnet_diagnostic.xUnit2017.severity = warning
+
+# Title    : Do not compare an object's exact type to an abstract class or interface
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2018
+dotnet_diagnostic.xUnit2018.severity = warning
+
+# Title    : Do not use obsolete throws check to check for asynchronously thrown exception
+# Category : Assertions
+# Help Link: https://xunit.github.io/xunit.analyzers/rules/xUnit2019
+dotnet_diagnostic.xUnit2019.severity = warning
+
+# Title    : Test case classes must derive directly or indirectly from Xunit.LongLivedMarshalByRefObject
+# Category : Extensibility
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit3000
+dotnet_diagnostic.xUnit3000.severity = error
+
+# Title    : Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
+# Category : Extensibility
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit3001
+dotnet_diagnostic.xUnit3001.severity = error
+

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test.globalconfig
@@ -1,0 +1,4588 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:59Z
+# Max Tier  : 3
+# Attributes: general, general_externalonly, test
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, xunit.analyzers
+
+is_global = true
+global_level = -1
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = none
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = none
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = none
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = none
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = none
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = none
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = none
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = none
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = none
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = none
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = none
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = none
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = none
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = none
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = none
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = none
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = none
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = suggestion
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = none
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = none
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = none
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = none
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = none
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = none
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = none
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = none
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = none
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = none
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = none
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = none
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = none
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = none
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = none
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = none
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = none
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = none
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = none
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = none
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = none
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = none
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = none
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = none
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = none
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = none
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = none
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = none
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = none
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = none
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = none
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = none
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = none
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = none
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = none
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = none
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = none
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = none
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = none
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = none
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = none
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = none
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = none
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = none
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = none
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = none
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = none
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = none
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = none
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = none
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = none
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = none
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = none
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = none
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = none
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = none
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = none
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = none
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = none
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = none
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = none
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = none
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = none
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = none
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = none
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = none
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = none
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = none
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = none
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = none
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = none
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = none
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = none
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = none
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = none
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = none
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = none
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = none
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = none
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = none
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = none
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = none
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = none
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = none
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = none
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = none
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = none
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = none
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = none
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = none
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = none
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = none
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = none
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = none
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = none
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = none
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = none
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = none
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = none
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = none
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = none
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = none
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = none
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = none
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = none
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = none
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = none
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = none
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = none
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = none
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = none
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = none
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = none
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = none
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = none
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = none
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = none
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = none
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = none
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = none
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = none
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = none
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = warning
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = none
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = none
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = none
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = none
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = none
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = none
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = none
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = none
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = none
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = none
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = none
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = none
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = none
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = none
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# Title    : Test classes must be public
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1000
+dotnet_diagnostic.xUnit1000.severity = error
+
+# Title    : Fact methods cannot have parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1001
+dotnet_diagnostic.xUnit1001.severity = error
+
+# Title    : Test methods cannot have multiple Fact or Theory attributes
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1002
+dotnet_diagnostic.xUnit1002.severity = error
+
+# Title    : Theory methods must have test data
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1003
+dotnet_diagnostic.xUnit1003.severity = error
+
+# Title    : Test methods should not be skipped
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1004
+dotnet_diagnostic.xUnit1004.severity = suggestion
+
+# Title    : Fact methods should not have test data
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1005
+dotnet_diagnostic.xUnit1005.severity = error
+
+# Title    : Theory methods should have parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1006
+dotnet_diagnostic.xUnit1006.severity = warning
+
+# Title    : ClassData must point at a valid class
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1007
+dotnet_diagnostic.xUnit1007.severity = error
+
+# Title    : Test data attribute should only be used on a Theory
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1008
+dotnet_diagnostic.xUnit1008.severity = error
+
+# Title    : InlineData values must match the number of method parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1009
+dotnet_diagnostic.xUnit1009.severity = error
+
+# Title    : The value is not convertible to the method parameter type
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1010
+dotnet_diagnostic.xUnit1010.severity = error
+
+# Title    : There is no matching method parameter
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1011
+dotnet_diagnostic.xUnit1011.severity = error
+
+# Title    : Null should not be used for value type parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1012
+dotnet_diagnostic.xUnit1012.severity = warning
+
+# Title    : Public method should be marked as test
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1013
+dotnet_diagnostic.xUnit1013.severity = warning
+
+# Title    : MemberData should use nameof operator for member name
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1014
+dotnet_diagnostic.xUnit1014.severity = warning
+
+# Title    : MemberData must reference an existing member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1015
+dotnet_diagnostic.xUnit1015.severity = error
+
+# Title    : MemberData must reference a public member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1016
+dotnet_diagnostic.xUnit1016.severity = error
+
+# Title    : MemberData must reference a static member
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1017
+dotnet_diagnostic.xUnit1017.severity = error
+
+# Title    : MemberData must reference a valid member kind
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1018
+dotnet_diagnostic.xUnit1018.severity = error
+
+# Title    : MemberData must reference a member providing a valid data type
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1019
+dotnet_diagnostic.xUnit1019.severity = error
+
+# Title    : MemberData must reference a property with a public getter
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1020
+dotnet_diagnostic.xUnit1020.severity = error
+
+# Title    : MemberData should not have parameters if the referenced member is not a method
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1021
+dotnet_diagnostic.xUnit1021.severity = error
+
+# Title    : Theory methods cannot have a parameter array
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1022
+dotnet_diagnostic.xUnit1022.severity = error
+
+# Title    : Theory methods cannot have default parameter values
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1023
+dotnet_diagnostic.xUnit1023.severity = error
+
+# Title    : Test methods cannot have overloads
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1024
+dotnet_diagnostic.xUnit1024.severity = error
+
+# Title    : InlineData should be unique within the Theory it belongs to
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1025
+dotnet_diagnostic.xUnit1025.severity = warning
+
+# Title    : Theory methods should use all of their parameters
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1026
+dotnet_diagnostic.xUnit1026.severity = warning
+
+# Title    : Collection definition classes must be public
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1027
+dotnet_diagnostic.xUnit1027.severity = error
+
+# Title    : Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
+# Category : Usage
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit1033
+dotnet_diagnostic.xUnit1033.severity = suggestion
+
+# Title    : Constants and literals should be the expected argument
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2000
+dotnet_diagnostic.xUnit2000.severity = warning
+
+# Title    : Do not use invalid equality check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2001
+dotnet_diagnostic.xUnit2001.severity = silent
+
+# Title    : Do not use null check on value type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2002
+dotnet_diagnostic.xUnit2002.severity = warning
+
+# Title    : Do not use equality check to test for null value
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2003
+dotnet_diagnostic.xUnit2003.severity = warning
+
+# Title    : Do not use equality check to test for boolean conditions
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2004
+dotnet_diagnostic.xUnit2004.severity = warning
+
+# Title    : Do not use identity check on value type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2005
+dotnet_diagnostic.xUnit2005.severity = warning
+
+# Title    : Do not use invalid string equality check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2006
+dotnet_diagnostic.xUnit2006.severity = warning
+
+# Title    : Do not use typeof expression to check the type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2007
+dotnet_diagnostic.xUnit2007.severity = warning
+
+# Title    : Do not use boolean check to match on regular expressions
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2008
+dotnet_diagnostic.xUnit2008.severity = warning
+
+# Title    : Do not use boolean check to check for substrings
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2009
+dotnet_diagnostic.xUnit2009.severity = warning
+
+# Title    : Do not use boolean check to check for string equality
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2010
+dotnet_diagnostic.xUnit2010.severity = warning
+
+# Title    : Do not use empty collection check
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2011
+dotnet_diagnostic.xUnit2011.severity = warning
+
+# Title    : Do not use boolean check to check if a value exists in a collection
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2012
+dotnet_diagnostic.xUnit2012.severity = warning
+
+# Title    : Do not use equality check to check for collection size.
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2013
+dotnet_diagnostic.xUnit2013.severity = warning
+
+# Title    : Do not use throws check to check for asynchronously thrown exception
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2014
+dotnet_diagnostic.xUnit2014.severity = error
+
+# Title    : Do not use typeof expression to check the exception type
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2015
+dotnet_diagnostic.xUnit2015.severity = warning
+
+# Title    : Keep precision in the allowed range when asserting equality of doubles or decimals.
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2016
+dotnet_diagnostic.xUnit2016.severity = error
+
+# Title    : Do not use Contains() to check if a value exists in a collection
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2017
+dotnet_diagnostic.xUnit2017.severity = warning
+
+# Title    : Do not compare an object's exact type to an abstract class or interface
+# Category : Assertions
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit2018
+dotnet_diagnostic.xUnit2018.severity = warning
+
+# Title    : Do not use obsolete throws check to check for asynchronously thrown exception
+# Category : Assertions
+# Help Link: https://xunit.github.io/xunit.analyzers/rules/xUnit2019
+dotnet_diagnostic.xUnit2019.severity = warning
+
+# Title    : Test case classes must derive directly or indirectly from Xunit.LongLivedMarshalByRefObject
+# Category : Extensibility
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit3000
+dotnet_diagnostic.xUnit3000.severity = error
+
+# Title    : Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
+# Category : Extensibility
+# Help Link: https://xunit.net/xunit.analyzers/rules/xUnit3001
+dotnet_diagnostic.xUnit3001.severity = error
+

--- a/src/Shared/.editorconfig
+++ b/src/Shared/.editorconfig
@@ -1,0 +1,6118 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:52Z
+# Max Tier  : 2147483647
+# Attributes: general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = none
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = none
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = none
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/ToBeMoved/.editorconfig
+++ b/src/ToBeMoved/.editorconfig
@@ -1,0 +1,6118 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:51Z
+# Max Tier  : 2147483647
+# Attributes: general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = none
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = none
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = none
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/ToBeMoved/Directory.Build.props
+++ b/src/ToBeMoved/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreTargetFrameworks)$(ConditionalNet462)</TargetFrameworks>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
+    <Api>false</Api>
 
     <InjectDiagnosticAttributesOnLegacy Condition="'$(InjectDiagnosticAttributesOnLegacy)' == ''">true</InjectDiagnosticAttributesOnLegacy>
     <InjectIsExternalInitOnLegacy Condition="'$(InjectIsExternalInitOnLegacy)' == ''">true</InjectIsExternalInitOnLegacy>

--- a/src/ToBeRemoved/.editorconfig
+++ b/src/ToBeRemoved/.editorconfig
@@ -1,0 +1,6118 @@
+# Created by DiagConfig, the diagnostic config generator
+# Generated : 2023-05-24 21:09:51Z
+# Max Tier  : 2147483647
+# Attributes: general, performance, production
+# Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
+
+[*.cs]
+
+# Title    : Do not use model binding attributes with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0003.severity = warning
+
+# Title    : Do not use action results with route handlers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0004.severity = warning
+
+# Title    : Do not place attribute on method called by route handler lambda
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0005.severity = warning
+
+# Title    : Do not use non-literal sequence numbers
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0006.severity = warning
+
+# Title    : Route parameter and argument optionality is mismatched
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0007.severity = warning
+
+# Title    : Do not use ConfigureWebHost with WebApplicationBuilder.Host
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0008.severity = error
+
+# Title    : Do not use Configure with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0009.severity = error
+
+# Title    : Do not use UseStartup with WebApplicationBuilder.WebHost
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0010.severity = error
+
+# Title    : Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0011.severity = warning
+
+# Title    : Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0012.severity = warning
+
+# Title    : Suggest switching from using Configure methods to WebApplicationBuilder.Configuration
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0013.severity = warning
+
+# Title    : Suggest using top level route registrations
+# Category : Usage
+# Help Link: https://aka.ms/aspnet/analyzers
+dotnet_diagnostic.ASP0014.severity = warning
+
+# Title    : Component parameter should have public setters.
+# Category : Encapsulation
+dotnet_diagnostic.BL0001.severity = error
+
+# Title    : Component has multiple CaptureUnmatchedValues parameters
+# Category : Usage
+dotnet_diagnostic.BL0002.severity = warning
+
+# Title    : Component parameter with CaptureUnmatchedValues has the wrong type
+# Category : Usage
+dotnet_diagnostic.BL0003.severity = warning
+
+# Title    : Component parameter should be public.
+# Category : Encapsulation
+dotnet_diagnostic.BL0004.severity = error
+
+# Title    : Component parameter should not be set outside of its component.
+# Category : Usage
+dotnet_diagnostic.BL0005.severity = warning
+
+# Title    : Do not use RenderTree types
+# Category : Usage
+dotnet_diagnostic.BL0006.severity = warning
+
+# Title    : Component parameters should be auto properties
+# Category : Usage
+dotnet_diagnostic.BL0007.severity = warning
+
+# Title    : Do not declare static members on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+dotnet_diagnostic.CA1000.severity = none
+
+# Title    : Types that own disposable fields should be disposable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+dotnet_diagnostic.CA1001.severity = warning
+
+# Title    : Do not expose generic lists
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+dotnet_diagnostic.CA1002.severity = none
+
+# Title    : Use generic event handler instances
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+dotnet_diagnostic.CA1003.severity = none
+
+# Title    : Avoid excessive parameters on generic types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+dotnet_diagnostic.CA1005.severity = none
+
+# Title    : Enums should have zero value
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+dotnet_diagnostic.CA1008.severity = none
+
+# Title    : Generic interface should also be implemented
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+dotnet_diagnostic.CA1010.severity = warning
+dotnet_code_quality.CA1010.api_surface = all
+dotnet_code_quality.CA1010.additional_required_generic_interfaces = T:System.Collections.IDictionary->T:System.Collections.Generic.IDictionary`2
+
+# Title    : Abstract types should not have public constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+dotnet_diagnostic.CA1012.severity = warning
+dotnet_code_quality.CA1012.api_surface = all
+
+# Title    : Mark assemblies with CLSCompliant
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# Title    : Mark assemblies with assembly version
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+dotnet_diagnostic.CA1016.severity = suggestion
+
+# Title    : Mark assemblies with ComVisible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+dotnet_diagnostic.CA1017.severity = none
+
+# Title    : Mark attributes with AttributeUsageAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+dotnet_diagnostic.CA1018.severity = warning
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = suggestion
+
+# Title    : Define accessors for attribute arguments
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+dotnet_diagnostic.CA1019.severity = warning
+
+# Title    : Avoid out parameters
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+dotnet_diagnostic.CA1021.severity = none
+
+# Title    : Use properties where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+dotnet_diagnostic.CA1024.severity = none
+
+# Title    : Mark enums with FlagsAttribute
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+dotnet_diagnostic.CA1027.severity = warning
+dotnet_code_quality.CA1027.api_surface = all
+
+# Title    : Enum Storage should be Int32
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+dotnet_diagnostic.CA1028.severity = none
+
+# Title    : Use events where appropriate
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+dotnet_diagnostic.CA1030.severity = warning
+
+# Title    : Do not catch general exception types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Title    : Implement standard exception constructors
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+dotnet_diagnostic.CA1032.severity = none
+
+# Title    : Interface methods should be callable by child types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+dotnet_diagnostic.CA1033.severity = warning
+
+# Title    : Nested types should not be visible
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+dotnet_diagnostic.CA1034.severity = none
+
+# Title    : Override methods on comparable types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+dotnet_diagnostic.CA1036.severity = none
+
+# Title    : Avoid empty interfaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# Comment  : Reasonably frequent in modern .NET programming
+dotnet_diagnostic.CA1040.severity = none
+
+# Title    : Provide ObsoleteAttribute message
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+dotnet_diagnostic.CA1041.severity = warning
+dotnet_code_quality.CA1041.api_surface = all
+
+# Title    : Use Integral Or String Argument For Indexers
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+dotnet_diagnostic.CA1043.severity = none
+
+# Title    : Properties should not be write only
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+dotnet_diagnostic.CA1044.severity = warning
+
+# Title    : Do not pass types by reference
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+dotnet_diagnostic.CA1045.severity = none
+
+# Title    : Do not overload equality operator on reference types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+dotnet_diagnostic.CA1046.severity = warning
+dotnet_code_quality.CA1046.api_surface = all
+
+# Title    : Do not declare protected member in sealed type
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+dotnet_diagnostic.CA1047.severity = warning
+dotnet_code_quality.CA1047.api_surface = all
+
+# Title    : Declare types in namespaces
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+dotnet_diagnostic.CA1050.severity = none
+
+# Title    : Do not declare visible instance fields
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+dotnet_diagnostic.CA1051.severity = none
+
+# Title    : Static holder types should be Static or NotInheritable
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+dotnet_diagnostic.CA1052.severity = warning
+
+# Title    : URI-like parameters should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+dotnet_diagnostic.CA1054.severity = none
+
+# Title    : URI-like return values should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+dotnet_diagnostic.CA1055.severity = none
+
+# Title    : URI-like properties should not be strings
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+dotnet_diagnostic.CA1056.severity = none
+
+# Title    : Types should not extend certain base types
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+dotnet_diagnostic.CA1058.severity = warning
+dotnet_code_quality.CA1058.api_surface = public
+
+# Title    : Move pinvokes to native methods class
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+dotnet_diagnostic.CA1060.severity = warning
+
+# Title    : Do not hide base class methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+dotnet_diagnostic.CA1061.severity = warning
+dotnet_code_quality.CA1061.api_surface = all
+
+# Title    : Validate arguments of public methods
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1062.severity = none
+
+# Title    : Implement IDisposable Correctly
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+dotnet_diagnostic.CA1063.severity = warning
+
+# Title    : Exceptions should be public
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+dotnet_diagnostic.CA1064.severity = warning
+dotnet_code_quality.CA1064.api_surface = all
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Do not raise exceptions in unexpected locations
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+dotnet_diagnostic.CA1065.severity = warning
+
+# Title    : Implement IEquatable when overriding Object.Equals
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+dotnet_diagnostic.CA1066.severity = warning
+
+# Title    : Override Object.Equals(object) when implementing IEquatable<T>
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+dotnet_diagnostic.CA1067.severity = warning
+
+# Title    : CancellationToken parameters must come last
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+dotnet_diagnostic.CA1068.severity = none
+
+# Title    : Enums values should not be duplicated
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+dotnet_diagnostic.CA1069.severity = warning
+
+# Title    : Do not declare event fields as virtual
+# Category : Design
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+dotnet_diagnostic.CA1070.severity = warning
+dotnet_code_quality.CA1070.api_surface = all
+
+# Title    : Avoid using cref tags with a prefix
+# Category : Documentation
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+dotnet_diagnostic.CA1200.severity = warning
+
+# Title    : Do not pass literals as localized parameters
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+dotnet_diagnostic.CA1303.severity = warning
+
+# Title    : Specify CultureInfo
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+dotnet_diagnostic.CA1304.severity = warning
+
+# Title    : Specify IFormatProvider
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+dotnet_diagnostic.CA1305.severity = warning
+
+# Title    : Specify StringComparison for clarity
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+dotnet_diagnostic.CA1307.severity = warning
+
+# Title    : Normalize strings to uppercase
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+dotnet_diagnostic.CA1308.severity = warning
+
+# Title    : Use ordinal string comparison
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+dotnet_diagnostic.CA1309.severity = warning
+
+# Title    : Specify StringComparison for correctness
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+dotnet_diagnostic.CA1310.severity = warning
+
+# Title    : Specify a culture or use an invariant version
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+dotnet_diagnostic.CA1311.severity = warning
+
+# Title    : P/Invokes should not be visible
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+dotnet_diagnostic.CA1401.severity = none
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+dotnet_diagnostic.CA1416.severity = warning
+
+# Title    : Do not use 'OutAttribute' on string parameters for P/Invokes
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+dotnet_diagnostic.CA1417.severity = warning
+
+# Title    : Use valid platform string
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+dotnet_diagnostic.CA1418.severity = warning
+
+# Title    : Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+dotnet_diagnostic.CA1419.severity = warning
+
+# Title    : Property, type, or attribute requires runtime marshalling
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+dotnet_diagnostic.CA1420.severity = warning
+
+# Title    : This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+dotnet_diagnostic.CA1421.severity = suggestion
+
+# Title    : Validate platform compatibility
+# Category : Interoperability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+dotnet_diagnostic.CA1422.severity = warning
+
+# Title    : Avoid excessive inheritance
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+dotnet_diagnostic.CA1501.severity = warning
+dotnet_code_quality.CA1501.api_surface = public
+
+# Title    : Avoid excessive complexity
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1502.severity = none
+
+# Title    : Avoid unmaintainable code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+dotnet_diagnostic.CA1505.severity = warning
+
+# Title    : Avoid excessive class coupling
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# Comment  : Code gets complicated
+dotnet_diagnostic.CA1506.severity = none
+
+# Title    : Use nameof to express symbol names
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+dotnet_diagnostic.CA1507.severity = warning
+
+# Title    : Avoid dead conditional code
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+dotnet_diagnostic.CA1508.severity = warning
+
+# Title    : Invalid entry in code metrics rule specification file
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+dotnet_diagnostic.CA1509.severity = warning
+
+# Title    : Use ArgumentNullException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+dotnet_diagnostic.CA1510.severity = suggestion
+
+# Title    : Use ArgumentException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+dotnet_diagnostic.CA1511.severity = suggestion
+
+# Title    : Use ArgumentOutOfRangeException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+dotnet_diagnostic.CA1512.severity = suggestion
+
+# Title    : Use ObjectDisposedException throw helper
+# Category : Maintainability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+dotnet_diagnostic.CA1513.severity = suggestion
+
+# Title    : Do not name enum values 'Reserved'
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+dotnet_diagnostic.CA1700.severity = none
+
+# Title    : Identifiers should not contain underscores
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# Comment  : StyleCop handles this
+dotnet_diagnostic.CA1707.severity = none
+
+# Title    : Identifiers should differ by more than case
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+dotnet_diagnostic.CA1708.severity = silent
+
+# Title    : Identifiers should have correct suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+dotnet_diagnostic.CA1710.severity = silent
+
+# Title    : Identifiers should not have incorrect suffix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+dotnet_diagnostic.CA1711.severity = silent
+
+# Title    : Do not prefix enum values with type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+dotnet_diagnostic.CA1712.severity = warning
+
+# Title    : Events should not have 'Before' or 'After' prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+dotnet_diagnostic.CA1713.severity = warning
+
+# Title    : Identifiers should have correct prefix
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# Redundant: IDE1006
+dotnet_diagnostic.CA1715.severity = none
+
+# Title    : Identifiers should not match keywords
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+dotnet_diagnostic.CA1716.severity = warning
+dotnet_code_quality.CA1716.api_surface = all
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = all
+
+# Title    : Identifier contains type name
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+dotnet_diagnostic.CA1720.severity = silent
+
+# Title    : Property names should not match get methods
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+dotnet_diagnostic.CA1721.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+dotnet_diagnostic.CA1724.severity = none
+
+# Title    : Parameter names should match base declaration
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = warning
+
+# Title    : Use PascalCase for named placeholders
+# Category : Naming
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+dotnet_diagnostic.CA1727.severity = silent
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Review unused parameters
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# Redundant: IDE0060
+dotnet_diagnostic.CA1801.severity = none
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Use literals where appropriate
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+dotnet_diagnostic.CA1802.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not initialize unnecessarily
+# Category : Performance
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+dotnet_diagnostic.CA1805.severity = warning
+
+# Title    : Do not ignore method results
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+dotnet_diagnostic.CA1806.severity = warning
+
+# Title    : Initialize reference type static fields inline
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+dotnet_diagnostic.CA1810.severity = warning
+
+# Title    : Avoid uninstantiated internal classes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# Comment  : S1144 finds more cases and has no false positives
+# Redundant: S1144
+dotnet_diagnostic.CA1812.severity = none
+
+# Title    : Avoid unsealed attributes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+dotnet_diagnostic.CA1813.severity = warning
+
+# Title    : Prefer jagged arrays over multidimensional
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+dotnet_diagnostic.CA1814.severity = warning
+
+# Title    : Override equals and operator equals on value types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+dotnet_diagnostic.CA1815.severity = warning
+
+# Title    : Dispose methods should call SuppressFinalize
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+dotnet_diagnostic.CA1816.severity = warning
+
+# Title    : Properties should not return arrays
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+dotnet_diagnostic.CA1819.severity = warning
+
+# Title    : Test for empty strings using string length
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+dotnet_diagnostic.CA1820.severity = warning
+
+# Title    : Remove empty Finalizers
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+dotnet_diagnostic.CA1821.severity = warning
+
+# Title    : Mark members as static
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+dotnet_diagnostic.CA1822.severity = warning
+
+# Title    : Avoid unused private fields
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# Redundant: S1144
+dotnet_diagnostic.CA1823.severity = none
+
+# Title    : Mark assemblies with NeutralResourcesLanguageAttribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+dotnet_diagnostic.CA1824.severity = warning
+
+# Title    : Avoid zero-length array allocations
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+dotnet_diagnostic.CA1825.severity = warning
+
+# Title    : Do not use Enumerable methods on indexable collections
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+dotnet_diagnostic.CA1826.severity = warning
+
+# Title    : Do not use Count() or LongCount() when Any() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+dotnet_diagnostic.CA1827.severity = warning
+
+# Title    : Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+dotnet_diagnostic.CA1828.severity = warning
+
+# Title    : Use Length/Count property instead of Count() when available
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+dotnet_diagnostic.CA1829.severity = warning
+
+# Title    : Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+dotnet_diagnostic.CA1830.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+dotnet_diagnostic.CA1831.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+dotnet_diagnostic.CA1832.severity = warning
+
+# Title    : Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+dotnet_diagnostic.CA1833.severity = warning
+
+# Title    : Consider using 'StringBuilder.Append(char)' when applicable
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+dotnet_diagnostic.CA1834.severity = warning
+
+# Title    : Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+dotnet_diagnostic.CA1835.severity = warning
+
+# Title    : Prefer IsEmpty over Count
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+dotnet_diagnostic.CA1836.severity = warning
+
+# Title    : Use 'Environment.ProcessId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+dotnet_diagnostic.CA1837.severity = warning
+
+# Title    : Avoid 'StringBuilder' parameters for P/Invokes
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+dotnet_diagnostic.CA1838.severity = warning
+
+# Title    : Use 'Environment.ProcessPath'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+dotnet_diagnostic.CA1839.severity = warning
+
+# Title    : Use 'Environment.CurrentManagedThreadId'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+dotnet_diagnostic.CA1840.severity = warning
+
+# Title    : Prefer Dictionary.Contains methods
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+dotnet_diagnostic.CA1841.severity = warning
+
+# Title    : Do not use 'WhenAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+dotnet_diagnostic.CA1842.severity = suggestion
+
+# Title    : Do not use 'WaitAll' with a single task
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+dotnet_diagnostic.CA1843.severity = warning
+
+# Title    : Provide memory-based overrides of async methods when subclassing 'Stream'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+dotnet_diagnostic.CA1844.severity = warning
+
+# Title    : Use span-based 'string.Concat'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+dotnet_diagnostic.CA1845.severity = warning
+
+# Title    : Prefer 'AsSpan' over 'Substring'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+dotnet_diagnostic.CA1846.severity = warning
+
+# Title    : Use char literal for a single character lookup
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+dotnet_diagnostic.CA1847.severity = warning
+
+# Title    : Use the LoggerMessage delegates
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# Comment  : Use R9 logging model instead
+dotnet_diagnostic.CA1848.severity = none
+
+# Title    : Call async methods when in an async method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+dotnet_diagnostic.CA1849.severity = warning
+
+# Title    : Prefer static 'HashData' method over 'ComputeHash'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+dotnet_diagnostic.CA1850.severity = suggestion
+
+# Title    : Possible multiple enumerations of 'IEnumerable' collection
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+dotnet_diagnostic.CA1851.severity = suggestion
+
+# Title    : Seal internal types
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# Redundant: R9A013
+dotnet_diagnostic.CA1852.severity = none
+
+# Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+dotnet_diagnostic.CA1853.severity = suggestion
+
+# Title    : Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+dotnet_diagnostic.CA1854.severity = warning
+
+# Title    : Prefer 'Clear' over 'Fill'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+dotnet_diagnostic.CA1855.severity = warning
+
+# Title    : Incorrect usage of ConstantExpected attribute
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+dotnet_diagnostic.CA1856.severity = error
+
+# Title    : A constant is expected for the parameter
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+dotnet_diagnostic.CA1857.severity = warning
+
+# Title    : Use 'StartsWith' instead of 'IndexOf'
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = suggestion
+
+# Title    : Use concrete types when possible for improved performance
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Title    : Avoid using 'Enumerable.Any()' extension method
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# Title    : Avoid constant arrays as arguments
+# Category : Performance
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# Title    : Dispose objects before losing scope
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+dotnet_diagnostic.CA2000.severity = warning
+
+# Title    : Do not lock on objects with weak identity
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+dotnet_diagnostic.CA2002.severity = warning
+
+# Title    : Consider calling ConfigureAwait on the awaited task
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+dotnet_diagnostic.CA2007.severity = warning
+
+# Title    : Do not create tasks without passing a TaskScheduler
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+dotnet_diagnostic.CA2008.severity = warning
+
+# Title    : Do not call ToImmutableCollection on an ImmutableCollection value
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+dotnet_diagnostic.CA2009.severity = warning
+
+# Title    : Avoid infinite recursion
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+dotnet_diagnostic.CA2011.severity = error
+
+# Title    : Use ValueTasks correctly
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+dotnet_diagnostic.CA2012.severity = warning
+
+# Title    : Do not use ReferenceEquals with value types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+dotnet_diagnostic.CA2013.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not use stackalloc in loops
+# Category : Reliability
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+dotnet_diagnostic.CA2014.severity = warning
+
+# Title    : Do not define finalizers for types derived from MemoryManager<T>
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+dotnet_diagnostic.CA2015.severity = warning
+
+# Title    : Forward the 'CancellationToken' parameter to methods
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+dotnet_diagnostic.CA2016.severity = warning
+
+# Title    : Parameter count mismatch
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+dotnet_diagnostic.CA2017.severity = warning
+
+# Title    : 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+dotnet_diagnostic.CA2018.severity = warning
+
+# Title    : Improper 'ThreadStatic' field initialization
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+dotnet_diagnostic.CA2019.severity = warning
+
+# Title    : Prevent behavioral change
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+dotnet_diagnostic.CA2020.severity = suggestion
+
+# Title    : Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# Category : Reliability
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+dotnet_diagnostic.CA2021.severity = warning
+
+# Title    : Review SQL queries for security vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+dotnet_diagnostic.CA2100.severity = warning
+
+# Title    : Specify marshaling for P/Invoke string arguments
+# Category : Globalization
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+dotnet_diagnostic.CA2101.severity = warning
+
+# Title    : Review visible event handlers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+dotnet_diagnostic.CA2109.severity = none
+
+# Title    : Seal methods that satisfy private interfaces
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+dotnet_diagnostic.CA2119.severity = warning
+
+# Title    : Do Not Catch Corrupted State Exceptions
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+dotnet_diagnostic.CA2153.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Rethrow to preserve stack details
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+dotnet_diagnostic.CA2200.severity = warning
+
+# Title    : Do not raise reserved exception types
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+dotnet_diagnostic.CA2201.severity = warning
+
+# Title    : Initialize value type static fields inline
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+dotnet_diagnostic.CA2207.severity = warning
+
+# Title    : Instantiate argument exceptions correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+dotnet_diagnostic.CA2208.severity = warning
+
+# Title    : Non-constant fields should not be visible
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+dotnet_diagnostic.CA2211.severity = none
+
+# Title    : Disposable fields should be disposed
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+dotnet_diagnostic.CA2213.severity = warning
+
+# Title    : Do not call overridable methods in constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+dotnet_diagnostic.CA2214.severity = warning
+
+# Title    : Dispose methods should call base class dispose
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+dotnet_diagnostic.CA2215.severity = warning
+
+# Title    : Disposable types should declare finalizer
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+dotnet_diagnostic.CA2216.severity = warning
+
+# Title    : Do not mark enums with FlagsAttribute
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+dotnet_diagnostic.CA2217.severity = warning
+dotnet_code_quality.CA2217.api_surface = all
+
+# Title    : Do not raise exceptions in finally clauses
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+dotnet_diagnostic.CA2219.severity = warning
+
+# Title    : Operator overloads have named alternates
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+dotnet_diagnostic.CA2225.severity = none
+
+# Title    : Operators should have symmetrical overloads
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# Redundant: CS0216
+dotnet_diagnostic.CA2226.severity = none
+
+# Title    : Collection properties should be read only
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = none
+
+# Title    : Implement serialization constructors
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# Comment  : Obsolete
+dotnet_diagnostic.CA2229.severity = none
+
+# Title    : Overload operator equals on overriding value type Equals
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+dotnet_diagnostic.CA2231.severity = error
+
+# Title    : Pass system uri objects instead of strings
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+dotnet_diagnostic.CA2234.severity = warning
+
+# Title    : Mark all non-serializable fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# Comment  : Obsolete
+dotnet_diagnostic.CA2235.severity = none
+
+# Title    : Mark ISerializable types with serializable
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# Comment  : Obsolete
+dotnet_diagnostic.CA2237.severity = none
+
+# Title    : Provide correct arguments to formatting methods
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+dotnet_diagnostic.CA2241.severity = warning
+
+# Title    : Test for NaN correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+dotnet_diagnostic.CA2242.severity = warning
+
+# Title    : Attribute string literals should parse correctly
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+dotnet_diagnostic.CA2243.severity = warning
+
+# Title    : Do not duplicate indexed element initializations
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+dotnet_diagnostic.CA2244.severity = warning
+
+# Title    : Do not assign a property to itself
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+dotnet_diagnostic.CA2245.severity = warning
+
+# Title    : Assigning symbol and its member in the same statement
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+dotnet_diagnostic.CA2246.severity = warning
+
+# Title    : Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+dotnet_diagnostic.CA2247.severity = warning
+
+# Title    : Provide correct 'enum' argument to 'Enum.HasFlag'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+dotnet_diagnostic.CA2248.severity = warning
+
+# Title    : Consider using 'string.Contains' instead of 'string.IndexOf'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+dotnet_diagnostic.CA2249.severity = warning
+
+# Title    : Use 'ThrowIfCancellationRequested'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+dotnet_diagnostic.CA2250.severity = suggestion
+
+# Title    : Use 'string.Equals'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+dotnet_diagnostic.CA2251.severity = warning
+
+# Title    : This API requires opting into preview features
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+dotnet_diagnostic.CA2252.severity = error
+
+# Title    : Named placeholders should not be numeric values
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+dotnet_diagnostic.CA2253.severity = warning
+
+# Title    : Template should be a static expression
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# Title    : The 'ModuleInitializer' attribute should not be used in libraries
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+dotnet_diagnostic.CA2255.severity = warning
+
+# Title    : All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+dotnet_diagnostic.CA2256.severity = error
+
+# Title    : Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+dotnet_diagnostic.CA2257.severity = warning
+
+# Title    : Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+dotnet_diagnostic.CA2258.severity = warning
+
+# Title    : 'ThreadStatic' only affects static fields
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+dotnet_diagnostic.CA2259.severity = warning
+
+# Title    : Use correct type parameter
+# Category : Usage
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+dotnet_diagnostic.CA2260.severity = warning
+
+# Title    : Do not use insecure deserializer BinaryFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+dotnet_diagnostic.CA2300.severity = warning
+
+# Title    : Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+dotnet_diagnostic.CA2301.severity = warning
+
+# Title    : Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+dotnet_diagnostic.CA2302.severity = warning
+
+# Title    : Do not use insecure deserializer LosFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+dotnet_diagnostic.CA2305.severity = warning
+
+# Title    : Do not use insecure deserializer NetDataContractSerializer
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+dotnet_diagnostic.CA2310.severity = warning
+
+# Title    : Do not deserialize without first setting NetDataContractSerializer.Binder
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+dotnet_diagnostic.CA2311.severity = warning
+
+# Title    : Ensure NetDataContractSerializer.Binder is set before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+dotnet_diagnostic.CA2312.severity = warning
+
+# Title    : Do not use insecure deserializer ObjectStateFormatter
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+dotnet_diagnostic.CA2315.severity = warning
+
+# Title    : Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+dotnet_diagnostic.CA2321.severity = warning
+
+# Title    : Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+dotnet_diagnostic.CA2322.severity = warning
+
+# Title    : Do not use TypeNameHandling values other than None
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+dotnet_diagnostic.CA2326.severity = warning
+
+# Title    : Do not use insecure JsonSerializerSettings
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+dotnet_diagnostic.CA2327.severity = warning
+
+# Title    : Ensure that JsonSerializerSettings are secure
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+dotnet_diagnostic.CA2328.severity = warning
+
+# Title    : Do not deserialize with JsonSerializer using an insecure configuration
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+dotnet_diagnostic.CA2329.severity = warning
+
+# Title    : Ensure that JsonSerializer has a secure configuration when deserializing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+dotnet_diagnostic.CA2330.severity = warning
+
+# Title    : Do not use DataTable.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+dotnet_diagnostic.CA2350.severity = warning
+
+# Title    : Do not use DataSet.ReadXml() with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+dotnet_diagnostic.CA2351.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+dotnet_diagnostic.CA2352.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in serializable type
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+dotnet_diagnostic.CA2353.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+dotnet_diagnostic.CA2354.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type found in deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+dotnet_diagnostic.CA2355.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Unsafe DataSet or DataTable type in web deserializable object graph
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+dotnet_diagnostic.CA2356.severity = warning
+
+# Title    : Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+dotnet_diagnostic.CA2361.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+dotnet_diagnostic.CA2362.severity = warning
+
+# Title    : Review code for SQL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+dotnet_diagnostic.CA3001.severity = warning
+
+# Title    : Review code for XSS vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+dotnet_diagnostic.CA3002.severity = warning
+
+# Title    : Review code for file path injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+dotnet_diagnostic.CA3003.severity = warning
+
+# Title    : Review code for information disclosure vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+dotnet_diagnostic.CA3004.severity = warning
+
+# Title    : Review code for LDAP injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+dotnet_diagnostic.CA3005.severity = warning
+
+# Title    : Review code for process command injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+dotnet_diagnostic.CA3006.severity = warning
+
+# Title    : Review code for open redirect vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+dotnet_diagnostic.CA3007.severity = warning
+
+# Title    : Review code for XPath injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+dotnet_diagnostic.CA3008.severity = warning
+
+# Title    : Review code for XML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+dotnet_diagnostic.CA3009.severity = warning
+
+# Title    : Review code for XAML injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+dotnet_diagnostic.CA3010.severity = warning
+
+# Title    : Review code for DLL injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+dotnet_diagnostic.CA3011.severity = warning
+
+# Title    : Review code for regex injection vulnerabilities
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+dotnet_diagnostic.CA3012.severity = warning
+
+# Title    : Do Not Add Schema By URL
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+dotnet_diagnostic.CA3061.severity = silent
+
+# Title    : Insecure DTD processing in XML
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+dotnet_diagnostic.CA3075.severity = warning
+
+# Title    : Insecure XSLT script processing.
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure XSLT script processing
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+dotnet_diagnostic.CA3076.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Insecure Processing in API Design, XmlDocument and XmlTextReader
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+dotnet_diagnostic.CA3077.severity = warning
+
+# Title    : Mark Verb Handlers With Validate Antiforgery Token
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+dotnet_diagnostic.CA3147.severity = warning
+
+# Title    : Do Not Use Weak Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+dotnet_diagnostic.CA5350.severity = error
+
+# Title    : Do Not Use Broken Cryptographic Algorithms
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+dotnet_diagnostic.CA5351.severity = error
+
+# Title    : Review cipher mode usage with cryptography experts
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+dotnet_diagnostic.CA5358.severity = warning
+
+# Title    : Do Not Disable Certificate Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+dotnet_diagnostic.CA5359.severity = warning
+
+# Title    : Do Not Call Dangerous Methods In Deserialization
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+dotnet_diagnostic.CA5360.severity = warning
+
+# Title    : Do Not Disable SChannel Use of Strong Crypto
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+dotnet_diagnostic.CA5361.severity = warning
+
+# Title    : Potential reference cycle in deserialized object graph
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+dotnet_diagnostic.CA5362.severity = warning
+
+# Title    : Do Not Disable Request Validation
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+dotnet_diagnostic.CA5363.severity = warning
+
+# Title    : Do Not Use Deprecated Security Protocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+dotnet_diagnostic.CA5364.severity = warning
+
+# Title    : Do Not Disable HTTP Header Checking
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+dotnet_diagnostic.CA5365.severity = warning
+
+# Title    : Use XmlReader for 'DataSet.ReadXml()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+dotnet_diagnostic.CA5366.severity = warning
+
+# Title    : Do Not Serialize Types With Pointer Fields
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+dotnet_diagnostic.CA5367.severity = warning
+
+# Title    : Set ViewStateUserKey For Classes Derived From Page
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+dotnet_diagnostic.CA5368.severity = warning
+
+# Title    : Use XmlReader for 'XmlSerializer.Deserialize()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+dotnet_diagnostic.CA5369.severity = warning
+
+# Title    : Use XmlReader for XmlValidatingReader constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+dotnet_diagnostic.CA5370.severity = warning
+
+# Title    : Use XmlReader for 'XmlSchema.Read()'
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+dotnet_diagnostic.CA5371.severity = warning
+
+# Title    : Use XmlReader for XPathDocument constructor
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+dotnet_diagnostic.CA5372.severity = warning
+
+# Title    : Do not use obsolete key derivation function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+dotnet_diagnostic.CA5373.severity = warning
+
+# Title    : Do Not Use XslTransform
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+dotnet_diagnostic.CA5374.severity = warning
+
+# Title    : Do Not Use Account Shared Access Signature
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+dotnet_diagnostic.CA5375.severity = warning
+
+# Title    : Use SharedAccessProtocol HttpsOnly
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+dotnet_diagnostic.CA5376.severity = warning
+
+# Title    : Use Container Level Access Policy
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+dotnet_diagnostic.CA5377.severity = warning
+
+# Title    : Do not disable ServicePointManagerSecurityProtocols
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+dotnet_diagnostic.CA5378.severity = warning
+
+# Title    : Ensure Key Derivation Function algorithm is sufficiently strong
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+dotnet_diagnostic.CA5379.severity = warning
+
+# Title    : Do Not Add Certificates To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+dotnet_diagnostic.CA5380.severity = warning
+
+# Title    : Ensure Certificates Are Not Added To Root Store
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+dotnet_diagnostic.CA5381.severity = warning
+
+# Title    : Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+dotnet_diagnostic.CA5382.severity = warning
+
+# Title    : Ensure Use Secure Cookies In ASP.NET Core
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+dotnet_diagnostic.CA5383.severity = warning
+
+# Title    : Do Not Use Digital Signature Algorithm (DSA)
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+dotnet_diagnostic.CA5384.severity = warning
+
+# Title    : Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+dotnet_diagnostic.CA5385.severity = warning
+
+# Title    : Avoid hardcoding SecurityProtocolType value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+dotnet_diagnostic.CA5386.severity = warning
+
+# Title    : Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+dotnet_diagnostic.CA5387.severity = warning
+
+# Title    : Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+dotnet_diagnostic.CA5388.severity = warning
+
+# Title    : Do Not Add Archive Item's Path To The Target File System Path
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+dotnet_diagnostic.CA5389.severity = warning
+
+# Title    : Do not hard-code encryption key
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+dotnet_diagnostic.CA5390.severity = warning
+
+# Title    : Use antiforgery tokens in ASP.NET Core MVC controllers
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+dotnet_diagnostic.CA5391.severity = warning
+
+# Title    : Use DefaultDllImportSearchPaths attribute for P/Invokes
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+dotnet_diagnostic.CA5392.severity = warning
+
+# Title    : Do not use unsafe DllImportSearchPath value
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+dotnet_diagnostic.CA5393.severity = warning
+
+# Title    : Do not use insecure randomness
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+dotnet_diagnostic.CA5394.severity = warning
+
+# Title    : Miss HttpVerb attribute for action methods
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+dotnet_diagnostic.CA5395.severity = warning
+
+# Title    : Set HttpOnly to true for HttpCookie
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+dotnet_diagnostic.CA5396.severity = warning
+
+# Title    : Do not use deprecated SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+dotnet_diagnostic.CA5397.severity = warning
+
+# Title    : Avoid hardcoded SslProtocols values
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+dotnet_diagnostic.CA5398.severity = warning
+
+# Title    : HttpClients should enable certificate revocation list checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+dotnet_diagnostic.CA5399.severity = warning
+
+# Title    : Ensure HttpClient certificate revocation list check is not disabled
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+dotnet_diagnostic.CA5400.severity = warning
+
+# Title    : Do not use CreateEncryptor with non-default IV
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+dotnet_diagnostic.CA5401.severity = warning
+
+# Title    : Use CreateEncryptor with the default IV 
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+dotnet_diagnostic.CA5402.severity = warning
+
+# Title    : Do not hard-code certificate
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+dotnet_diagnostic.CA5403.severity = warning
+
+# Title    : Do not disable token validation checks
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+dotnet_diagnostic.CA5404.severity = warning
+
+# Title    : Do not always skip token validation in delegates
+# Category : Security
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+dotnet_diagnostic.CA5405.severity = warning
+
+# Title    : Set MSBuild property 'GenerateDocumentationFile' to 'true'
+# Category : Style
+# Help Link: https://github.com/dotnet/roslyn/issues/41640
+dotnet_diagnostic.EnableGenerateDocumentationFile.severity = warning
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0001.severity = silent
+
+# Title    : Simplify name
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0002.severity = silent
+
+# Title    : Remove this or Me qualification
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0003.severity = silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Title    : Remove Unnecessary Cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0004
+dotnet_diagnostic.IDE0004.severity = warning
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# Redundant: S1128
+dotnet_diagnostic.IDE0005.severity = none
+
+# Title    : Using directive is unnecessary.
+# Category : Style
+# Redundant: S1128
+dotnet_diagnostic.IDE0005_gen.severity = none
+
+# Title    : Use implicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0007
+dotnet_diagnostic.IDE0007.severity = silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = true
+
+# Title    : Use explicit type
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0008
+dotnet_diagnostic.IDE0008.severity = silent
+
+# Title    : Member access should be qualified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0009.severity = none
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
+dotnet_diagnostic.IDE0010.severity = silent
+
+# Title    : Add braces
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
+dotnet_diagnostic.IDE0011.severity = warning
+csharp_prefer_braces = true
+
+# Title    : Use 'throw' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0016
+dotnet_diagnostic.IDE0016.severity = warning
+csharp_style_throw_expression = true
+
+# Title    : Simplify object initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0017
+dotnet_diagnostic.IDE0017.severity = warning
+dotnet_style_object_initializer = true
+
+# Title    : Inline variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0018
+dotnet_diagnostic.IDE0018.severity = warning
+csharp_style_inlined_variable_declaration = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
+dotnet_diagnostic.IDE0019.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0020
+dotnet_diagnostic.IDE0020.severity = silent
+csharp_style_pattern_matching_over_is_with_cast_check
+
+# Title    : Use expression body for constructor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0021
+dotnet_diagnostic.IDE0021.severity = warning
+csharp_style_expression_bodied_constructors = false
+
+# Title    : Use expression body for method
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0022
+dotnet_diagnostic.IDE0022.severity = silent
+csharp_style_expression_bodied_methods = when_on_single_line
+
+# Title    : Use expression body for conversion operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0023
+dotnet_diagnostic.IDE0023.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0024
+dotnet_diagnostic.IDE0024.severity = warning
+csharp_style_expression_bodied_operators = false
+
+# Title    : Use expression body for property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0025
+dotnet_diagnostic.IDE0025.severity = warning
+csharp_style_expression_bodied_properties = true
+
+# Title    : Use expression body for indexer
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0026
+dotnet_diagnostic.IDE0026.severity = warning
+csharp_style_expression_bodied_indexers = true
+
+# Title    : Use expression body for accessor
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0027
+dotnet_diagnostic.IDE0027.severity = warning
+csharp_style_expression_bodied_accessors = true
+
+# Title    : Simplify collection initialization
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028
+dotnet_diagnostic.IDE0028.severity = warning
+dotnet_style_collection_initializer = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0029
+dotnet_diagnostic.IDE0029.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0030
+dotnet_diagnostic.IDE0030.severity = warning
+dotnet_style_coalesce_expression = true
+
+# Title    : Use null propagation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031
+dotnet_diagnostic.IDE0031.severity = warning
+dotnet_style_null_propagation = true
+
+# Title    : Use auto property
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032
+dotnet_diagnostic.IDE0032.severity = warning
+dotnet_style_prefer_auto_properties = true
+
+# Title    : Use explicitly provided tuple name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0033
+dotnet_diagnostic.IDE0033.severity = warning
+dotnet_style_explicit_tuple_names = true
+
+# Title    : Simplify 'default' expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0034
+dotnet_diagnostic.IDE0034.severity = warning
+csharp_prefer_simple_default_expression = true
+
+# Title    : Unreachable code detected
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0035.severity = warning
+
+# Title    : Order modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036
+dotnet_diagnostic.IDE0036.severity = silent
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Title    : Use inferred member name
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0037
+dotnet_diagnostic.IDE0037.severity = silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+
+# Title    : Use local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0039
+dotnet_diagnostic.IDE0039.severity = silent
+csharp_style_prefer_local_over_anonymous_function = false
+
+# Title    : Add accessibility modifiers
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0040
+dotnet_diagnostic.IDE0040.severity = warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Title    : Use 'is null' check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0041
+dotnet_diagnostic.IDE0041.severity = warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Title    : Deconstruct variable declaration
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0042
+dotnet_diagnostic.IDE0042.severity = silent
+csharp_style_deconstructed_variable_declaration = true
+
+# Title    : Invalid format string
+# Category : Compiler
+dotnet_diagnostic.IDE0043.severity = warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = warning
+dotnet_style_readonly_field = true:warning
+
+# Title    : Add readonly modifier
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0044
+dotnet_diagnostic.IDE0044.severity = silent
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0045
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_style_prefer_conditional_expression_over_assignment = true
+
+# Title    : Convert to conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0046
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_style_prefer_conditional_expression_over_return = true
+
+# Title    : Remove unnecessary parentheses
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
+dotnet_diagnostic.IDE0047.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Title    : Add parentheses for clarity
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0048
+dotnet_diagnostic.IDE0048.severity = silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Title    : Use language keywords instead of framework type names for type references
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line. This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0049.severity = none
+
+# Title    : Convert to tuple
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0050.severity = silent
+
+# Title    : Remove unused private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
+dotnet_diagnostic.IDE0051.severity = warning
+
+# Title    : Remove unread private members
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
+dotnet_diagnostic.IDE0052.severity = warning
+
+# Title    : Use block body for lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# Comment  : This metadata was entered manually, since it is not exposed in the normal way from the analyzer assembly.
+dotnet_diagnostic.IDE0053.severity = suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0054
+dotnet_diagnostic.IDE0054.severity = warning
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Fix formatting
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_style_namespace_match_folder = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = flush_left
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Title    : Use index operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0056
+dotnet_diagnostic.IDE0056.severity = silent
+csharp_style_prefer_index_operator = true
+
+# Title    : Use range operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0057
+dotnet_diagnostic.IDE0057.severity = silent
+csharp_style_prefer_range_operator = true:warning
+
+# Title    : Expression value is never used
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
+dotnet_diagnostic.IDE0058.severity = warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# Title    : Unnecessary assignment of a value
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# Redundant: CS0219
+dotnet_diagnostic.IDE0059.severity = none
+
+# Title    : Remove unused parameter
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0060
+dotnet_diagnostic.IDE0060.severity = warning
+dotnet_code_quality_unused_parameters = all
+
+# Title    : Use expression body for local function
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0061
+dotnet_diagnostic.IDE0061.severity = warning
+csharp_style_expression_bodied_local_functions = true
+
+# Title    : Make local function 'static'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0062
+dotnet_diagnostic.IDE0062.severity = warning
+csharp_prefer_static_local_function = true
+
+# Title    : Use simple 'using' statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = warning
+csharp_prefer_simple_using_statement = true
+
+# Title    : Make readonly fields writable
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0064
+dotnet_diagnostic.IDE0064.severity = warning
+
+# Title    : Misplaced using directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065
+dotnet_diagnostic.IDE0065.severity = warning
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# Title    : Convert switch statement to expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0066
+dotnet_diagnostic.IDE0066.severity = warning
+csharp_style_prefer_switch_expression = true:warning
+
+# Title    : Use 'System.HashCode'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0070
+dotnet_diagnostic.IDE0070.severity = warning
+
+# Title    : Simplify interpolation
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071
+dotnet_diagnostic.IDE0071.severity = warning
+dotnet_style_prefer_simplified_interpolation = true
+
+# Title    : Add missing cases
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0072
+dotnet_diagnostic.IDE0072.severity = silent
+
+# Title    : The file header does not match the required text
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0073
+dotnet_diagnostic.IDE0073.severity = warning
+
+# Title    : Use compound assignment
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0074
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0074.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
+
+# Title    : Simplify conditional expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0075
+dotnet_diagnostic.IDE0075.severity = warning
+dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Title    : Invalid global 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0076
+dotnet_diagnostic.IDE0076.severity = warning
+
+# Title    : Avoid legacy format target in 'SuppressMessageAttribute'
+# Category : CodeQuality
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0077
+dotnet_diagnostic.IDE0077.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
+dotnet_diagnostic.IDE0078.severity = silent
+csharp_style_prefer_pattern_matching = true
+
+# Title    : Remove unnecessary suppression
+# Category : Style
+# Comment  : This diagnostic only triggers in Visual Studio, not when building from the command-line
+dotnet_diagnostic.IDE0079.severity = suggestion
+dotnet_remove_unnecessary_suppression_exclusions = CS0618
+
+# Title    : Remove unnecessary suppression operator
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0080
+dotnet_diagnostic.IDE0080.severity = warning
+
+# Title    : 'typeof' can be converted  to 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082
+dotnet_diagnostic.IDE0082.severity = warning
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0083
+dotnet_diagnostic.IDE0083.severity = silent
+csharp_style_prefer_not_pattern = true
+
+# Title    : Use 'new(...)'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
+dotnet_diagnostic.IDE0090.severity = warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Title    : Remove redundant equality
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# Comment  : S1125 triggers in more cases
+# Redundant: S1125
+dotnet_diagnostic.IDE0100.severity = none
+
+# Title    : Remove unnecessary discard
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0110
+dotnet_diagnostic.IDE0110.severity = warning
+
+# Title    : Simplify LINQ expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0120
+dotnet_diagnostic.IDE0120.severity = silent
+
+# Title    : Namespace does not match folder structure
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
+dotnet_diagnostic.IDE0130.severity = silent
+
+# Title    : Prefer 'null' check over type check
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0150
+dotnet_diagnostic.IDE0150.severity = warning
+csharp_style_prefer_null_check_over_type_check = true
+
+# Title    : Convert to block scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0160
+dotnet_diagnostic.IDE0160.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Convert to file-scoped namespace
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0161
+dotnet_diagnostic.IDE0161.severity = silent
+csharp_style_namespace_declarations = file_scoped
+
+# Title    : Property pattern can be simplified
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0170
+dotnet_diagnostic.IDE0170.severity = silent
+csharp_style_prefer_extended_property_pattern = true
+
+# Title    : Use tuple to swap values
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0180
+dotnet_diagnostic.IDE0180.severity = silent
+csharp_style_prefer_tuple_swap = true
+
+# Title    : Null check can be simplified
+# Category : Style
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0190
+dotnet_diagnostic.IDE0190.severity = silent
+
+# Title    : Remove unnecessary lambda expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0200
+dotnet_diagnostic.IDE0200.severity = silent
+
+# Title    : Convert to top-level statements
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0210
+dotnet_diagnostic.IDE0210.severity = silent
+
+# Title    : Convert to 'Program.Main' style program
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0211
+dotnet_diagnostic.IDE0211.severity = silent
+
+# Title    : Add explicit cast
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0220
+dotnet_diagnostic.IDE0220.severity = silent
+
+# Title    : Use UTF-8 string literal
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0230
+dotnet_diagnostic.IDE0230.severity = silent
+
+# Title    : Remove redundant nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240
+dotnet_diagnostic.IDE0240.severity = warning
+
+# Title    : Remove unnecessary nullable directive
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241
+dotnet_diagnostic.IDE0241.severity = warning
+
+# Title    : Make struct 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
+dotnet_diagnostic.IDE0250.severity = warning
+
+# Title    : Make member 'readonly'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
+dotnet_diagnostic.IDE0251.severity = none
+
+# Title    : Use pattern matching
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260
+dotnet_diagnostic.IDE0260.severity = silent
+
+# Title    : Use coalesce expression
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
+dotnet_diagnostic.IDE0270.severity = silent
+
+# Title    : Use 'nameof'
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280
+dotnet_diagnostic.IDE0280.severity = silent
+
+# Title    : Delegate invocation can be simplified.
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005
+dotnet_diagnostic.IDE1005.severity = warning
+csharp_style_conditional_delegate_call = true
+
+# Title    : Naming Styles
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
+dotnet_diagnostic.IDE1006.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interface_should_be_ipascalcase.symbols = interface
+dotnet_naming_rule.interface_should_be_ipascalcase.style = ipascalcase
+dotnet_naming_rule.types_should_be_pascalcase.severity = warning
+dotnet_naming_rule.types_should_be_pascalcase.symbols = types
+dotnet_naming_rule.types_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.constant_should_be_pascalcase.severity = warning
+dotnet_naming_rule.constant_should_be_pascalcase.symbols = constant
+dotnet_naming_rule.constant_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+dotnet_naming_rule.method_parameter_should_be_camelcase.severity = warning
+dotnet_naming_rule.method_parameter_should_be_camelcase.symbols = method_parameter
+dotnet_naming_rule.method_parameter_should_be_camelcase.style = camelcase
+dotnet_naming_rule.local_variable_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variable_should_be_camelcase.symbols = local_variable
+dotnet_naming_rule.local_variable_should_be_camelcase.style = camelcase
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.symbols = type_parameter
+dotnet_naming_rule.type_parameter_should_be_tpascalcase.style = tpascalcase
+dotnet_naming_rule.private_field_should_be__camelcase.severity = warning
+dotnet_naming_rule.private_field_should_be__camelcase.symbols = private_field
+dotnet_naming_rule.private_field_should_be__camelcase.style = _camelcase
+dotnet_naming_rule.field_should_be_pascalcase.severity = warning
+dotnet_naming_rule.field_should_be_pascalcase.symbols = field
+dotnet_naming_rule.field_should_be_pascalcase.style = pascalcase
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.method_parameter.applicable_kinds = parameter
+dotnet_naming_symbols.method_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.method_parameter.required_modifiers =
+dotnet_naming_symbols.local_variable.applicable_kinds = local
+dotnet_naming_symbols.local_variable.applicable_accessibilities = local
+dotnet_naming_symbols.local_variable.required_modifiers =
+dotnet_naming_symbols.type_parameter.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameter.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameter.required_modifiers =
+dotnet_naming_symbols.constant.applicable_kinds = field, local
+dotnet_naming_symbols.constant.applicable_accessibilities = *
+dotnet_naming_symbols.constant.required_modifiers = const
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private
+dotnet_naming_symbols.private_field.required_modifiers =
+dotnet_naming_symbols.field.applicable_kinds = field
+dotnet_naming_symbols.field.applicable_accessibilities = public, internal, protected, protected_internal, private_protected, local
+dotnet_naming_symbols.field.required_modifiers =
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator =
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator =
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator =
+dotnet_naming_style.camelcase.capitalization = camel_case
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator =
+dotnet_naming_style._camelcase.capitalization = camel_case
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator =
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+# Title    : Avoid multiple blank lines
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = warning
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Title    : Embedded statements must be on their own line
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = warning
+
+# Title    : Consecutive braces must not have blank line between them
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = warning
+
+# Title    : Blank line required between block and subsequent statement
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = silent
+
+# Title    : Blank line not allowed after constructor initializer colon
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = warning
+
+# Title    : Blank line not allowed after conditional expression token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = silent
+
+# Title    : Blank line not allowed after arrow expression clause token
+# Category : Style
+# Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = silent
+
+# Title    : Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+# Category : Trimming
+dotnet_diagnostic.IL2026.severity = warning
+
+# Title    : The value passed as the assembly name or type name to the CreateInstance method can't be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2032.severity = warning
+
+# Title    : The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters.
+# Category : Trimming
+dotnet_diagnostic.IL2041.severity = warning
+
+# Title    : 'DynamicallyAccessedMembersAttribute' on property conflicts with the same attribute on its accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2043.severity = warning
+
+# Title    : 'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : Trimming
+dotnet_diagnostic.IL2046.severity = warning
+
+# Title    : Correctness of COM interop cannot be guaranteed after trimming. Interfaces and interface members might be removed.
+# Category : Trimming
+dotnet_diagnostic.IL2050.severity = warning
+
+# Title    : Either the type on which the MakeGenericType is called can't be statically determined, or the type parameters to be used for generic arguments can't be statically determined.
+# Category : Trimming
+dotnet_diagnostic.IL2055.severity = warning
+
+# Title    : Unrecognized value passed to the parameter of method. It's not possible to guarantee the availability of the target type.
+# Category : Trimming
+dotnet_diagnostic.IL2057.severity = warning
+
+# Title    : Parameters passed to method cannot be analyzed. Consider using methods 'System.Type.GetType' and `System.Activator.CreateInstance` instead.
+# Category : Trimming
+dotnet_diagnostic.IL2058.severity = warning
+
+# Title    : The type passed to the RunClassConstructor is not statically known, Trimmer can't make sure that its static constructor is available.
+# Category : Trimming
+dotnet_diagnostic.IL2059.severity = warning
+
+# Title    : Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method.
+# Category : Trimming
+dotnet_diagnostic.IL2060.severity = warning
+
+# Title    : The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2062.severity = warning
+
+# Title    : The return value of method has a DynamicallyAccessedMembersAttribute, but the value returned from the method can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2063.severity = warning
+
+# Title    : The field has a DynamicallyAccessedMembersAttribute, but the value assigned to it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2064.severity = warning
+
+# Title    : The method has a DynamicallyAccessedMembersAttribute (which applies to the implicit 'this' parameter), but the value used for the 'this' parameter can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2065.severity = warning
+
+# Title    : The generic parameter of type or method has a DynamicallyAccessedMembersAttribute, but the value used for it can not be statically analyzed.
+# Category : Trimming
+dotnet_diagnostic.IL2066.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2067.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2068.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2069.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2070.severity = warning
+
+# Title    : Generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The parameter of method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2071.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2072.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2073.severity = warning
+
+# Title    : Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2074.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The return value of the source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2075.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The return value of the source method does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+# Category : Trimming
+dotnet_diagnostic.IL2076.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2077.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2078.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2079.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2080.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The source field does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2081.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2082.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2083.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2084.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2085.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The implicit 'this' argument of source method does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2086.severity = warning
+
+# Title    : Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2087.severity = warning
+
+# Title    : Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2088.severity = warning
+
+# Title    : Value stored in target field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2089.severity = warning
+
+# Title    : 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2090.severity = warning
+
+# Title    : Target generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in target method or type. The generic parameter of the source method or type does not have matching annotations.
+# Category : Trimming
+dotnet_diagnostic.IL2091.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the parameter of method don't match overridden parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2092.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the return value of method don't match overridden return value of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2093.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the implicit 'this' parameter of method don't match overridden implicit 'this' parameter of method. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2094.severity = warning
+
+# Title    : 'DynamicallyAccessedMemberTypes' on the generic parameter of method or type don't match overridden generic parameter method or type. All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.
+# Category : Trimming
+dotnet_diagnostic.IL2095.severity = warning
+
+# Title    : Call to 'Type.GetType' method can perform case insensitive lookup of the type, currently ILLink can not guarantee presence of all the matching types.
+# Category : Trimming
+dotnet_diagnostic.IL2096.severity = warning
+
+# Title    : Field has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2097.severity = warning
+
+# Title    : Parameter of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2098.severity = warning
+
+# Title    : Property has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2099.severity = warning
+
+# Title    : Value passed to the parameter of method cannot be statically determined as a property accessor.
+# Category : Trimming
+dotnet_diagnostic.IL2103.severity = warning
+
+# Title    : Return type of method has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.
+# Category : Trimming
+dotnet_diagnostic.IL2106.severity = warning
+
+# Title    : Types that derive from a base class with 'RequiresUnreferencedCodeAttribute' need to explicitly use the 'RequiresUnreferencedCodeAttribute' or suppress this warning
+# Category : Trimming
+dotnet_diagnostic.IL2109.severity = warning
+
+# Title    : Field with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.
+# Category : Trimming
+dotnet_diagnostic.IL2110.severity = warning
+
+# Title    : Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+# Category : Trimming
+dotnet_diagnostic.IL2111.severity = warning
+
+# Title    : The use of 'RequiresUnreferencedCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : Trimming
+dotnet_diagnostic.IL2116.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
+dotnet_diagnostic.IL3000.severity = warning
+
+# Title    : Avoid accessing Assembly file path when publishing as a single file
+# Category : SingleFile
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid using accessing Assembly file path when publishing as a single-file
+# Category : Publish
+# Help Link: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3001
+dotnet_diagnostic.IL3001.severity = warning
+
+# Title    : Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file
+# Category : SingleFile
+dotnet_diagnostic.IL3002.severity = warning
+
+# Title    : 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# Category : SingleFile
+dotnet_diagnostic.IL3003.severity = warning
+
+# Title    : The use of 'RequiresAssemblyFilesAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : SingleFile
+dotnet_diagnostic.IL3004.severity = warning
+
+# Title    : Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+# Category : AOT
+dotnet_diagnostic.IL3050.severity = warning
+
+# Title    : 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.
+# Category : AOT
+dotnet_diagnostic.IL3051.severity = warning
+
+# Title    : The use of 'RequiresDynamicCodeAttribute' on static constructors is disallowed since is a method not callable by the user, is only called by the runtime. Placing the attribute directly on the static constructor will have no effect, instead use 'RequiresUnreferencedCodeAttribute' on the type which will handle warning and silencing from the static constructor.
+# Category : AOT
+dotnet_diagnostic.IL3056.severity = warning
+
+# Title    : Use source generated logging methods for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a000
+dotnet_diagnostic.R9A000.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a014
+dotnet_diagnostic.R9A014.severity = warning
+
+# Title    : Use the 'Microsoft.Shared.Diagnostics.Throws' class instead of explicitly throwing exception for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a015
+dotnet_diagnostic.R9A015.severity = warning
+
+# Title    : Use 'System.Text.CompositeFormat' instead of 'string.Format' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a018
+dotnet_diagnostic.R9A018.severity = warning
+
+# Title    : Remove unnecessary dictionary lookups
+# Category : Performance
+# Help Link: https://TODO/r9a019
+dotnet_diagnostic.R9A019.severity = warning
+
+# Title    : Remove unnecessary set lookups
+# Category : Performance
+# Help Link: https://TODO/r9a020
+dotnet_diagnostic.R9A020.severity = warning
+
+# Title    : Perform message formatting in the body of the logging method
+# Category : Performance
+# Help Link: https://TODO/r9a021
+dotnet_diagnostic.R9A021.severity = warning
+
+# Title    : Use 'System.TimeProvider' to make the code easier to test
+# Category : Reliability
+# Help Link: https://TODO/r9a022
+dotnet_diagnostic.R9A022.severity = warning
+
+# Title    : Using experimental API
+# Category : Reliability
+# Help Link: https://TODO/r9a029
+dotnet_diagnostic.R9A029.severity = none
+
+# Title    : Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
+# Category : Performance
+# Help Link: https://TODO/r9a030
+dotnet_diagnostic.R9A030.severity = warning
+
+# Title    : Make types declared in an executable internal
+# Category : Performance
+# Help Link: https://TODO/r9a031
+dotnet_diagnostic.R9A031.severity = warning
+
+# Title    : Consider using an array instead of a collection
+# Category : Performance
+# Help Link: https://TODO/r9a032
+dotnet_diagnostic.R9A032.severity = none
+
+# Title    : Replace uses of 'Enum.GetName' and 'Enum.ToString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a033
+dotnet_diagnostic.R9A033.severity = warning
+
+# Title    : Use 'Microsoft.Shared.Text.NumericExtensions.ToInvariantString' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a036
+dotnet_diagnostic.R9A036.severity = warning
+
+# Title    : Use 'System.ValueTuple' instead of 'System.Tuple' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a037
+dotnet_diagnostic.R9A037.severity = warning
+
+# Title    : Use generic collections instead of legacy collections for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a040
+dotnet_diagnostic.R9A040.severity = warning
+
+# Title    : Use 'System.MemoryExtensions.Split' for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a043
+dotnet_diagnostic.R9A043.severity = warning
+
+# Title    : Assign array of literal values to a static field for improved performance
+# Category : Performance
+# Help Link: https://TODO/r9a044
+dotnet_diagnostic.R9A044.severity = warning
+
+# Title    : Newly added symbols must be marked as experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a049
+dotnet_diagnostic.R9A049.severity = none
+
+# Title    : Experimental symbols cannot be marked as obsolete
+# Category : Correctness
+# Help Link: https://TODO/r9a050
+dotnet_diagnostic.R9A050.severity = none
+
+# Title    : Published symbols cannot be marked experimental
+# Category : Correctness
+# Help Link: https://TODO/r9a051
+dotnet_diagnostic.R9A051.severity = none
+
+# Title    : Published symbols cannot be deleted to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a052
+dotnet_diagnostic.R9A052.severity = none
+
+# Title    : A deprecated API is not annotated with the obsolete attribute
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
+dotnet_diagnostic.R9A053.severity = none
+
+# Title    : A deprecated API is marked as experimental
+# Category : Correctness
+# Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
+dotnet_diagnostic.R9A054.severity = none
+
+# Title    : Published symbols cannot be changed to maintain compatibility
+# Category : Correctness
+# Help Link: https://TODO/r9a055
+dotnet_diagnostic.R9A055.severity = none
+
+# Title    : Fire-and-forget async call inside a 'using' block
+# Category : Correctness
+# Help Link: https://TODO/r9a056
+dotnet_diagnostic.R9A056.severity = warning
+
+# Title    : Consider removing unnecessary conditional access operator (?)
+# Category : Performance
+# Help Link: https://TODO/r9a058
+dotnet_diagnostic.R9A058.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing assignment (??=)
+# Category : Performance
+# Help Link: https://TODO/r9a059
+dotnet_diagnostic.R9A059.severity = suggestion
+
+# Title    : Consider removing unnecessary null coalescing operator (??)
+# Category : Performance
+# Help Link: https://TODO/r9a060
+dotnet_diagnostic.R9A060.severity = suggestion
+
+# Title    : The async method doesn't support cancellation
+# Category : Resilience
+# Help Link: https://TODO/r9a061
+dotnet_diagnostic.R9A061.severity = warning
+
+# Title    : 
+# Category : Style
+dotnet_diagnostic.RemoveUnnecessaryImportsFixable.severity = silent
+
+# Title    : Methods and properties should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-100
+# Redundant: IDE1006
+dotnet_diagnostic.S100.severity = none
+
+# Title    : Method overrides should not change parameter defaults
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1006
+dotnet_diagnostic.S1006.severity = warning
+
+# Title    : Types should be named in PascalCase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-101
+# Redundant: IDE1006
+dotnet_diagnostic.S101.severity = none
+
+# Title    : Lines should not be too long
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-103
+dotnet_diagnostic.S103.severity = warning
+
+# Title    : Files should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-104
+dotnet_diagnostic.S104.severity = warning
+
+# Title    : Destructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1048
+# Redundant: CA1065
+dotnet_diagnostic.S1048.severity = none
+
+# Title    : Tabulation characters should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-105
+# Redundant: SA1027
+dotnet_diagnostic.S105.severity = none
+
+# Title    : Standard outputs should not be used directly to log anything
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-106
+dotnet_diagnostic.S106.severity = warning
+
+# Title    : Collapsible "if" statements should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1066
+dotnet_diagnostic.S1066.severity = none
+
+# Title    : Expressions should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1067
+dotnet_diagnostic.S1067.severity = warning
+
+# Title    : Methods should not have too many parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-107
+dotnet_diagnostic.S107.severity = warning
+
+# Title    : URIs should not be hardcoded
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1075
+dotnet_diagnostic.S1075.severity = warning
+
+# Title    : Nested blocks of code should not be left empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-108
+dotnet_diagnostic.S108.severity = warning
+
+# Title    : Magic numbers should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-109
+dotnet_diagnostic.S109.severity = warning
+
+# Title    : Inheritance tree of classes should not be too deep
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-110
+dotnet_diagnostic.S110.severity = warning
+
+# Title    : Fields should not have public accessibility
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1104
+# Redundant: CA1051
+dotnet_diagnostic.S1104.severity = none
+
+# Title    : A close curly brace should be located at the beginning of a line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1109
+# Redundant: SA1500
+dotnet_diagnostic.S1109.severity = none
+
+# Title    : Redundant pairs of parentheses should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1110
+# Redundant: SA1119
+dotnet_diagnostic.S1110.severity = none
+
+# Title    : Empty statements should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1116
+# Redundant: SA1106
+dotnet_diagnostic.S1116.severity = none
+
+# Title    : Local variables should not shadow class fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1117
+dotnet_diagnostic.S1117.severity = warning
+
+# Title    : Utility classes should not have public constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1118
+# Redundant: CA1052
+dotnet_diagnostic.S1118.severity = none
+
+# Title    : General exceptions should never be thrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-112
+# Redundant: CA2219
+dotnet_diagnostic.S112.severity = none
+
+# Title    : Assignments should not be made from within sub-expressions
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1121
+dotnet_diagnostic.S1121.severity = warning
+
+# Title    : "Obsolete" attributes should include explanations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1123
+# Redundant: CA1041
+dotnet_diagnostic.S1123.severity = none
+
+# Title    : Boolean literals should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1125
+dotnet_diagnostic.S1125.severity = warning
+
+# Title    : Unused "using" should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1128
+dotnet_diagnostic.S1128.severity = warning
+
+# Title    : Files should contain an empty newline at the end
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-113
+dotnet_diagnostic.S113.severity = none
+
+# Title    : Track uses of "FIXME" tags
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1134
+dotnet_diagnostic.S1134.severity = warning
+
+# Title    : Track uses of "TODO" tags
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1135
+dotnet_diagnostic.S1135.severity = warning
+
+# Title    : Unused private types or members should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1144
+dotnet_diagnostic.S1144.severity = warning
+
+# Title    : Useless "if(true) {...}" and "if(false){...}" blocks should be removed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1145
+dotnet_diagnostic.S1145.severity = warning
+
+# Title    : Exit methods should not be called
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1147
+dotnet_diagnostic.S1147.severity = warning
+
+# Title    : "switch case" clauses should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1151
+dotnet_diagnostic.S1151.severity = none
+
+# Title    : "Any()" should be used to test for emptiness
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1155
+dotnet_diagnostic.S1155.severity = warning
+
+# Title    : Exceptions should not be thrown in finally blocks
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1163
+# Redundant: CA2219
+dotnet_diagnostic.S1163.severity = none
+
+# Title    : Empty arrays and collections should be returned instead of null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1168
+dotnet_diagnostic.S1168.severity = warning
+
+# Title    : Unused method parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1172
+# Redundant: IDE0060
+dotnet_diagnostic.S1172.severity = none
+
+# Title    : Overriding members should do more than simply call the same member in the base class
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1185
+dotnet_diagnostic.S1185.severity = warning
+
+# Title    : Methods should not be empty
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1186
+dotnet_diagnostic.S1186.severity = warning
+
+# Title    : String literals should not be duplicated
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1192
+dotnet_diagnostic.S1192.severity = suggestion
+
+# Title    : Nested code blocks should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1199
+dotnet_diagnostic.S1199.severity = warning
+
+# Title    : Classes should not be coupled to too many other classes (Single Responsibility Principle)
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1200
+dotnet_diagnostic.S1200.severity = none
+
+# Title    : "Equals(Object)" and "GetHashCode()" should be overridden in pairs
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1206
+# Redundant: CS0659
+dotnet_diagnostic.S1206.severity = none
+
+# Title    : Control structures should use curly braces
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-121
+# Redundant: SA1503
+dotnet_diagnostic.S121.severity = none
+
+# Title    : "Equals" and the comparison operators should be overridden when implementing "IComparable"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1210
+# Redundant: CA1036
+dotnet_diagnostic.S1210.severity = none
+
+# Title    : "GC.Collect" should not be called
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1215
+dotnet_diagnostic.S1215.severity = warning
+
+# Title    : Statements should be on separate lines
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-122
+dotnet_diagnostic.S122.severity = none
+
+# Title    : Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1226
+dotnet_diagnostic.S1226.severity = warning
+
+# Title    : break statements should not be used except for switch cases
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1227
+dotnet_diagnostic.S1227.severity = none
+
+# Title    : Floating point numbers should not be tested for equality
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1244
+dotnet_diagnostic.S1244.severity = error
+
+# Title    : Sections of code should not be commented out
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-125
+dotnet_diagnostic.S125.severity = warning
+
+# Title    : "if ... else if" constructs should end with "else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-126
+dotnet_diagnostic.S126.severity = none
+
+# Title    : A "while" loop should be used instead of a "for" loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1264
+dotnet_diagnostic.S1264.severity = warning
+
+# Title    : "for" loop stop conditions should be invariant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-127
+dotnet_diagnostic.S127.severity = warning
+
+# Title    : "switch" statements should have at least 3 "case" clauses
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1301
+dotnet_diagnostic.S1301.severity = none
+
+# Title    : Track uses of in-source issue suppressions
+# Category : Info Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1309
+# Comment  : Suppressions are frequently necessary.
+dotnet_diagnostic.S1309.severity = none
+
+# Title    : "switch/Select" statements should contain a "default/Case Else" clauses
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-131
+dotnet_diagnostic.S131.severity = none
+
+# Title    : Using hardcoded IP addresses is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1313
+dotnet_diagnostic.S1313.severity = warning
+
+# Title    : Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-134
+dotnet_diagnostic.S134.severity = none
+
+# Title    : Functions should not have too many lines of code
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-138
+dotnet_diagnostic.S138.severity = none
+
+# Title    : Culture should be specified for "string" operations
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1449
+dotnet_diagnostic.S1449.severity = warning
+
+# Title    : Private fields only used as local variables in methods should become local variables
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1450
+dotnet_diagnostic.S1450.severity = warning
+
+# Title    : Track lack of copyright and license headers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1451
+# Redundant: IDE0073
+dotnet_diagnostic.S1451.severity = none
+
+# Title    : "switch" statements should not have too many "case" clauses
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1479
+dotnet_diagnostic.S1479.severity = warning
+
+# Title    : Unused local variables should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1481
+# Redundant: CS0168
+dotnet_diagnostic.S1481.severity = none
+
+# Title    : Methods and properties should not be too complex
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1541
+dotnet_diagnostic.S1541.severity = none
+
+# Title    : Tests should not be ignored
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1607
+dotnet_diagnostic.S1607.severity = warning
+
+# Title    : Strings should not be concatenated using '+' in a loop
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1643
+dotnet_diagnostic.S1643.severity = warning
+
+# Title    : Variables should not be self-assigned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1656
+dotnet_diagnostic.S1656.severity = warning
+
+# Title    : Multiple variables should not be declared on the same line
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1659
+dotnet_diagnostic.S1659.severity = warning
+
+# Title    : An abstract class should have both abstract and concrete methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1694
+dotnet_diagnostic.S1694.severity = warning
+
+# Title    : NullReferenceException should not be caught
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1696
+dotnet_diagnostic.S1696.severity = warning
+
+# Title    : Short-circuit logic should be used to prevent null pointer dereferences in conditionals
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1697
+dotnet_diagnostic.S1697.severity = warning
+
+# Title    : "==" should not be used when "Equals" is overridden
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1698
+dotnet_diagnostic.S1698.severity = warning
+
+# Title    : Constructors should only call non-overridable methods
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1699
+dotnet_diagnostic.S1699.severity = warning
+
+# Title    : Loops with at most one iteration should be refactored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1751
+dotnet_diagnostic.S1751.severity = warning
+
+# Title    : Identical expressions should not be used on both sides of a binary operator
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1764
+dotnet_diagnostic.S1764.severity = warning
+
+# Title    : "switch" statements should not be nested
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1821
+dotnet_diagnostic.S1821.severity = none
+
+# Title    : Objects should not be created to be dropped immediately without being used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1848
+dotnet_diagnostic.S1848.severity = warning
+
+# Title    : Unused assignments should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1854
+# Redundant: IDE0059
+dotnet_diagnostic.S1854.severity = none
+
+# Title    : "ToString()" calls should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1858
+dotnet_diagnostic.S1858.severity = warning
+
+# Title    : Related "if/else if" statements should not have the same condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1862
+dotnet_diagnostic.S1862.severity = warning
+
+# Title    : Two branches in a conditional structure should not have exactly the same implementation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1871
+dotnet_diagnostic.S1871.severity = warning
+
+# Title    : Redundant casts should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1905
+# Redundant: IDE0004
+dotnet_diagnostic.S1905.severity = none
+
+# Title    : Inheritance list should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1939
+dotnet_diagnostic.S1939.severity = warning
+
+# Title    : Boolean checks should not be inverted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1940
+dotnet_diagnostic.S1940.severity = warning
+
+# Title    : Inappropriate casts should not be made
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1944
+dotnet_diagnostic.S1944.severity = warning
+
+# Title    : "for" loop increment clauses should modify the loops' counters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-1994
+dotnet_diagnostic.S1994.severity = warning
+
+# Title    : Hashes should include an unpredictable salt
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2053
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S2053.severity = none
+
+# Title    : Hard-coded credentials are security-sensitive
+# Category : Blocker Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2068
+dotnet_diagnostic.S2068.severity = warning
+
+# Title    : SHA-1 and Message-Digest hash algorithms should not be used in secure contexts
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2070
+# Redundant: CA5350
+dotnet_diagnostic.S2070.severity = none
+
+# Title    : Formatting SQL queries is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2077
+dotnet_diagnostic.S2077.severity = warning
+
+# Title    : Creating cookies without the "secure" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2092
+dotnet_diagnostic.S2092.severity = warning
+
+# Title    : Collections should not be passed as arguments to their own methods
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2114
+dotnet_diagnostic.S2114.severity = warning
+
+# Title    : A secure password should be used when connecting to a database
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2115
+dotnet_diagnostic.S2115.severity = warning
+
+# Title    : Values should not be uselessly incremented
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2123
+dotnet_diagnostic.S2123.severity = warning
+
+# Title    : Underscores should be used to make large numbers readable
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2148
+dotnet_diagnostic.S2148.severity = warning
+
+# Title    : "sealed" classes should not have "protected" members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2156
+dotnet_diagnostic.S2156.severity = warning
+
+# Title    : Short-circuit logic should be used in boolean contexts
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2178
+dotnet_diagnostic.S2178.severity = warning
+
+# Title    : Integral numbers should not be shifted by zero or more than their number of bits-1
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2183
+dotnet_diagnostic.S2183.severity = warning
+
+# Title    : Results of integer division should not be assigned to floating point variables
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2184
+dotnet_diagnostic.S2184.severity = warning
+
+# Title    : TestCases should contain tests
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2187
+dotnet_diagnostic.S2187.severity = warning
+
+# Title    : Recursion should not be infinite
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2190
+dotnet_diagnostic.S2190.severity = warning
+
+# Title    : Modulus results should not be checked for direct equality
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2197
+dotnet_diagnostic.S2197.severity = warning
+
+# Title    : Return values from functions without side effects should not be ignored
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2201
+# Redundant: CA1806
+dotnet_diagnostic.S2201.severity = none
+
+# Title    : Runtime type checking should be simplified
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2219
+dotnet_diagnostic.S2219.severity = warning
+
+# Title    : "Exception" should not be caught
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2221
+dotnet_diagnostic.S2221.severity = none
+
+# Title    : Locks should be released on all paths
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2222
+dotnet_diagnostic.S2222.severity = warning
+
+# Title    : Non-constant static fields should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2223
+dotnet_diagnostic.S2223.severity = warning
+
+# Title    : "ToString()" method should not return null
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2225
+dotnet_diagnostic.S2225.severity = warning
+
+# Title    : Console logging should not be used
+# Category : Minor Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2228
+dotnet_diagnostic.S2228.severity = warning
+
+# Title    : Parameters should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2234
+dotnet_diagnostic.S2234.severity = warning
+
+# Title    : Using pseudorandom number generators (PRNGs) is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2245
+dotnet_diagnostic.S2245.severity = warning
+
+# Title    : A "for" loop update clause should move the counter in the right direction
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2251
+dotnet_diagnostic.S2251.severity = warning
+
+# Title    : For-loop conditions should be true at least once
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2252
+dotnet_diagnostic.S2252.severity = warning
+
+# Title    : Writing cookies is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2255
+dotnet_diagnostic.S2255.severity = warning
+
+# Title    : Using non-standard cryptographic algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2257
+dotnet_diagnostic.S2257.severity = warning
+
+# Title    : Null pointers should not be dereferenced
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2259
+# Comment  : Redundant, covered by modern C# compiler
+dotnet_diagnostic.S2259.severity = none
+
+# Title    : Composite format strings should not lead to unexpected behavior at runtime
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2275
+dotnet_diagnostic.S2275.severity = warning
+
+# Title    : Neither DES (Data Encryption Standard) nor DESede (3DES) should be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2278
+dotnet_diagnostic.S2278.severity = warning
+
+# Title    : Field-like events should not be virtual
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2290
+dotnet_diagnostic.S2290.severity = warning
+
+# Title    : Overflow checking should not be disabled for "Enumerable.Sum"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2291
+dotnet_diagnostic.S2291.severity = warning
+
+# Title    : Trivial properties should be auto-implemented
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2292
+# Redundant: IDE0032
+dotnet_diagnostic.S2292.severity = none
+
+# Title    : "nameof" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2302
+dotnet_diagnostic.S2302.severity = warning
+
+# Title    : "async" and "await" should not be used as identifiers
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2306
+dotnet_diagnostic.S2306.severity = warning
+
+# Title    : Methods and properties that don't access instance data should be static
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2325
+# Redundant: CA1822
+dotnet_diagnostic.S2325.severity = none
+
+# Title    : Unused type parameters should be removed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2326
+# Comment  : Valid pattern used in a number of places
+dotnet_diagnostic.S2326.severity = none
+
+# Title    : "try" statements with identical "catch" and/or "finally" blocks should be merged
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2327
+dotnet_diagnostic.S2327.severity = warning
+
+# Title    : "GetHashCode" should not reference mutable fields
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2328
+dotnet_diagnostic.S2328.severity = warning
+
+# Title    : Array covariance should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2330
+dotnet_diagnostic.S2330.severity = warning
+
+# Title    : Redundant modifiers should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2333
+dotnet_diagnostic.S2333.severity = warning
+
+# Title    : Public constant members should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2339
+dotnet_diagnostic.S2339.severity = none
+
+# Title    : Enumeration types should comply with a naming convention
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2342
+dotnet_diagnostic.S2342.severity = none
+
+# Title    : Enumeration type names should not have "Flags" or "Enum" suffixes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2344
+dotnet_diagnostic.S2344.severity = warning
+
+# Title    : Flags enumerations should explicitly initialize all their members
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2345
+dotnet_diagnostic.S2345.severity = warning
+
+# Title    : Flags enumerations zero-value members should be named "None"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2346
+# Redundant: CA1008
+dotnet_diagnostic.S2346.severity = none
+
+# Title    : Fields should be private
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2357
+# Redundant: CA1051
+dotnet_diagnostic.S2357.severity = none
+
+# Title    : Optional parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2360
+dotnet_diagnostic.S2360.severity = none
+
+# Title    : Properties should not make collection or array copies
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2365
+dotnet_diagnostic.S2365.severity = warning
+
+# Title    : Public methods should not have multidimensional array parameters
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2368
+dotnet_diagnostic.S2368.severity = warning
+
+# Title    : Exceptions should not be thrown from property getters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2372
+dotnet_diagnostic.S2372.severity = warning
+
+# Title    : Write-only properties should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2376
+dotnet_diagnostic.S2376.severity = warning
+
+# Title    : Mutable fields should not be "public static"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2386
+dotnet_diagnostic.S2386.severity = warning
+
+# Title    : Child class fields should not shadow parent class fields
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2387
+dotnet_diagnostic.S2387.severity = warning
+
+# Title    : Types and methods should not have too many generic parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2436
+# Redundant: CA1005
+dotnet_diagnostic.S2436.severity = none
+
+# Title    : Silly bit operations should not be performed
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2437
+dotnet_diagnostic.S2437.severity = warning
+
+# Title    : Whitespace and control characters in string literals should be explicit
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2479
+dotnet_diagnostic.S2479.severity = warning
+
+# Title    : Generic exceptions should not be ignored
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2486
+dotnet_diagnostic.S2486.severity = warning
+
+# Title    : Shared resources should not be used for locking
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2551
+dotnet_diagnostic.S2551.severity = warning
+
+# Title    : Conditionally executed code should be reachable
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2583
+# Redundant: CA1508
+dotnet_diagnostic.S2583.severity = none
+
+# Title    : Boolean expressions should not be gratuitous
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2589
+dotnet_diagnostic.S2589.severity = warning
+
+# Title    : Setting loose file permissions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2612
+dotnet_diagnostic.S2612.severity = warning
+
+# Title    : The length returned from a stream read should be checked
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2674
+dotnet_diagnostic.S2674.severity = warning
+
+# Title    : Multiline blocks should be enclosed in curly braces
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2681
+dotnet_diagnostic.S2681.severity = warning
+
+# Title    : "NaN" should not be used in comparisons
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2688
+dotnet_diagnostic.S2688.severity = warning
+
+# Title    : "IndexOf" checks should not be for positive numbers
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2692
+dotnet_diagnostic.S2692.severity = warning
+
+# Title    : Instance members should not write to "static" fields
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2696
+dotnet_diagnostic.S2696.severity = warning
+
+# Title    : Tests should include assertions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2699
+dotnet_diagnostic.S2699.severity = warning
+
+# Title    : Literal boolean values should not be used in assertions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2701
+dotnet_diagnostic.S2701.severity = warning
+
+# Title    : "catch" clauses should do more than rethrow
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2737
+dotnet_diagnostic.S2737.severity = warning
+
+# Title    : Static fields should not be used in generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2743
+dotnet_diagnostic.S2743.severity = none
+
+# Title    : XML parsers should not be vulnerable to XXE attacks
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2755
+dotnet_diagnostic.S2755.severity = warning
+
+# Title    : "=+" should not be used instead of "+="
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2757
+dotnet_diagnostic.S2757.severity = warning
+
+# Title    : The ternary operator should not return the same value regardless of the condition
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2758
+dotnet_diagnostic.S2758.severity = warning
+
+# Title    : Sequential tests should not check the same condition
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2760
+dotnet_diagnostic.S2760.severity = warning
+
+# Title    : Doubled prefix operators "!!" and "~~" should not be used
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2761
+dotnet_diagnostic.S2761.severity = warning
+
+# Title    : SQL keywords should be delimited by whitespace
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2857
+dotnet_diagnostic.S2857.severity = warning
+
+# Title    : "IDisposables" should be disposed
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2930
+# Redundant: CA2000
+dotnet_diagnostic.S2930.severity = none
+
+# Title    : Classes with "IDisposable" members should implement "IDisposable"
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2931
+# Redundant: CA1001
+dotnet_diagnostic.S2931.severity = none
+
+# Title    : Fields that are only assigned in the constructor should be "readonly"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2933
+# Redundant: IDE0044
+dotnet_diagnostic.S2933.severity = none
+
+# Title    : Property assignments should not be made for "readonly" fields not constrained to reference types
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2934
+dotnet_diagnostic.S2934.severity = warning
+
+# Title    : Classes should "Dispose" of members from the classes' own "Dispose" methods
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2952
+dotnet_diagnostic.S2952.severity = warning
+
+# Title    : Methods named "Dispose" should implement "IDisposable.Dispose"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2953
+dotnet_diagnostic.S2953.severity = warning
+
+# Title    : Generic parameters not constrained to reference types should not be compared to "null"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2955
+dotnet_diagnostic.S2955.severity = warning
+
+# Title    : "IEnumerable" LINQs should be simplified
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2971
+dotnet_diagnostic.S2971.severity = warning
+
+# Title    : "Object.ReferenceEquals" should not be used for value types
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2995
+dotnet_diagnostic.S2995.severity = warning
+
+# Title    : "ThreadStatic" fields should not be initialized
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2996
+dotnet_diagnostic.S2996.severity = warning
+
+# Title    : "IDisposables" created in a "using" statement should not be returned
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-2997
+dotnet_diagnostic.S2997.severity = warning
+
+# Title    : "ThreadStatic" should not be used on non-static fields
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3005
+dotnet_diagnostic.S3005.severity = warning
+
+# Title    : Static fields should not be updated in constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3010
+dotnet_diagnostic.S3010.severity = warning
+
+# Title    : Reflection should not be used to increase accessibility of classes, methods, or fields
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3011
+dotnet_diagnostic.S3011.severity = warning
+
+# Title    : Members should not be initialized to default values
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3052
+# Redundant: CA1805
+dotnet_diagnostic.S3052.severity = none
+
+# Title    : Types should not have members with visibility set higher than the type's visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3059
+dotnet_diagnostic.S3059.severity = none
+
+# Title    : "is" should not be used with "this"
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3060
+dotnet_diagnostic.S3060.severity = warning
+
+# Title    : "async" methods should not return "void"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3168
+# Redundant: VSTHRD100
+dotnet_diagnostic.S3168.severity = none
+
+# Title    : Multiple "OrderBy" calls should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3169
+dotnet_diagnostic.S3169.severity = warning
+
+# Title    : Delegates should not be subtracted
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3172
+dotnet_diagnostic.S3172.severity = warning
+
+# Title    : "interface" instances should not be cast to concrete types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3215
+dotnet_diagnostic.S3215.severity = warning
+
+# Title    : "ConfigureAwait(false)" should be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3216
+# Redundant: CA2007
+dotnet_diagnostic.S3216.severity = none
+
+# Title    : "Explicit" conversions of "foreach" loops should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3217
+dotnet_diagnostic.S3217.severity = warning
+
+# Title    : Inner class members should not shadow outer class "static" or type members
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3218
+dotnet_diagnostic.S3218.severity = warning
+
+# Title    : Method calls should not resolve ambiguously to overloads with "params"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3220
+dotnet_diagnostic.S3220.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be invoked for types without destructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3234
+dotnet_diagnostic.S3234.severity = warning
+
+# Title    : Redundant parentheses should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3235
+dotnet_diagnostic.S3235.severity = warning
+
+# Title    : Caller information arguments should not be provided explicitly
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3236
+dotnet_diagnostic.S3236.severity = warning
+
+# Title    : "value" parameters should be used
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3237
+dotnet_diagnostic.S3237.severity = warning
+
+# Title    : The simplest possible condition syntax should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3240
+# Redundant: IDE0054
+dotnet_diagnostic.S3240.severity = none
+
+# Title    : Methods should not return values that are never used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3241
+dotnet_diagnostic.S3241.severity = warning
+
+# Title    : Method parameters should be declared with base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3242
+# Comment  : We want to encourage concrete types instead of interface types when possible as it's considerably faster.
+dotnet_diagnostic.S3242.severity = none
+
+# Title    : Anonymous delegates should not be used to unsubscribe from Events
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3244
+dotnet_diagnostic.S3244.severity = warning
+
+# Title    : Generic type parameters should be co/contravariant when possible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3246
+dotnet_diagnostic.S3246.severity = warning
+
+# Title    : Duplicate casts should not be made
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3247
+dotnet_diagnostic.S3247.severity = warning
+
+# Title    : Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3249
+dotnet_diagnostic.S3249.severity = warning
+
+# Title    : Implementations should be provided for "partial" methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3251
+dotnet_diagnostic.S3251.severity = warning
+
+# Title    : Constructor and destructor declarations should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3253
+dotnet_diagnostic.S3253.severity = warning
+
+# Title    : Default parameter values should not be passed as arguments
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3254
+dotnet_diagnostic.S3254.severity = warning
+
+# Title    : "string.IsNullOrEmpty" should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3256
+dotnet_diagnostic.S3256.severity = warning
+
+# Title    : Declarations and initializations should be as concise as possible
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3257
+dotnet_diagnostic.S3257.severity = warning
+
+# Title    : Non-derived "private" classes and records should be "sealed"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3260
+# Redundant: R9A013
+dotnet_diagnostic.S3260.severity = none
+
+# Title    : Namespaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3261
+dotnet_diagnostic.S3261.severity = warning
+
+# Title    : "params" should be used on overrides
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3262
+dotnet_diagnostic.S3262.severity = warning
+
+# Title    : Static fields should appear in the order they must be initialized 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3263
+dotnet_diagnostic.S3263.severity = warning
+
+# Title    : Events should be invoked
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3264
+dotnet_diagnostic.S3264.severity = warning
+
+# Title    : Non-flags enums should not be used in bitwise operations
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3265
+dotnet_diagnostic.S3265.severity = warning
+
+# Title    : Loops should be simplified with "LINQ" expressions
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3267
+dotnet_diagnostic.S3267.severity = none
+
+# Title    : Cipher Block Chaining IVs should be unpredictable
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3329
+# Comment  : Analysis is too slow
+dotnet_diagnostic.S3329.severity = none
+
+# Title    : Creating cookies without the "HttpOnly" flag is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3330
+dotnet_diagnostic.S3330.severity = warning
+
+# Title    : Caller information parameters should come at the end of the parameter list
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3343
+dotnet_diagnostic.S3343.severity = warning
+
+# Title    : Expressions used in "Debug.Assert" should not produce side effects
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3346
+dotnet_diagnostic.S3346.severity = warning
+
+# Title    : Unchanged local variables should be "const"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3353
+dotnet_diagnostic.S3353.severity = warning
+
+# Title    : Ternary operators should not be nested
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3358
+dotnet_diagnostic.S3358.severity = warning
+
+# Title    : "this" should not be exposed from constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3366
+dotnet_diagnostic.S3366.severity = warning
+
+# Title    : Attribute, EventArgs, and Exception type names should end with the type being extended
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3376
+# Redundant: CA1710
+dotnet_diagnostic.S3376.severity = none
+
+# Title    : "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3397
+dotnet_diagnostic.S3397.severity = warning
+
+# Title    : Methods should not return constants
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3400
+dotnet_diagnostic.S3400.severity = warning
+
+# Title    : Assertion arguments should be passed in the correct order
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3415
+dotnet_diagnostic.S3415.severity = warning
+
+# Title    : Method overloads with default parameter values should not overlap 
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3427
+dotnet_diagnostic.S3427.severity = warning
+
+# Title    : "[ExpectedException]" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3431
+dotnet_diagnostic.S3431.severity = warning
+
+# Title    : Test method signatures should be correct
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3433
+dotnet_diagnostic.S3433.severity = warning
+
+# Title    : Variables should not be checked against the values they're about to be assigned
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3440
+dotnet_diagnostic.S3440.severity = warning
+
+# Title    : Redundant property names should be omitted in anonymous classes
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3441
+dotnet_diagnostic.S3441.severity = warning
+
+# Title    : "abstract" classes should not have "public" constructors
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3442
+dotnet_diagnostic.S3442.severity = warning
+
+# Title    : Type should not be examined on "System.Type" instances
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3443
+dotnet_diagnostic.S3443.severity = warning
+
+# Title    : Interfaces should not simply inherit from base interfaces with colliding members
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3444
+dotnet_diagnostic.S3444.severity = warning
+
+# Title    : Exceptions should not be explicitly rethrown
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3445
+dotnet_diagnostic.S3445.severity = warning
+
+# Title    : "[Optional]" should not be used on "ref" or "out" parameters
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3447
+dotnet_diagnostic.S3447.severity = warning
+
+# Title    : Right operands of shift operators should be integers
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3449
+dotnet_diagnostic.S3449.severity = warning
+
+# Title    : Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3450
+dotnet_diagnostic.S3450.severity = warning
+
+# Title    : "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3451
+dotnet_diagnostic.S3451.severity = warning
+
+# Title    : Classes should not have only "private" constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3453
+dotnet_diagnostic.S3453.severity = warning
+
+# Title    : "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3456
+dotnet_diagnostic.S3456.severity = warning
+
+# Title    : Composite format strings should be used correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3457
+dotnet_diagnostic.S3457.severity = warning
+
+# Title    : Empty "case" clauses that fall through to the "default" should be omitted
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3458
+dotnet_diagnostic.S3458.severity = warning
+
+# Title    : Unassigned members should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3459
+dotnet_diagnostic.S3459.severity = warning
+
+# Title    : Type inheritance should not be recursive
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3464
+dotnet_diagnostic.S3464.severity = warning
+
+# Title    : Optional parameters should be passed to "base" calls
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3466
+dotnet_diagnostic.S3466.severity = warning
+
+# Title    : Empty "default" clauses should be removed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3532
+dotnet_diagnostic.S3532.severity = warning
+
+# Title    : "ServiceContract" and "OperationContract" attributes should be used together
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3597
+dotnet_diagnostic.S3597.severity = warning
+
+# Title    : One-way "OperationContract" methods should have "void" return type
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3598
+dotnet_diagnostic.S3598.severity = warning
+
+# Title    : "params" should not be introduced on overrides
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3600
+dotnet_diagnostic.S3600.severity = warning
+
+# Title    : Methods with "Pure" attribute should return a value 
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3603
+dotnet_diagnostic.S3603.severity = warning
+
+# Title    : Member initializer values should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3604
+dotnet_diagnostic.S3604.severity = warning
+
+# Title    : Nullable type comparison should not be redundant
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3610
+dotnet_diagnostic.S3610.severity = warning
+
+# Title    : Jump statements should not be redundant
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3626
+dotnet_diagnostic.S3626.severity = warning
+
+# Title    : Empty nullable value should not be accessed
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3655
+dotnet_diagnostic.S3655.severity = warning
+
+# Title    : Exception constructors should not throw exceptions
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3693
+dotnet_diagnostic.S3693.severity = warning
+
+# Title    : Track use of "NotImplementedException"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3717
+dotnet_diagnostic.S3717.severity = warning
+
+# Title    : Cognitive Complexity of methods should not be too high
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3776
+# Comment  : Code gets complicated
+dotnet_diagnostic.S3776.severity = none
+
+# Title    : "SafeHandle.DangerousGetHandle" should not be called
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3869
+dotnet_diagnostic.S3869.severity = warning
+
+# Title    : Exception types should be "public"
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3871
+# Redundant: CA1064
+dotnet_diagnostic.S3871.severity = none
+
+# Title    : Parameter names should not duplicate the names of their methods
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3872
+dotnet_diagnostic.S3872.severity = warning
+
+# Title    : "out" and "ref" parameters should not be used
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3874
+# Redundant: CA1021
+dotnet_diagnostic.S3874.severity = none
+
+# Title    : "operator==" should not be overloaded on reference types
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3875
+dotnet_diagnostic.S3875.severity = warning
+
+# Title    : Strings or integral types should be used for indexers
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3876
+dotnet_diagnostic.S3876.severity = warning
+
+# Title    : Exceptions should not be thrown from unexpected methods
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3877
+dotnet_diagnostic.S3877.severity = warning
+
+# Title    : Finalizers should not be empty
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3880
+dotnet_diagnostic.S3880.severity = warning
+
+# Title    : "IDisposable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3881
+dotnet_diagnostic.S3881.severity = none
+
+# Title    : "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
+# Category : Blocker Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3884
+dotnet_diagnostic.S3884.severity = warning
+
+# Title    : "Assembly.Load" should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3885
+dotnet_diagnostic.S3885.severity = warning
+
+# Title    : Mutable, non-private fields should not be "readonly"
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3887
+dotnet_diagnostic.S3887.severity = warning
+
+# Title    : Neither "Thread.Resume" nor "Thread.Suspend" should be used
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3889
+dotnet_diagnostic.S3889.severity = warning
+
+# Title    : Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3897
+dotnet_diagnostic.S3897.severity = warning
+
+# Title    : Value types should implement "IEquatable<T>"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3898
+dotnet_diagnostic.S3898.severity = none
+
+# Title    : Arguments of public methods should be validated against null
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3900
+# Redundant: CA1062
+dotnet_diagnostic.S3900.severity = none
+
+# Title    : "Assembly.GetExecutingAssembly" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3902
+dotnet_diagnostic.S3902.severity = warning
+
+# Title    : Types should be defined in named namespaces
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3903
+# Comment  : Doesn't work with file-scoped namespaces, so disabling for now.
+dotnet_diagnostic.S3903.severity = none
+
+# Title    : Assemblies should have version information
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3904
+dotnet_diagnostic.S3904.severity = warning
+
+# Title    : Event Handlers should have the correct signature
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3906
+dotnet_diagnostic.S3906.severity = warning
+
+# Title    : Generic event handlers should be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3908
+dotnet_diagnostic.S3908.severity = warning
+
+# Title    : Collections should implement the generic interface
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3909
+# Redundant: CA1010
+dotnet_diagnostic.S3909.severity = none
+
+# Title    : All branches in a conditional structure should not have exactly the same implementation
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3923
+dotnet_diagnostic.S3923.severity = warning
+
+# Title    : "ISerializable" should be implemented correctly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3925
+# Comment  : TODO - is ISerializable still relevant?
+dotnet_diagnostic.S3925.severity = none
+
+# Title    : Deserialization methods should be provided for "OptionalField" members
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3926
+dotnet_diagnostic.S3926.severity = warning
+
+# Title    : Serialization event handlers should be implemented correctly
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3927
+dotnet_diagnostic.S3927.severity = warning
+
+# Title    : Parameter names used into ArgumentException constructors should match an existing one 
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3928
+dotnet_diagnostic.S3928.severity = warning
+
+# Title    : Number patterns should be regular
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3937
+dotnet_diagnostic.S3937.severity = warning
+
+# Title    : Calculations should not overflow
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3949
+dotnet_diagnostic.S3949.severity = suggestion
+
+# Title    : "Generic.List" instances should not be part of public APIs
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3956
+# Redundant: CA1002
+dotnet_diagnostic.S3956.severity = none
+
+# Title    : "static readonly" constants should be "const" instead
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3962
+# Redundant: CA1802
+dotnet_diagnostic.S3962.severity = none
+
+# Title    : "static" fields should be initialized inline
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3963
+# Redundant: CA1810 and CA2207
+dotnet_diagnostic.S3963.severity = none
+
+# Title    : Objects should not be disposed more than once
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3966
+dotnet_diagnostic.S3966.severity = warning
+
+# Title    : Multidimensional arrays should not be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3967
+dotnet_diagnostic.S3967.severity = warning
+
+# Title    : "GC.SuppressFinalize" should not be called
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3971
+dotnet_diagnostic.S3971.severity = warning
+
+# Title    : Conditionals should start on new lines
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3972
+dotnet_diagnostic.S3972.severity = warning
+
+# Title    : A conditionally executed single line should be denoted by indentation
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3973
+dotnet_diagnostic.S3973.severity = warning
+
+# Title    : Collection sizes and array length comparisons should make sense
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3981
+dotnet_diagnostic.S3981.severity = warning
+
+# Title    : Exceptions should not be created without being thrown
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3984
+dotnet_diagnostic.S3984.severity = warning
+
+# Title    : Assemblies should be marked as CLS compliant
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3990
+# Redundant: CA1014
+dotnet_diagnostic.S3990.severity = none
+
+# Title    : Assemblies should explicitly specify COM visibility
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3992
+# Redundant: CA1017
+dotnet_diagnostic.S3992.severity = none
+
+# Title    : Custom attributes should be marked with "System.AttributeUsageAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3993
+# Redundant: CA1018
+dotnet_diagnostic.S3993.severity = none
+
+# Title    : URI Parameters should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3994
+dotnet_diagnostic.S3994.severity = none
+
+# Title    : URI return values should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3995
+dotnet_diagnostic.S3995.severity = warning
+
+# Title    : URI properties should not be strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3996
+dotnet_diagnostic.S3996.severity = warning
+
+# Title    : String URI overloads should call "System.Uri" overloads
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3997
+dotnet_diagnostic.S3997.severity = warning
+
+# Title    : Threads should not lock on objects with weak identity
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-3998
+dotnet_diagnostic.S3998.severity = warning
+
+# Title    : Pointers to unmanaged memory should not be visible
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4000
+dotnet_diagnostic.S4000.severity = warning
+
+# Title    : Disposable types should declare finalizers
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4002
+dotnet_diagnostic.S4002.severity = warning
+
+# Title    : Collection properties should be readonly
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4004
+# Redundant: CA2227
+dotnet_diagnostic.S4004.severity = none
+
+# Title    : "System.Uri" arguments should be used instead of strings
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4005
+# Redundant: CA2234
+dotnet_diagnostic.S4005.severity = none
+
+# Title    : Inherited member visibility should not be decreased
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4015
+dotnet_diagnostic.S4015.severity = warning
+
+# Title    : Enumeration members should not be named "Reserved"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4016
+dotnet_diagnostic.S4016.severity = warning
+
+# Title    : Method signatures should not contain nested generic types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4017
+dotnet_diagnostic.S4017.severity = none
+
+# Title    : All type parameters should be used in the parameter list to enable type inference
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4018
+dotnet_diagnostic.S4018.severity = none
+
+# Title    : Base class methods should not be hidden
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4019
+dotnet_diagnostic.S4019.severity = warning
+
+# Title    : Enumerations should have "Int32" storage
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4022
+dotnet_diagnostic.S4022.severity = warning
+
+# Title    : Interfaces should not be empty
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4023
+dotnet_diagnostic.S4023.severity = warning
+
+# Title    : Child class fields should not differ from parent class fields only by capitalization
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4025
+dotnet_diagnostic.S4025.severity = warning
+
+# Title    : Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4026
+dotnet_diagnostic.S4026.severity = warning
+
+# Title    : Exceptions should provide standard constructors
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4027
+# Redundant: CA1032
+dotnet_diagnostic.S4027.severity = none
+
+# Title    : Classes implementing "IEquatable<T>" should be sealed
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4035
+dotnet_diagnostic.S4035.severity = warning
+
+# Title    : Searching OS commands in PATH is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4036
+dotnet_diagnostic.S4036.severity = warning
+
+# Title    : Interface methods should be callable by derived types
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4039
+dotnet_diagnostic.S4039.severity = warning
+
+# Title    : Strings should be normalized to uppercase
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4040
+# Redundant: CA1308
+dotnet_diagnostic.S4040.severity = none
+
+# Title    : Type names should not match namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4041
+dotnet_diagnostic.S4041.severity = warning
+
+# Title    : Generics should be used when appropriate
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4047
+dotnet_diagnostic.S4047.severity = warning
+
+# Title    : Properties should be preferred
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4049
+# Redundant: CA1024
+dotnet_diagnostic.S4049.severity = none
+
+# Title    : Operators should be overloaded consistently
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4050
+dotnet_diagnostic.S4050.severity = warning
+
+# Title    : Types should not extend outdated base types
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4052
+dotnet_diagnostic.S4052.severity = warning
+
+# Title    : Literals should not be passed as localized parameters
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4055
+dotnet_diagnostic.S4055.severity = none
+
+# Title    : Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4056
+# Redundant: CA1305
+dotnet_diagnostic.S4056.severity = none
+
+# Title    : Locales should be set for data types
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4057
+dotnet_diagnostic.S4057.severity = warning
+
+# Title    : Overloads with a "StringComparison" parameter should be used
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4058
+# Redundant: CA1310
+dotnet_diagnostic.S4058.severity = none
+
+# Title    : Property names should not match get methods
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4059
+dotnet_diagnostic.S4059.severity = warning
+
+# Title    : Non-abstract attributes should be sealed
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4060
+# Redundant: CA1813
+dotnet_diagnostic.S4060.severity = none
+
+# Title    : "params" should be used instead of "varargs"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4061
+dotnet_diagnostic.S4061.severity = warning
+
+# Title    : Operator overloads should have named alternatives
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4069
+# Redundant: CA2225
+dotnet_diagnostic.S4069.severity = none
+
+# Title    : Non-flags enums should not be marked with "FlagsAttribute"
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4070
+# Redundant: CA2217
+dotnet_diagnostic.S4070.severity = none
+
+# Title    : Method overloads should be grouped together
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4136
+dotnet_diagnostic.S4136.severity = warning
+
+# Title    : Duplicate values should not be passed as arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4142
+dotnet_diagnostic.S4142.severity = warning
+
+# Title    : Collection elements should not be replaced unconditionally
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4143
+dotnet_diagnostic.S4143.severity = warning
+
+# Title    : Methods should not have identical implementations
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4144
+dotnet_diagnostic.S4144.severity = warning
+
+# Title    : Empty collections should not be accessed or iterated
+# Category : Minor Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4158
+dotnet_diagnostic.S4158.severity = warning
+
+# Title    : Classes should implement their "ExportAttribute" interfaces
+# Category : Blocker Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4159
+dotnet_diagnostic.S4159.severity = warning
+
+# Title    : Native methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4200
+dotnet_diagnostic.S4200.severity = warning
+
+# Title    : Null checks should not be used with "is"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4201
+dotnet_diagnostic.S4201.severity = warning
+
+# Title    : Windows Forms entry points should be marked with STAThread
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4210
+dotnet_diagnostic.S4210.severity = warning
+
+# Title    : Members should not have conflicting transparency annotations
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4211
+dotnet_diagnostic.S4211.severity = warning
+
+# Title    : Serialization constructors should be secured
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4212
+dotnet_diagnostic.S4212.severity = warning
+
+# Title    : "P/Invoke" methods should not be visible
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4214
+dotnet_diagnostic.S4214.severity = warning
+
+# Title    : Events should have proper arguments
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4220
+dotnet_diagnostic.S4220.severity = warning
+
+# Title    : Extension methods should not extend "object"
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4225
+dotnet_diagnostic.S4225.severity = warning
+
+# Title    : Extensions should be in separate namespaces
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4226
+dotnet_diagnostic.S4226.severity = none
+
+# Title    : "ConstructorArgument" parameters should exist in constructors
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4260
+dotnet_diagnostic.S4260.severity = warning
+
+# Title    : Methods should be named according to their synchronicities
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4261
+dotnet_diagnostic.S4261.severity = none
+
+# Title    : Getters and setters should access the expected fields
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4275
+dotnet_diagnostic.S4275.severity = warning
+
+# Title    : "Shared" parts should not be created with "new"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4277
+dotnet_diagnostic.S4277.severity = warning
+
+# Title    : Weak SSL/TLS protocols should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4423
+dotnet_diagnostic.S4423.severity = warning
+
+# Title    : Cryptographic keys should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4426
+dotnet_diagnostic.S4426.severity = warning
+
+# Title    : "PartCreationPolicyAttribute" should be used with "ExportAttribute"
+# Category : Major Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4428
+dotnet_diagnostic.S4428.severity = warning
+
+# Title    : AES encryption algorithm should be used with secured mode
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4432
+dotnet_diagnostic.S4432.severity = warning
+
+# Title    : LDAP connections should be authenticated
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4433
+dotnet_diagnostic.S4433.severity = warning
+
+# Title    : Parameter validation in yielding methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4456
+dotnet_diagnostic.S4456.severity = warning
+
+# Title    : Parameter validation in "async"/"await" methods should be wrapped
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4457
+dotnet_diagnostic.S4457.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4462
+# Redundant: VSTHRD002
+dotnet_diagnostic.S4462.severity = none
+
+# Title    : Unread "private" fields should be removed
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4487
+# Redundant: IDE0052
+dotnet_diagnostic.S4487.severity = none
+
+# Title    : Disabling CSRF protections is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4502
+dotnet_diagnostic.S4502.severity = warning
+
+# Title    : Delivering code in production with debug features activated is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4507
+dotnet_diagnostic.S4507.severity = warning
+
+# Title    : "default" clauses should be first or last
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4524
+dotnet_diagnostic.S4524.severity = warning
+
+# Title    : ASP.NET HTTP request validation feature should not be disabled
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4564
+dotnet_diagnostic.S4564.severity = warning
+
+# Title    : "new Guid()" should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4581
+dotnet_diagnostic.S4581.severity = warning
+
+# Title    : Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4583
+dotnet_diagnostic.S4583.severity = warning
+
+# Title    : Non-async "Task/Task<T>" methods should not return null
+# Category : Critical Bug
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4586
+dotnet_diagnostic.S4586.severity = warning
+
+# Title    : String offset-based methods should be preferred for finding substrings from offsets
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4635
+dotnet_diagnostic.S4635.severity = warning
+
+# Title    : Using regular expressions is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4784
+dotnet_diagnostic.S4784.severity = warning
+
+# Title    : Encrypting data is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4787
+dotnet_diagnostic.S4787.severity = warning
+
+# Title    : Using weak hashing algorithms is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4790
+dotnet_diagnostic.S4790.severity = warning
+
+# Title    : Configuring loggers is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4792
+dotnet_diagnostic.S4792.severity = warning
+
+# Title    : Using Sockets is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4818
+dotnet_diagnostic.S4818.severity = warning
+
+# Title    : Using command line arguments is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4823
+dotnet_diagnostic.S4823.severity = warning
+
+# Title    : Reading the Standard Input is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4829
+dotnet_diagnostic.S4829.severity = warning
+
+# Title    : Server certificates should be verified during SSL/TLS connections
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4830
+# Redundant: CA5359
+dotnet_diagnostic.S4830.severity = none
+
+# Title    : Controlling permissions is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-4834
+dotnet_diagnostic.S4834.severity = warning
+
+# Title    : "ValueTask" should be consumed correctly
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5034
+dotnet_diagnostic.S5034.severity = warning
+
+# Title    : Expanding archive files without controlling resource consumption is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5042
+dotnet_diagnostic.S5042.severity = warning
+
+# Title    : Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Category : Minor Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5122
+dotnet_diagnostic.S5122.severity = warning
+
+# Title    : Using clear-text protocols is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5332
+dotnet_diagnostic.S5332.severity = warning
+
+# Title    : Using publicly writable directories is security-sensitive
+# Category : Critical Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5443
+dotnet_diagnostic.S5443.severity = warning
+
+# Title    : Insecure temporary file creation methods should not be used
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5445
+dotnet_diagnostic.S5445.severity = warning
+
+# Title    : Encryption algorithms should be used with secure mode and padding scheme
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5542
+dotnet_diagnostic.S5542.severity = warning
+
+# Title    : Cipher algorithms should be robust
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5547
+dotnet_diagnostic.S5547.severity = warning
+
+# Title    : JWT should be signed and verified with strong cipher algorithms
+# Category : Critical Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5659
+dotnet_diagnostic.S5659.severity = warning
+
+# Title    : Allowing requests with excessive content length is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5693
+dotnet_diagnostic.S5693.severity = warning
+
+# Title    : Disabling ASP.NET "Request Validation" feature is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5753
+dotnet_diagnostic.S5753.severity = warning
+
+# Title    : Deserializing objects without performing data validation is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5766
+dotnet_diagnostic.S5766.severity = warning
+
+# Title    : Types allowed to be deserialized should be restricted
+# Category : Major Vulnerability
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-5773
+dotnet_diagnostic.S5773.severity = warning
+
+# Title    : Use a testable date/time provider
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6354
+# Redundant: R9A022
+dotnet_diagnostic.S6354.severity = none
+
+# Title    : Azure Functions should be stateless
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6419
+dotnet_diagnostic.S6419.severity = warning
+
+# Title    : Client instances should not be recreated on each Azure Function invocation
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6420
+dotnet_diagnostic.S6420.severity = warning
+
+# Title    : Azure Functions should use Structured Error Handling
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6421
+dotnet_diagnostic.S6421.severity = warning
+
+# Title    : Calls to "async" methods should not be blocking in Azure Functions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6422
+dotnet_diagnostic.S6422.severity = warning
+
+# Title    : Azure Functions should log all failures
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6423
+dotnet_diagnostic.S6423.severity = warning
+
+# Title    : Interfaces for durable entities should satisfy the restrictions
+# Category : Blocker Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6424
+dotnet_diagnostic.S6424.severity = warning
+
+# Title    : Not specifying a timeout for regular expressions is security-sensitive
+# Category : Major Security Hotspot
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-6444
+dotnet_diagnostic.S6444.severity = warning
+
+# Title    : Literal suffixes should be upper case
+# Category : Minor Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-818
+dotnet_diagnostic.S818.severity = warning
+
+# Title    : Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-881
+dotnet_diagnostic.S881.severity = suggestion
+
+# Title    : "goto" statement should not be used
+# Category : Major Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-907
+dotnet_diagnostic.S907.severity = warning
+
+# Title    : Parameter names should match base declaration and other partial definitions
+# Category : Critical Code Smell
+# Help Link: https://rules.sonarsource.com/csharp/RSPEC-927
+# Redundant: CA1725
+dotnet_diagnostic.S927.severity = none
+
+# Title    : Copy-paste token calculator
+# Category : 
+dotnet_diagnostic.S9999-cpd.severity = warning
+
+# Title    : Log generator
+# Category : 
+dotnet_diagnostic.S9999-log.severity = none
+
+# Title    : File metadata generator
+# Category : 
+dotnet_diagnostic.S9999-metadata.severity = warning
+
+# Title    : Metrics calculator
+# Category : 
+dotnet_diagnostic.S9999-metrics.severity = warning
+
+# Title    : Symbol reference calculator
+# Category : 
+dotnet_diagnostic.S9999-symbolRef.severity = warning
+
+# Title    : Token type calculator
+# Category : 
+dotnet_diagnostic.S9999-token-type.severity = warning
+
+# Title    : XML comment analysis disabled
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+dotnet_diagnostic.SA0001.severity = none
+
+# Title    : Invalid settings file
+# Category : StyleCop.CSharp.SpecialRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+dotnet_diagnostic.SA0002.severity = warning
+
+# Title    : Keywords should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1000.severity = none
+
+# Title    : Commas should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1001.severity = none
+
+# Title    : Semicolons should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1002.severity = none
+
+# Title    : Symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1003.severity = none
+
+# Title    : Documentation lines should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+dotnet_diagnostic.SA1004.severity = warning
+
+# Title    : Single line comments should begin with single space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+dotnet_diagnostic.SA1005.severity = warning
+
+# Title    : Preprocessor keywords should not be preceded by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+dotnet_diagnostic.SA1006.severity = warning
+
+# Title    : Operator keyword should be followed by space
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1007.severity = none
+
+# Title    : Opening parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1008.severity = none
+
+# Title    : Closing parenthesis should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1009.severity = none
+
+# Title    : Opening square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1010.severity = none
+
+# Title    : Closing square brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1011.severity = none
+
+# Title    : Opening braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1012.severity = none
+
+# Title    : Closing braces should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1013.severity = none
+
+# Title    : Opening generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1014.severity = none
+
+# Title    : Closing generic brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1015.severity = none
+
+# Title    : Opening attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1016.severity = none
+
+# Title    : Closing attribute brackets should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1017.severity = none
+
+# Title    : Nullable type symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1018.severity = none
+
+# Title    : Member access symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1019.severity = none
+
+# Title    : Increment decrement symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1020.severity = none
+
+# Title    : Negative signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1021.severity = none
+
+# Title    : Positive signs should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1022.severity = none
+
+# Title    : Dereference and access of symbols should be spaced correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1023.severity = none
+
+# Title    : Colons Should Be Spaced Correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1024.severity = none
+
+# Title    : Code should not contain multiple whitespace in a row
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1025.severity = none
+
+# Title    : Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1026.severity = none
+
+# Title    : Use tabs correctly
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+dotnet_diagnostic.SA1027.severity = warning
+
+# Title    : Code should not contain trailing whitespace
+# Category : StyleCop.CSharp.SpacingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1028.severity = none
+
+# Title    : Do not prefix calls with base unless local implementation exists
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+dotnet_diagnostic.SA1100.severity = warning
+
+# Title    : Prefix local calls with this
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+dotnet_diagnostic.SA1101.severity = none
+
+# Title    : Query clause should follow previous clause
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+dotnet_diagnostic.SA1102.severity = warning
+
+# Title    : Query clauses should be on separate lines or all on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+dotnet_diagnostic.SA1103.severity = warning
+
+# Title    : Query clause should begin on new line when previous clause spans multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+dotnet_diagnostic.SA1104.severity = warning
+
+# Title    : Query clauses spanning multiple lines should begin on own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+dotnet_diagnostic.SA1105.severity = warning
+
+# Title    : Code should not contain empty statements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+dotnet_diagnostic.SA1106.severity = warning
+
+# Title    : Code should not contain multiple statements on one line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# Redundant: IDE2001
+dotnet_diagnostic.SA1107.severity = none
+
+# Title    : Block statements should not contain embedded comments
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+dotnet_diagnostic.SA1108.severity = warning
+
+# Title    : Block statements should not contain embedded regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+dotnet_diagnostic.SA1109.severity = warning
+
+# Title    : Opening parenthesis or bracket should be on declaration line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+dotnet_diagnostic.SA1110.severity = warning
+
+# Title    : Closing parenthesis should be on line of last parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+dotnet_diagnostic.SA1111.severity = warning
+
+# Title    : Closing parenthesis should be on line of opening parenthesis
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+dotnet_diagnostic.SA1112.severity = warning
+
+# Title    : Comma should be on the same line as previous parameter
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+dotnet_diagnostic.SA1113.severity = warning
+
+# Title    : Parameter list should follow declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+dotnet_diagnostic.SA1114.severity = warning
+
+# Title    : Parameter should follow comma
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+dotnet_diagnostic.SA1115.severity = none
+
+# Title    : Split parameters should start on line after declaration
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+dotnet_diagnostic.SA1116.severity = none
+
+# Title    : Parameters should be on same line or separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+dotnet_diagnostic.SA1117.severity = none
+
+# Title    : Parameter should not span multiple lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+dotnet_diagnostic.SA1118.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119.severity = warning
+
+# Title    : Statement should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+dotnet_diagnostic.SA1119_p.severity = none
+
+# Title    : Comments should contain text
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+dotnet_diagnostic.SA1120.severity = warning
+
+# Title    : Use built-in type alias
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+dotnet_diagnostic.SA1121.severity = warning
+
+# Title    : Use string.Empty for empty strings
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+dotnet_diagnostic.SA1122.severity = warning
+
+# Title    : Do not place regions within elements
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+dotnet_diagnostic.SA1123.severity = warning
+
+# Title    : Do not use regions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+dotnet_diagnostic.SA1124.severity = none
+
+# Title    : Use shorthand for nullable types
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+dotnet_diagnostic.SA1125.severity = warning
+
+# Title    : Prefix calls correctly
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+dotnet_diagnostic.SA1126.severity = none
+
+# Title    : Generic type constraints should be on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+dotnet_diagnostic.SA1127.severity = warning
+
+# Title    : Put constructor initializers on their own line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+dotnet_diagnostic.SA1128.severity = warning
+
+# Title    : Do not use default value type constructor
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+dotnet_diagnostic.SA1129.severity = warning
+
+# Title    : Use lambda syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+dotnet_diagnostic.SA1130.severity = warning
+
+# Title    : Use readable conditions
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+dotnet_diagnostic.SA1131.severity = warning
+
+# Title    : Do not combine fields
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# Comment  : S1169 handles fields and variables
+# Redundant: S1169
+dotnet_diagnostic.SA1132.severity = none
+
+# Title    : Do not combine attributes
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+dotnet_diagnostic.SA1133.severity = warning
+
+# Title    : Attributes should not share line
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# Redundant: IDE0055
+dotnet_diagnostic.SA1134.severity = none
+
+# Title    : Using directives should be qualified
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+dotnet_diagnostic.SA1135.severity = warning
+
+# Title    : Enum values should be on separate lines
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+dotnet_diagnostic.SA1136.severity = warning
+
+# Title    : Elements should have the same indentation
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Comment  : Doesn't work with file-scoped namespaces
+dotnet_diagnostic.SA1137.severity = none
+
+# Title    : Use literal suffix notation instead of casting
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+dotnet_diagnostic.SA1139.severity = warning
+
+# Title    : Use tuple syntax
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+dotnet_diagnostic.SA1141.severity = warning
+
+# Title    : Refer to tuple fields by name
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Redundant: IDE0033
+dotnet_diagnostic.SA1142.severity = none
+
+# Title    : Using directives should be placed correctly
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Redundant: IDE0065
+dotnet_diagnostic.SA1200.severity = none
+
+# Title    : Elements should appear in the correct order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+dotnet_diagnostic.SA1201.severity = none
+
+# Title    : Elements should be ordered by access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+dotnet_diagnostic.SA1202.severity = warning
+
+# Title    : Constants should appear before fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+dotnet_diagnostic.SA1203.severity = warning
+
+# Title    : Static elements should appear before instance elements
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+dotnet_diagnostic.SA1204.severity = warning
+
+# Title    : Partial elements should declare access
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+dotnet_diagnostic.SA1205.severity = warning
+
+# Title    : Declaration keywords should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+dotnet_diagnostic.SA1206.severity = warning
+
+# Title    : Protected should come before internal
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+dotnet_diagnostic.SA1207.severity = warning
+
+# Title    : System using directives should be placed before other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+dotnet_diagnostic.SA1208.severity = warning
+
+# Title    : Using alias directives should be placed after other using directives
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+dotnet_diagnostic.SA1209.severity = warning
+
+# Title    : Using directives should be ordered alphabetically by namespace
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+dotnet_diagnostic.SA1210.severity = warning
+
+# Title    : Using alias directives should be ordered alphabetically by alias name
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+dotnet_diagnostic.SA1211.severity = warning
+
+# Title    : Property accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+dotnet_diagnostic.SA1212.severity = warning
+
+# Title    : Event accessors should follow order
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+dotnet_diagnostic.SA1213.severity = warning
+
+# Title    : Readonly fields should appear before non-readonly fields
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+dotnet_diagnostic.SA1214.severity = warning
+
+# Title    : Using static directives should be placed at the correct location
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+dotnet_diagnostic.SA1216.severity = warning
+
+# Title    : Using static directives should be ordered alphabetically
+# Category : StyleCop.CSharp.OrderingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+dotnet_diagnostic.SA1217.severity = warning
+
+# Title    : Element should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1300.severity = none
+
+# Title    : Element should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1301.severity = none
+
+# Title    : Interface names should begin with I
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1302.severity = none
+
+# Title    : Const field names should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1303.severity = none
+
+# Title    : Non-private readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1304.severity = none
+
+# Title    : Field names should not use Hungarian notation
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1305.severity = none
+
+# Title    : Field names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1306.severity = none
+
+# Title    : Accessible fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1307.severity = none
+
+# Title    : Variable names should not be prefixed
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1308.severity = none
+
+# Title    : Field names should not begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1309.severity = none
+
+# Title    : Field names should not contain underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+dotnet_diagnostic.SA1310.severity = warning
+
+# Title    : Static readonly fields should begin with upper-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1311.severity = none
+
+# Title    : Variable names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1312.severity = none
+
+# Title    : Parameter names should begin with lower-case letter
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1313.severity = none
+
+# Title    : Type parameter names should begin with T
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# Redundant: IDE1006
+dotnet_diagnostic.SA1314.severity = none
+
+# Title    : Tuple element names should use correct casing
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+dotnet_diagnostic.SA1316.severity = warning
+
+# Title    : Access modifier should be declared
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+dotnet_diagnostic.SA1400.severity = warning
+
+# Title    : Fields should be private
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Redundant: CA1051
+dotnet_diagnostic.SA1401.severity = none
+
+# Title    : File may only contain a single type
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+dotnet_diagnostic.SA1402.severity = warning
+
+# Title    : File may only contain a single namespace
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+dotnet_diagnostic.SA1403.severity = warning
+
+# Title    : Code analysis suppression should have justification
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+dotnet_diagnostic.SA1404.severity = warning
+
+# Title    : Debug.Assert should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+dotnet_diagnostic.SA1405.severity = warning
+
+# Title    : Debug.Fail should provide message text
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+dotnet_diagnostic.SA1406.severity = warning
+
+# Title    : Arithmetic expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+dotnet_diagnostic.SA1407.severity = warning
+
+# Title    : Conditional expressions should declare precedence
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+dotnet_diagnostic.SA1408.severity = warning
+
+# Title    : Remove unnecessary code
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+dotnet_diagnostic.SA1409.severity = warning
+
+# Title    : Remove delegate parenthesis when possible
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+dotnet_diagnostic.SA1410.severity = warning
+
+# Title    : Attribute constructor should not use unnecessary parenthesis
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+dotnet_diagnostic.SA1411.severity = warning
+
+# Title    : Store files as UTF-8 with byte order mark
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# Comment  : Pedantic
+dotnet_diagnostic.SA1412.severity = none
+
+# Title    : Use trailing comma in multi-line initializers
+# Category : StyleCop.CSharp.MaintainabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+dotnet_diagnostic.SA1413.severity = none
+
+# Title    : Tuple types in signatures should have element names
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+dotnet_diagnostic.SA1414.severity = warning
+
+# Title    : Braces for multi-line statements should not share line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+dotnet_diagnostic.SA1500.severity = warning
+
+# Title    : Statement should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+dotnet_diagnostic.SA1501.severity = warning
+
+# Title    : Element should not be on a single line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+dotnet_diagnostic.SA1502.severity = warning
+
+# Title    : Braces should not be omitted
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# Redundant: IDE0011
+dotnet_diagnostic.SA1503.severity = none
+
+# Title    : All accessors should be single-line or multi-line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+dotnet_diagnostic.SA1504.severity = warning
+
+# Title    : Opening braces should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+dotnet_diagnostic.SA1505.severity = warning
+
+# Title    : Element documentation headers should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+dotnet_diagnostic.SA1506.severity = warning
+
+# Title    : Code should not contain multiple blank lines in a row
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# Redundant: IDE2000
+dotnet_diagnostic.SA1507.severity = none
+
+# Title    : Closing braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# Redundant: IDE2002
+dotnet_diagnostic.SA1508.severity = none
+
+# Title    : Opening braces should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+dotnet_diagnostic.SA1509.severity = warning
+
+# Title    : Chained statement blocks should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+dotnet_diagnostic.SA1510.severity = warning
+
+# Title    : While-do footer should not be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+dotnet_diagnostic.SA1511.severity = warning
+
+# Title    : Single-line comments should not be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+dotnet_diagnostic.SA1512.severity = none
+
+# Title    : Closing brace should be followed by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+dotnet_diagnostic.SA1513.severity = warning
+
+# Title    : Element documentation header should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+dotnet_diagnostic.SA1514.severity = warning
+
+# Title    : Single-line comment should be preceded by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+dotnet_diagnostic.SA1515.severity = warning
+
+# Title    : Elements should be separated by blank line
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+dotnet_diagnostic.SA1516.severity = none
+
+# Title    : Code should not contain blank lines at start of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+dotnet_diagnostic.SA1517.severity = warning
+
+# Title    : Use line endings correctly at end of file
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+dotnet_diagnostic.SA1518.severity = none
+
+# Title    : Braces should not be omitted from multi-line child statement
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+dotnet_diagnostic.SA1519.severity = warning
+
+# Title    : Use braces consistently
+# Category : StyleCop.CSharp.LayoutRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+dotnet_diagnostic.SA1520.severity = warning
+
+# Title    : Elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+dotnet_diagnostic.SA1600.severity = none
+
+# Title    : Partial elements should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+dotnet_diagnostic.SA1601.severity = none
+
+# Title    : Enumeration items should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+dotnet_diagnostic.SA1602.severity = none
+
+# Title    : Documentation should contain valid XML
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+dotnet_diagnostic.SA1603.severity = warning
+
+# Title    : Element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+dotnet_diagnostic.SA1604.severity = warning
+
+# Title    : Partial element documentation should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+dotnet_diagnostic.SA1605.severity = warning
+
+# Title    : Element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+dotnet_diagnostic.SA1606.severity = warning
+
+# Title    : Partial element documentation should have summary text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+dotnet_diagnostic.SA1607.severity = warning
+
+# Title    : Element documentation should not have default summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+dotnet_diagnostic.SA1608.severity = warning
+
+# Title    : Property documentation should have value
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+dotnet_diagnostic.SA1609.severity = none
+
+# Title    : Property documentation should have value text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+dotnet_diagnostic.SA1610.severity = none
+
+# Title    : Element parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# Redundant: CS1573
+dotnet_diagnostic.SA1611.severity = none
+
+# Title    : Element parameter documentation should match element parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+dotnet_diagnostic.SA1612.severity = warning
+
+# Title    : Element parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+dotnet_diagnostic.SA1613.severity = warning
+
+# Title    : Element parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+dotnet_diagnostic.SA1614.severity = warning
+
+# Title    : Element return value should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+dotnet_diagnostic.SA1615.severity = none
+
+# Title    : Element return value documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+dotnet_diagnostic.SA1616.severity = warning
+
+# Title    : Void return value should not be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+dotnet_diagnostic.SA1617.severity = warning
+
+# Title    : Generic type parameters should be documented
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+dotnet_diagnostic.SA1618.severity = warning
+
+# Title    : Generic type parameters should be documented partial class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+dotnet_diagnostic.SA1619.severity = warning
+
+# Title    : Generic type parameter documentation should match type parameters
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+dotnet_diagnostic.SA1620.severity = warning
+
+# Title    : Generic type parameter documentation should declare parameter name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+dotnet_diagnostic.SA1621.severity = warning
+
+# Title    : Generic type parameter documentation should have text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+dotnet_diagnostic.SA1622.severity = warning
+
+# Title    : Property summary documentation should match accessors
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+dotnet_diagnostic.SA1623.severity = warning
+
+# Title    : Property summary documentation should omit accessor with restricted access
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+dotnet_diagnostic.SA1624.severity = warning
+
+# Title    : Element documentation should not be copied and pasted
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+dotnet_diagnostic.SA1625.severity = warning
+
+# Title    : Single-line comments should not use documentation style slashes
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+dotnet_diagnostic.SA1626.severity = warning
+
+# Title    : Documentation text should not be empty
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+dotnet_diagnostic.SA1627.severity = warning
+
+# Title    : Documentation text should begin with a capital letter
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+dotnet_diagnostic.SA1628.severity = warning
+
+# Title    : Documentation text should end with a period
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+dotnet_diagnostic.SA1629.severity = warning
+
+# Title    : Documentation text should contain whitespace
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+dotnet_diagnostic.SA1630.severity = warning
+
+# Title    : Documentation should meet character percentage
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+dotnet_diagnostic.SA1631.severity = warning
+
+# Title    : Documentation text should meet minimum character length
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+dotnet_diagnostic.SA1632.severity = warning
+
+# Title    : File should have header
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# Redundant: IDE0073
+dotnet_diagnostic.SA1633.severity = none
+
+# Title    : File header should show copyright
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+dotnet_diagnostic.SA1634.severity = none
+
+# Title    : File header should have copyright text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+dotnet_diagnostic.SA1635.severity = none
+
+# Title    : File header copyright text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# Title    : File header should contain file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+dotnet_diagnostic.SA1637.severity = none
+
+# Title    : File header file name documentation should match file name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+dotnet_diagnostic.SA1638.severity = none
+
+# Title    : File header should have summary
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+dotnet_diagnostic.SA1639.severity = none
+
+# Title    : File header should have valid company text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+dotnet_diagnostic.SA1640.severity = none
+
+# Title    : File header company name text should match
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+dotnet_diagnostic.SA1641.severity = none
+
+# Title    : Constructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+dotnet_diagnostic.SA1642.severity = warning
+
+# Title    : Destructor summary documentation should begin with standard text
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+dotnet_diagnostic.SA1643.severity = warning
+
+# Title    : Documentation headers should not contain blank lines
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+dotnet_diagnostic.SA1644.severity = warning
+
+# Title    : Included documentation file does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+dotnet_diagnostic.SA1645.severity = warning
+
+# Title    : Included documentation XPath does not exist
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+dotnet_diagnostic.SA1646.severity = warning
+
+# Title    : Include node does not contain valid file and path
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+dotnet_diagnostic.SA1647.severity = warning
+
+# Title    : inheritdoc should be used with inheriting class
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+dotnet_diagnostic.SA1648.severity = warning
+
+# Title    : File name should match first type name
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+dotnet_diagnostic.SA1649.severity = warning
+
+# Title    : Element documentation should be spelled correctly
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# Comment  : Deprecated
+dotnet_diagnostic.SA1650.severity = none
+
+# Title    : Do not use placeholder elements
+# Category : StyleCop.CSharp.DocumentationRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+dotnet_diagnostic.SA1651.severity = warning
+
+# Title    : Do not prefix local calls with 'this.'
+# Category : StyleCop.CSharp.ReadabilityRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = warning
+
+# Title    : Field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309.severity = none
+
+# Title    : Static field names should begin with underscore
+# Category : StyleCop.CSharp.NamingRules
+# Help Link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+# Redundant: IDE1006
+dotnet_diagnostic.SX1309S.severity = none
+
+# Title    : Avoid legacy thread switching APIs
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD001.md
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Title    : Avoid problematic synchronous waits
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Title    : Avoid awaiting foreign Tasks
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD003.md
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Title    : Await SwitchToMainThreadAsync
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD004.md
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Title    : Invoke single-threaded types on Main thread
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD010.md
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Title    : Use AsyncLazy<T>
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD011.md
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Title    : Provide JoinableTaskFactory where allowed
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD012.md
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Title    : Avoid async void methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD100.md
+dotnet_diagnostic.VSTHRD100.severity = error
+
+# Title    : Avoid unsupported async delegates
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+dotnet_diagnostic.VSTHRD101.severity = error
+
+# Title    : Implement internal logic asynchronously
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD102.md
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Title    : Call async methods when in an async method
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Title    : Offer async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# Title    : Avoid method overloads that assume TaskScheduler.Current
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Title    : Use InvokeAsync to raise async events
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD106.md
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Title    : Await Task within using expression
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD107.md
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Title    : Assert thread affinity unconditionally
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD108.md
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Title    : Switch instead of assert in async methods
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD109.md
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Title    : Observe result of async calls
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md
+# Redundant: CS4014, IDE0058
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# Title    : Use ConfigureAwait(bool)
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Redundant: CA2007
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Title    : Implement System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD112.md
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Title    : Check for System.IAsyncDisposable
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD113.md
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Title    : Avoid returning a null Task
+# Category : Usage
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
+dotnet_diagnostic.VSTHRD114.severity = error
+
+# Title    : Use "Async" suffix for async methods
+# Category : Style
+# Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+dotnet_diagnostic.VSTHRD200.severity = none
+

--- a/src/ToBeRemoved/Directory.Build.props
+++ b/src/ToBeRemoved/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreTargetFrameworks)$(ConditionalNet462)</TargetFrameworks>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
+    <Api>false</Api>
 
     <InjectDiagnosticAttributesOnLegacy Condition="'$(InjectDiagnosticAttributesOnLegacy)' == ''">true</InjectDiagnosticAttributesOnLegacy>
     <InjectIsExternalInitOnLegacy Condition="'$(InjectIsExternalInitOnLegacy)' == ''">true</InjectIsExternalInitOnLegacy>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2023-05-23 23:01:34Z
+# Generated : 2023-05-24 21:09:53Z
 # Max Tier  : 2147483647
 # Attributes: general, test
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.Extensions.ExtraAnalyzers.Roslyn4.0, Microsoft.Extensions.LocalAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers, xunit.analyzers
@@ -2758,37 +2758,37 @@ dotnet_diagnostic.R9A044.severity = none
 # Title    : Newly added symbols must be marked as experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a049
-dotnet_diagnostic.R9A049.severity = warning
+dotnet_diagnostic.R9A049.severity = none
 
 # Title    : Experimental symbols cannot be marked as obsolete
 # Category : Correctness
 # Help Link: https://TODO/r9a050
-dotnet_diagnostic.R9A050.severity = warning
+dotnet_diagnostic.R9A050.severity = none
 
 # Title    : Published symbols cannot be marked experimental
 # Category : Correctness
 # Help Link: https://TODO/r9a051
-dotnet_diagnostic.R9A051.severity = warning
+dotnet_diagnostic.R9A051.severity = none
 
 # Title    : Published symbols cannot be deleted to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a052
-dotnet_diagnostic.R9A052.severity = warning
+dotnet_diagnostic.R9A052.severity = none
 
 # Title    : A deprecated API is not annotated with the obsolete attribute
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a053
-dotnet_diagnostic.R9A053.severity = warning
+dotnet_diagnostic.R9A053.severity = none
 
 # Title    : A deprecated API is marked as experimental
 # Category : Correctness
 # Help Link: https://eng.ms/docs/experiences-devices/r9-sdk/docs/static-analysis/analyzers/r9a054
-dotnet_diagnostic.R9A054.severity = warning
+dotnet_diagnostic.R9A054.severity = none
 
 # Title    : Published symbols cannot be changed to maintain compatibility
 # Category : Correctness
 # Help Link: https://TODO/r9a055
-dotnet_diagnostic.R9A055.severity = warning
+dotnet_diagnostic.R9A055.severity = none
 
 # Title    : Fire-and-forget async call inside a 'using' block
 # Category : Correctness

--- a/test/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/ApiLifecycleAnalyzerTest.cs
+++ b/test/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/ApiLifecycleAnalyzerTest.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.LocalAnalyzers.Resource.Test;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Telemetry.Logging;
 using Xunit;
 
 namespace Microsoft.Extensions.LocalAnalyzers.ApiLifecycle.Test;
@@ -72,11 +73,6 @@ public class ApiLifecycleAnalyzerTest
                 testAssemblyName: testAssemblyName)
             .ConfigureAwait(false);
 
-        if (expectedDiagnostics != diagnostics.Count)
-        {
-            System.Diagnostics.Debugger.Break();
-        }
-
         Assert.Equal(expectedDiagnostics, diagnostics.Count);
 
         for (int i = 0; i < diagnostics.Count; i++)
@@ -102,10 +98,35 @@ public class ApiLifecycleAnalyzerTest
         Assembly.GetAssembly(typeof(IDistributedCache))!,
         Assembly.GetAssembly(typeof(Microsoft.Extensions.ObjectPool.ObjectPool))!,
         Assembly.GetAssembly(typeof(IBufferWriter<>))!,
+        Assembly.GetAssembly(typeof(ILogPropertyCollector))!,
+        Assembly.GetAssembly(typeof(Microsoft.Extensions.Logging.ILogger))!,
     };
 
     public static IEnumerable<object[]> CodeWithMissingMembers => new List<object[]>
     {
+        new object[]
+        {
+            0,
+            "ApiLifecycle/Data/SimpleTaxonomy.json",
+            "SimpleTaxonomy",
+            new [] { DiagDescriptors.NewSymbolsMustBeMarkedExperimental.Id },
+            @"
+            using System;
+
+            namespace Microsoft.Extensions.Compliance.Testing;
+
+            [Flags]
+            public enum SimpleTaxonomy : ulong
+            {
+                None = 0,
+                PublicData = 1 << 0,
+                PrivateData = 1 << 1,
+                Unknown = 1 << 2,
+            }
+
+            "
+        },
+#if false
         new object[]
         {
             1,
@@ -765,6 +786,7 @@ public class ApiLifecycleAnalyzerTest
                 }
             "
         }
+#endif
     };
 
     public static IEnumerable<object[]> CodeWithMissingApis => new List<object[]>

--- a/test/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Data/SimpleTaxonomy.json
+++ b/test/Analyzers/Microsoft.Extensions.LocalAnalyzers/ApiLifecycle/Data/SimpleTaxonomy.json
@@ -1,0 +1,37 @@
+{
+  "Name": "SimpleTaxonomy",
+  "Types": [
+    {
+      "Type": "enum Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy : ulong",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.SimpleTaxonomy();",
+          "Stage": "Stable"
+        }
+      ],
+      "Fields": [
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.None",
+          "Stage": "Stable",
+          "Value": "0"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.PrivateData",
+          "Stage": "Stable",
+          "Value": "2"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.PublicData",
+          "Stage": "Stable",
+          "Value": "1"
+        },
+        {
+          "Member": "const Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy Microsoft.Extensions.Compliance.Testing.SimpleTaxonomy.Unknown",
+          "Stage": "Stable",
+          "Value": "9223372036854775808"
+        }
+      ]
+    }
+  ]
+}

--- a/test/Analyzers/Microsoft.Extensions.LocalAnalyzers/Microsoft.Extensions.LocalAnalyzers.Tests.csproj
+++ b/test/Analyzers/Microsoft.Extensions.LocalAnalyzers/Microsoft.Extensions.LocalAnalyzers.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Analyzers\Microsoft.Extensions.LocalAnalyzers\Microsoft.Extensions.LocalAnalyzers.csproj" ProjectUnderTest="true" />
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Telemetry.Abstractions\Microsoft.Extensions.Telemetry.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Add API baseline files.

- Fix a bug in the ApiLifecycle analyzer messing up some of the analysis.\

- Add missing files to the StaticAnalysis package. Those got missed because of gitignore.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4006)