### PR TITLE
Update Microsoft.Extensions.Telemetry.csproj

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Telemetry</RootNamespace>
     <Description>Provides canonical implementations of telemetry abstractions</Description>
@@ -47,7 +47,6 @@
     <InternalsVisibleToTest Include="Microsoft.AspNetCore.Telemetry.Tests" />
     <InternalsVisibleToTest Include="Microsoft.AspNetCore.Telemetry.Middleware.Tests" />
     <InternalsVisibleToTest Include="Microsoft.Extensions.Http.Telemetry.Tests" />
-    <InternalsVisibleToTest Include="Microsoft.Azure.Extensions.Telemetry.Tests" />
     <InternalsVisibleToTest Include="Microsoft.Extensions.Http.Telemetry.PerformanceTests" />
     <InternalsVisibleToDynamicProxyGenAssembly2 Include="*" />
     <InternalsVisibleTo Include="Microsoft.Extensions.Http.Telemetry" />


### PR DESCRIPTION
Contributes to #4073

Remove superficial IVT entry.

This entry makes the compiler very upset when signing is disabled, which has to be to appease stryker (the mutation test runner).
```
D:\Development\azure-dotnet-extensions-experimental\tests\Microsoft.Azure.Extensions.Telemetry.Tests\AzureMetadataTests.cs(16,22): error CS0281: Friend access was granted by 'Microsoft.Extensions.Telemetry, Version=8.0.0.0, Culture=neutral, PublicKeyTok 
en=31bf3856ad364e35', but the public key of the output assembly ('') does not match that specified by the InternalsVisibleTo attribute in the granting assembly. [D:\Development\azure-dotnet-extensions-experimental\tests\Microsoft.Azure.Extensions.Teleme 
try.Tests\Microsoft.Azure.Extensions.Telemetry.Tests.csproj::TargetFramework=net8.0]
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4072)