### PR TITLE
Improve HttpClient resilience benchmarks

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HedgingBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HedgingBenchmark.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,11 +10,12 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Http.Resilience.Bench;
 
-public class Benchmark
+public class HedgingBenchmark
 {
-    private static HttpRequestMessage Request => new(HttpMethod.Post, "https://bogus");
+    private static readonly Uri _uri = new("https://bogus");
+    private static HttpRequestMessage Request => new(HttpMethod.Post, _uri);
 
-    private System.Net.Http.HttpClient _client = null!;
+    private HttpClient _client = null!;
 
     [GlobalSetup]
     public void GlobalSetup()

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpClientFactory.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpClientFactory.cs
@@ -28,9 +28,9 @@ public enum HedgingClientType
 
 internal static class HttpClientFactory
 {
-    public const string EmptyClient = "Empty";
+    internal const string EmptyClient = "Empty";
 
-    public const string StandardClient = "Standard";
+    internal const string StandardClient = "Standard";
 
     private const string HedgingEndpoint1 = "http://localhost1";
     private const string HedgingEndpoint2 = "http://localhost2";

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Http.Resilience.Bench;
+
+public class HttpResilienceBenchmark
+{
+    private static readonly Uri _uri = new("https://bogus");
+
+    private static HttpRequestMessage Request
+    {
+        get
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, _uri);
+            request.Options.Set(new HttpRequestOptionsKey<string>("dummy"), "dummy");
+            return request;
+        }
+    }
+
+    private HttpClient _client = null!;
+    private HttpClient _standardClient = null!;
+    private HttpClient _hedgingClient = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var serviceProvider = HttpClientFactory.InitializeServiceProvider(HedgingClientType.Ordered);
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        _client = factory.CreateClient(HttpClientFactory.EmptyClient);
+        _standardClient = factory.CreateClient(HttpClientFactory.StandardClient);
+        _hedgingClient = factory.CreateClient(nameof(HedgingClientType.Ordered));
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<HttpResponseMessage> DefaultClient()
+    {
+        return _client.SendAsync(Request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public Task<HttpResponseMessage> StandardResilienceHandler()
+    {
+        return _standardClient.SendAsync(Request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public Task<HttpResponseMessage> StandardHedgingHandler()
+    {
+        return _hedgingClient.SendAsync(Request, CancellationToken.None);
+    }
+}

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
@@ -14,6 +14,10 @@ public class HttpResilienceBenchmark
 {
     private static readonly Uri _uri = new("https://bogus");
 
+    private HttpClient _client = null!;
+    private HttpClient _standardClient = null!;
+    private HttpClient _hedgingClient = null!;
+
     private static HttpRequestMessage Request
     {
         get
@@ -23,10 +27,6 @@ public class HttpResilienceBenchmark
             return request;
         }
     }
-
-    private HttpClient _client = null!;
-    private HttpClient _standardClient = null!;
-    private HttpClient _hedgingClient = null!;
 
     [GlobalSetup]
     public void GlobalSetup()

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Program.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Program.cs
@@ -15,9 +15,8 @@ namespace Microsoft.Extensions.Http.Resilience.FaultInjection.Benchmark
         {
             var doNotRequireSlnToRunBenchmarks = ManualConfig
                 .Create(DefaultConfig.Instance)
-                .AddJob(Job.MediumRun.WithToolchain(InProcessEmitToolchain.Instance))
-                .AddDiagnoser(MemoryDiagnoser.Default)
-                .WithOptions(ConfigOptions.DisableOptimizationsValidator);
+                .AddJob(Job.MediumRun.WithToolchain(InProcessEmitToolchain.Instance).WithIterationCount(100))
+                .AddDiagnoser(MemoryDiagnoser.Default);
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, doNotRequireSlnToRunBenchmarks);
         }

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Program.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Program.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Extensions.Http.Resilience.FaultInjection.Benchmark
         {
             var doNotRequireSlnToRunBenchmarks = ManualConfig
                 .Create(DefaultConfig.Instance)
-                .AddJob(Job.MediumRun.WithToolchain(InProcessEmitToolchain.Instance).WithIterationCount(100))
-                .AddDiagnoser(MemoryDiagnoser.Default);
+                .AddJob(Job.MediumRun.WithToolchain(InProcessEmitToolchain.Instance))
+                .AddDiagnoser(MemoryDiagnoser.Default)
+                .WithOptions(ConfigOptions.DisableOptimizationsValidator);
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, doNotRequireSlnToRunBenchmarks);
         }


### PR DESCRIPTION
Addiing a new benchmark that compares no-resilience, standard resilience and standard hedging resilience.

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.1848), VM=Hyper-V
Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.100-preview.6.23309.5
  [Host] : .NET 8.0.0 (8.0.23.30704), X64 RyuJIT AVX2

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15
LaunchCount=2  WarmupCount=10

|                    Method |       Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|-------------------------- |-----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
|             DefaultClient |   236.4 ns |  2.24 ns |  3.28 ns |  1.00 |    0.00 | 0.0191 |     488 B |        1.00 |
| StandardResilienceHandler | 4,101.4 ns | 21.96 ns | 32.19 ns | 17.35 |    0.22 | 0.1602 |    4152 B |        8.51 |
|    StandardHedgingHandler | 8,060.2 ns | 58.09 ns | 85.15 ns | 34.10 |    0.35 | 0.2289 |    5880 B |       12.05 |
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4100)