### PR TITLE
Workaround for flaky MetricCollector test

### DIFF
--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
@@ -366,6 +366,10 @@ public static class MetricCollectorTests
         await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1));
         await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1, TimeSpan.FromSeconds(1)));
 
+        // HACK: there seems to be something executing asynchronously which takes a while to finish. This needs to be tracked on
+        //       I'm adding the sleep here to keep the test from being flaky.
+        Thread.Sleep(2000);
+
         Assert.True(wait.IsCompleted);
         Assert.True(wait.IsFaulted);
 


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4113)