### PR TITLE
Remove unclear Advance() method from FakeTimeProvider

### DIFF
--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
@@ -81,11 +81,6 @@ public class FakeTimeProvider : TimeProvider
         WakeWaiters(waiters);
     }
 
-    /// <summary>
-    /// Advances the clock's time by one millisecond.
-    /// </summary>
-    public void Advance() => Advance(TimeSpan.FromMilliseconds(1));
-
     /// <inheritdoc />
     public override long GetTimestamp()
     {

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Logging/FakeLogCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Logging/FakeLogCollectorTests.cs
@@ -32,7 +32,7 @@ public class FakeLogCollectorTests
         var output = new Output();
 
         var timeProvider = new FakeTimeProvider();
-        timeProvider.Advance();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
 
         var options = new FakeLogCollectorOptions
         {
@@ -74,7 +74,7 @@ public class FakeLogCollectorTests
         var output = new Output();
 
         var timeProvider = new FakeTimeProvider();
-        timeProvider.Advance();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
 
         var options = new FakeLogCollectorOptions
         {

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Logging/FakeLoggerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Logging/FakeLoggerTests.cs
@@ -250,7 +250,7 @@ public class FakeLoggerTests
         logger.LogDebug("M1");
         logger.LogDebug("M2");
 
-        timeProvider.Advance();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
         logger.LogDebug("M3");
         logger.LogDebug("M4");
 

--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
@@ -173,7 +173,7 @@ public class FakeTimeProviderTests
         var timeProvider = new FakeTimeProvider();
 
         var delay = timeProvider.Delay(TimeSpan.FromMilliseconds(1), CancellationToken.None);
-        timeProvider.Advance();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
         await delay;
 
         Assert.True(delay.IsCompleted);
@@ -203,7 +203,7 @@ public class FakeTimeProviderTests
         var timeProvider = new FakeTimeProvider();
 
         using var cts = timeProvider.CreateCancellationTokenSource(TimeSpan.FromMilliseconds(1));
-        timeProvider.Advance();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
 
         await Assert.ThrowsAsync<TaskCanceledException>(() => timeProvider.Delay(TimeSpan.FromTicks(1), cts.Token));
     }
@@ -224,7 +224,7 @@ public class FakeTimeProviderTests
         var t = source.Task.WaitAsync(TimeSpan.FromSeconds(100000), timeProvider, CancellationToken.None);
         while (!t.IsCompleted)
         {
-            timeProvider.Advance();
+            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
             await Task.Delay(1);
             _ = source.TrySetResult(true);
         }
@@ -243,7 +243,7 @@ public class FakeTimeProviderTests
         var t = source.Task.WaitAsync(_infiniteTimeout, timeProvider, CancellationToken.None);
         while (!t.IsCompleted)
         {
-            timeProvider.Advance();
+            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
             await Task.Delay(1);
             _ = source.TrySetResult(true);
         }
@@ -262,7 +262,7 @@ public class FakeTimeProviderTests
         var t = source.Task.WaitAsync(TimeSpan.FromMilliseconds(1), timeProvider, CancellationToken.None);
         while (!t.IsCompleted)
         {
-            timeProvider.Advance();
+            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
             await Task.Delay(1);
         }
 


### PR DESCRIPTION
The `Advance()` method requires the reader to know implicitly that it is 1ms that time is being advanced with (or read docs/use an editor that shows the info), and it is an overload that can be easily added via an extension method by teams that have the need. So since the goal is a generally applicable fake, I would recommend keeping the API surface clean and not including Advance() out of the box.

Closes #4007

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4024)