### PR TITLE
Refactor removal of built-in HttpClient logging handler

### DIFF
--- a/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/HttpClientLoggingExtensionsTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/HttpClientLoggingExtensionsTest.cs
@@ -858,7 +858,9 @@ public class HttpClientLoggingExtensionsTest
         var collector = provider.GetFakeLogCollector();
         var logRecords = collector.GetSnapshot().Where(l => l.Category == "System.Net.Http.HttpClient.normal.LogicalHandler").ToList();
 
-        Assert.Equal(2, logRecords.Count);
+        Assert.Collection(logRecords,
+            r => Assert.Equal("RequestPipelineStart", r.Id.Name),
+            r => Assert.Equal("RequestPipelineEnd", r.Id.Name));
     }
 
     [Fact]


### PR DESCRIPTION
Implementation of what is discussed at https://github.com/dotnet/runtime/issues/85840#issuecomment-1582516227

It's a bit more complicated than I described because filters run after `HttpMessageHandlerBuilderActions` configuration. I worked around that by adding a filter that removes the handlers added by the logging filter.

`AddDefaultHttpClientLogging_DisablesNetScope` passes after this change.

cc @geeknoid @dpk83 @CarnaViire @noahfalk 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4060)