### PR TITLE
Update circuit breaker options docs

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Resilience/Polly/Options/CircuitBreakerPolicyOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Polly/Options/CircuitBreakerPolicyOptions.cs
@@ -52,7 +52,7 @@ public class CircuitBreakerPolicyOptions
     /// Gets or sets the duration of break.
     /// </summary>
     /// <value>
-    /// The duration the circuit will stay open before resetting. The default value is 100.
+    /// The duration the circuit will stay open before resetting. The default value is 5 seconds.
     /// </value>
     /// <remarks>
     /// The value must be greater than 0.5 seconds.


### PR DESCRIPTION
Fixes the docs for circuit breaker options - break duration to reflect the code. The default value in text states 100 when it should say 5 seconds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4069)