### PR TITLE
Include new Polly packages and upgrade to latest Polly version

### DIFF
--- a/eng/Packages/General.props
+++ b/eng/Packages/General.props
@@ -34,7 +34,10 @@
     <PackageVersion Include="OpenTelemetry" Version="1.4.0" />
     <PackageVersion Include="Polly.Contrib.Simmy" Version="0.3.0" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageVersion Include="Polly" Version="7.2.4" />
+    <PackageVersion Include="Polly" Version="8.0.0-alpha.1" />
+    <PackageVersion Include="Polly.Core" Version="8.0.0-alpha.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.0.0-alpha.1" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.0.0-alpha.1" />
     <PackageVersion Include="protobuf-net" Version="3.0.101" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
@@ -34,6 +34,9 @@
 
   <ItemGroup>
     <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Core" />
+    <PackageReference Include="Polly.Extensions" />
+    <PackageReference Include="Polly.RateLimiting" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />
     <PackageReference Include="Polly.Contrib.Simmy" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))" />


### PR DESCRIPTION
Just updating to latest Polly version and including new packages we will use. 
The builds/tests should pass without any regressions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4096)