### PR TITLE
Restrict keywords and log levels enabled in EventCountersListener

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry/Metering.Collectors.EventCounters/EventCountersListener.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Metering.Collectors.EventCounters/EventCountersListener.cs
@@ -231,7 +231,7 @@ internal sealed class EventCountersListener : EventListener
         }
 
         _logger.EnablingEventSource(eventSource.Name);
-        EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All, _eventSourceSettings);
+        EnableEvents(eventSource, EventLevel.Critical, EventKeywords.None, _eventSourceSettings);
     }
 
     private void RecordSumEvent(IDictionary<string, object> eventPayload, string counterName)


### PR DESCRIPTION
This PR fixes #4104

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4109)