### PR TITLE
Remove dotnet7 feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
@@ -25,9 +24,6 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet8">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet7">
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet8-transport">


### PR DESCRIPTION
Microsoft.NET.ILLink.Tasks 7.0.100 is now available on dotnet-public feed

Follow up on #4061

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4094)