### PR TITLE
Fix bug in MetricCollector.WaitForMeasurementsAsync

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry.Testing/Metering/MetricCollector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Testing/Metering/MetricCollector.cs
@@ -253,7 +253,11 @@ public sealed class MetricCollector<T> : IDisposable
     [SuppressMessage("Resilience", "R9A061:The async method doesn't support cancellation", Justification = "Not relevant in this case")]
     public async Task WaitForMeasurementsAsync(int minCount, TimeSpan timeout)
     {
-        using var cancellationTokenSource = new CancellationTokenSource(timeout);
+#if NET8_0_OR_GREATER
+        using var cancellationTokenSource = new CancellationTokenSource(timeout, _timeProvider);
+#else
+        using var cancellationTokenSource = _timeProvider.CreateCancellationTokenSource(timeout);
+#endif
         await WaitForMeasurementsAsync(minCount, cancellationTokenSource.Token).ConfigureAwait(false);
     }
 

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
@@ -334,9 +334,8 @@ public static class MetricCollectorTests
 
         var now = DateTimeOffset.Now;
 
-        var timeProvider = new FakeTimeProvider(now);
         using var meter = new Meter(Guid.NewGuid().ToString());
-        using var collector = new MetricCollector<long>(meter, CounterName, timeProvider);
+        using var collector = new MetricCollector<long>(meter, CounterName);
         var counter = meter.CreateCounter<long>(CounterName);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => collector.WaitForMeasurementsAsync(1, TimeSpan.FromMilliseconds(50)));
@@ -367,11 +366,8 @@ public static class MetricCollectorTests
         await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1));
         await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1, TimeSpan.FromSeconds(1)));
 
-#if false
-// TODO: This is broken for netcoreapp3.1 and net6.0, but works for net462 and net8.0.
         Assert.True(wait.IsCompleted);
         Assert.True(wait.IsFaulted);
-#endif
 
         collector = new MetricCollector<long>(meter, CounterName, timeProvider);
         collector.Dispose();


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4106)