### PR TITLE
Improve waiting for metrics

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry.Testing/Metering/MetricCollector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Testing/Metering/MetricCollector.cs
@@ -139,6 +139,7 @@ public sealed class MetricCollector<T> : IDisposable
             {
                 _ = w.TaskSource.TrySetException(MakeObjectDisposedException());
             }
+
             _waiters.Clear();
         }
     }

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -244,21 +246,51 @@ public static class MetricCollectorTests
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await collector.WaitForMeasurementsAsync(-1));
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await collector.WaitForMeasurementsAsync(0));
 
+        Assert.Equal(0, collector.WaitersCount);
+
         var wait = collector.WaitForMeasurementsAsync(2);
+        Assert.Equal(1, collector.WaitersCount);
         Assert.False(wait.IsCompleted);
 
         counter.Add(1);
         Assert.False(wait.IsCompleted);
+        Assert.Equal(1, collector.WaitersCount);
 
         counter.Add(1);
         Assert.True(wait.IsCompleted);
         Assert.False(wait.IsFaulted);
+        Assert.Equal(0, collector.WaitersCount);
 
         collector.Clear();
         counter.Add(1);
         wait = collector.WaitForMeasurementsAsync(1);
         Assert.True(wait.IsCompleted);
         Assert.False(wait.IsFaulted);
+        Assert.Equal(0, collector.WaitersCount);
+    }
+
+    [Fact]
+    public static async Task WaitWithCancellation()
+    {
+        const string CounterName = "MyCounter";
+
+        var now = DateTimeOffset.Now;
+
+        var timeProvider = new FakeTimeProvider(now);
+        using var meter = new Meter(Guid.NewGuid().ToString());
+        using var collector = new MetricCollector<long>(meter, CounterName, timeProvider);
+        var counter = meter.CreateCounter<long>(CounterName);
+
+        using var cts = new CancellationTokenSource();
+        var wait = collector.WaitForMeasurementsAsync(1, cts.Token);
+
+        Assert.Equal(1, collector.WaitersCount);
+
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+
+        Assert.Equal(0, collector.WaitersCount);
     }
 
     [Fact]
@@ -278,22 +310,37 @@ public static class MetricCollectorTests
 
         var wait = collector.WaitForMeasurementsAsync(2, TimeSpan.FromSeconds(1));
         Assert.False(wait.IsCompleted);
+        Assert.Equal(1, collector.WaitersCount);
 
         counter.Add(1);
         Assert.False(wait.IsCompleted);
-
-#if false
-// TODO: This is broken for netcoreapp3.1 and net6.0, but works for net462 and net8.0.
-        timeProvider.Advance(TimeSpan.FromSeconds(1));
-        Assert.True(wait.IsCompleted);
-        Assert.True(wait.IsFaulted);
-#endif
+        Assert.Equal(1, collector.WaitersCount);
 
         collector.Clear();
-        counter.Add(1);
         wait = collector.WaitForMeasurementsAsync(1, TimeSpan.FromSeconds(1));
+        Assert.Equal(2, collector.WaitersCount);
+        counter.Add(1);
+        Assert.Equal(1, collector.WaitersCount);
+
+        // TODO: For some reason IsCompleted isn't immediately set to true. Investigate why.
+        await wait;
         Assert.True(wait.IsCompleted);
         Assert.False(wait.IsFaulted);
+    }
+
+    [Fact]
+    public static async Task WaitWithTimeout_CanceledFromTimeout()
+    {
+        const string CounterName = "MyCounter";
+
+        var now = DateTimeOffset.Now;
+
+        var timeProvider = new FakeTimeProvider(now);
+        using var meter = new Meter(Guid.NewGuid().ToString());
+        using var collector = new MetricCollector<long>(meter, CounterName, timeProvider);
+        var counter = meter.CreateCounter<long>(CounterName);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => collector.WaitForMeasurementsAsync(1, TimeSpan.FromMilliseconds(50)));
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading;
@@ -288,7 +287,9 @@ public static class MetricCollectorTests
 
         cts.Cancel();
 
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
         Assert.Equal(0, collector.WaitersCount);
     }
@@ -322,10 +323,8 @@ public static class MetricCollectorTests
         counter.Add(1);
         Assert.Equal(1, collector.WaitersCount);
 
-        // TODO: For some reason IsCompleted isn't immediately set to true. Investigate why.
-        await wait;
-        Assert.True(wait.IsCompleted);
-        Assert.False(wait.IsFaulted);
+        // Task should be complete. Error if not complete after delay.
+        await wait.WaitAsync(TimeSpan.FromSeconds(5), TimeProvider.System);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Microsoft.Extensions.Telemetry.Testing.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Microsoft.Extensions.Telemetry.Testing.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Telemetry.Testing</RootNamespace>
     <Description>Unit tests for Microsoft.Extensions.Telemetry.Testing.</Description>
+    <InjectTaskWaitAsyncOnLegacy>true</InjectTaskWaitAsyncOnLegacy>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Builds on top of https://github.com/dotnet/extensions/pull/4087. I thought making these changes myself would be easier than explaining them in code review.

* Add cancellation token to `WaitForMeasurementsAsync`.
* Simplify timeout method to pass cancellation token to `WaitForMeasurementsAsync`.
* Previously, waiters weren't removed from the collector if they timed out/were canceled. They are now removed.
* The TCS is now created with `RunContinuationsAsynchronously` to ensure awaiting user code isn't run when holding the `_measurements` lock.

cc @geeknoid @noahfalk @tarekgh 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4091)