### PR TITLE
Use XUnit Test runner

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -102,7 +102,7 @@
       <_BlameArgs>--blame --blame-crash --blame-crash-dump-type full --blame-hang --blame-hang-dump-type full --blame-hang-timeout 6m</_BlameArgs>
 
       <!-- This property is used by the Arcade SDK while bootstrapping the VS Test runner -->
-      <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) $(_BlameArgs)</TestRunnerAdditionalArguments>
+      <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments)</TestRunnerAdditionalArguments>
     </PropertyGroup>
   </Target>
 </Project>

--- a/eng/Packages/TestOnly.props
+++ b/eng/Packages/TestOnly.props
@@ -6,12 +6,6 @@
 
     <!-- Redirect test logs into a subfolder -->
     <TestResultsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'TestLogs'))</TestResultsLogDir>
-
-    <!--
-      Run tests with the VS Test Runner (dotnet test) instead of the XUnit Test runner (dotnet exec).
-      This is needed to produce Cobertura code coverage. See the targets file to more information.
-    -->
-    <UseVSTestRunner>true</UseVSTestRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use XUnit Test runner instead of VS Test Runner because the former is faster.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4131)