### PR TITLE
Remove dependency on dotnet7 feed

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,6 +13,15 @@
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1138;MSB3270</MSBuildWarningsAsMessages>
     <WarningLevel>5</WarningLevel>
 
+    <!--
+      Related to https://github.com/dotnet/extensions/pull/4061
+
+      warning NU1603: Microsoft.AspNetCore.Telemetry depends on Microsoft.NET.ILLink.Tasks (>= 7.0.100-1.23211.1)
+                      but Microsoft.NET.ILLink.Tasks 7.0.100-1.23211.1 was not found.
+                      An approximate best match of Microsoft.NET.ILLink.Tasks 8.0.0-alpha.1.23060.9 was resolved.
+    -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
+
     <!-- This is false for local development, but set to true in the CI system -->
     <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
@@ -25,9 +24,6 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet8">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet7">
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet8-transport">

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -36,9 +36,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
-    <!-- Manually referencing Logging.Configuration in nca3.1 which is a transitive dependency of OpenTelemetry in order to bump the version to 8.0 era -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
     <PackageReference Include="OpenTelemetry" />
+
+    <!-- Manually reference Logging.Configuration in nca3.1 which is a transitive dependency of OpenTelemetry in order to bump the version to 8.0 era -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))" />
 
     <!-- In net462, we need to reference System.Net.Http as that is where HttpRequestMessage lives -->
     <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462'" />


### PR DESCRIPTION
Follow up on https://github.com/dotnet/extensions/pull/4061, which introduced dependency on dotnet7 NuGet feed. This change removes the feed, supressing the warning instead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4079)