### PR TITLE
Adopt latest Polly version

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Resilience.PerformanceTests/ResilienceEnrichmentBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Resilience.PerformanceTests/ResilienceEnrichmentBenchmark.cs
@@ -66,7 +66,7 @@ public class ResilienceEnrichmentBenchmark
             ResilienceContext context,
             TState state)
         {
-            _telemetry.Report("Dummy", context, "dummy-args");
+            _telemetry.Report(new ResilienceEvent(ResilienceEventSeverity.Information, "Dummy"), context, "dummy-args");
 
             return callback(context, state);
         }

--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -43,10 +43,11 @@
     <PackageVersion Include="OpenTelemetry" Version="1.4.0" />
     <PackageVersion Include="Polly.Contrib.Simmy" Version="0.3.0" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageVersion Include="Polly.Core" Version="8.0.0-alpha.4" />
-    <PackageVersion Include="Polly.Extensions" Version="8.0.0-alpha.4" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.0.0-alpha.4" />
-    <PackageVersion Include="Polly" Version="8.0.0-alpha.4" />
+    <PackageVersion Include="Polly.Core" Version="8.0.0-alpha.6" />
+    <PackageVersion Include="Polly.Extensions" Version="8.0.0-alpha.6" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.0.0-alpha.6" />
+    <PackageVersion Include="Polly" Version="8.0.0-alpha.6" />
+    <PackageVersion Include="Polly.Testing" Version="8.0.0-alpha.6" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/HttpKey.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/HttpKey.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Http.Resilience.Internal;
 
-internal readonly record struct HttpKey(string Name, string Key)
+internal readonly record struct HttpKey(string Name, string InstanceName)
 {
     public static readonly IEqualityComparer<HttpKey> BuilderComparer = new BuilderEqualityComparer();
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/HttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/HttpClientBuilderExtensions.Resilience.cs
@@ -136,7 +136,7 @@ public static partial class HttpClientBuilderExtensions
         _ = services.Configure<ResilienceStrategyRegistryOptions<HttpKey>>(options =>
         {
             options.BuilderNameFormatter = key => key.Name;
-            options.StrategyKeyFormatter = key => key.Key;
+            options.InstanceNameFormatter = key => key.InstanceName;
             options.BuilderComparer = HttpKey.BuilderComparer;
         });
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/Internal/ResilienceHandler.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/Internal/ResilienceHandler.cs
@@ -30,7 +30,7 @@ internal sealed class ResilienceHandler : DelegatingHandler
         var created = false;
         if (request.GetResilienceContext() is not ResilienceContext context)
         {
-            context = ResilienceContext.Get();
+            context = ResilienceContext.Get(cancellationToken);
             created = true;
             request.SetResilienceContext(context);
         }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
@@ -30,9 +30,9 @@ public sealed class ResilienceHandlerContext
     public string BuilderName => _context.StrategyKey.Name;
 
     /// <summary>
-    /// Gets the strategy key of the resilience strategy being built.
+    /// Gets the instance name of resilience strategy being built.
     /// </summary>
-    public string StrategyKey => _context.StrategyKey.Key;
+    public string InstanceName => _context.StrategyKey.InstanceName;
 
     /// <summary>
     /// Enables dynamic reloading of the resilience strategy whenever the <typeparamref name="TOptions"/> options are changed.

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Microsoft.Extensions.Http.Resilience.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Microsoft.Extensions.Http.Resilience.Tests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Polly.Testing" />
     <PackageReference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
     <PackageReference Include="System.ValueTuple" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))" />

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
@@ -125,7 +125,7 @@ public sealed partial class HttpClientBuilderExtensionsTests
             {
                 context.ServiceProvider.Should().NotBeNull();
                 context.BuilderName.Should().Be($"{BuilderName}-test");
-                context.StrategyKey.Should().Be("dummy-key");
+                context.InstanceName.Should().Be("dummy-key");
                 verified = true;
             })
             .SelectStrategyBy(_ => _ => "dummy-key");
@@ -151,7 +151,7 @@ public sealed partial class HttpClientBuilderExtensionsTests
         registryOptions.StrategyComparer.Equals(new HttpKey("A", "1"), new HttpKey("A", "2")).Should().BeFalse();
 
         registryOptions.BuilderNameFormatter(new HttpKey("A", "1")).Should().Be("A");
-        registryOptions.StrategyKeyFormatter(new HttpKey("A", "1")).Should().Be("1");
+        registryOptions.InstanceNameFormatter!(new HttpKey("A", "1")).Should().Be("1");
     }
 
     public enum PolicyType

--- a/test/Libraries/Microsoft.Extensions.Resilience.Tests/Resilience/ResilienceServiceCollectionExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Resilience.Tests/Resilience/ResilienceServiceCollectionExtensionsTests.cs
@@ -55,7 +55,7 @@ public class ResilienceServiceCollectionExtensionsTests : IDisposable
     public void AddResilienceEnrichment_NoOutcome_EnsureDimensions()
     {
         Build();
-        _telemetry!.Report("dummy-event", ResilienceContext.Get(), string.Empty);
+        _telemetry!.Report(new ResilienceEvent(ResilienceEventSeverity.Information, "dummy-event"), ResilienceContext.Get(), string.Empty);
 
         Tags["failure-reason"].Should().BeNull();
         Tags["failure-source"].Should().BeNull();
@@ -81,7 +81,7 @@ public class ResilienceServiceCollectionExtensionsTests : IDisposable
 
         Build();
         _telemetry!.Report(
-            "dummy-event",
+            new ResilienceEvent(ResilienceEventSeverity.Information, "dummy-event"),
             new OutcomeArguments<string, string>(ResilienceContext.Get(), Outcome.FromException<string>(new InvalidOperationException { Source = "my-source" }), string.Empty));
 
         Tags["failure-reason"].Should().Be("InvalidOperationException");
@@ -96,7 +96,7 @@ public class ResilienceServiceCollectionExtensionsTests : IDisposable
 
         Build();
         _telemetry!.Report(
-            "dummy-event",
+            new ResilienceEvent(ResilienceEventSeverity.Information, "dummy-event"),
             new OutcomeArguments<string, string>(ResilienceContext.Get(), Outcome.FromResult("string-result"), string.Empty));
 
         Tags["failure-source"].Should().Be("my-source");
@@ -111,7 +111,7 @@ public class ResilienceServiceCollectionExtensionsTests : IDisposable
         context.SetRequestMetadata(new RequestMetadata { RequestName = "my-req", DependencyName = "my-dep" });
 
         Build();
-        _telemetry!.Report("dummy-event", context, string.Empty);
+        _telemetry!.Report(new ResilienceEvent(ResilienceEventSeverity.Information, "dummy-event"), context, string.Empty);
 
         Tags["dep-name"].Should().Be("my-dep");
         Tags["req-name"].Should().Be("my-req");
@@ -124,7 +124,7 @@ public class ResilienceServiceCollectionExtensionsTests : IDisposable
         _services.TryAddSingleton(Mock.Of<IOutgoingRequestContext>(v => v.RequestMetadata == requestMetadata));
 
         Build();
-        _telemetry!.Report("dummy-event", ResilienceContext.Get(), string.Empty);
+        _telemetry!.Report(new ResilienceEvent(ResilienceEventSeverity.Information, "dummy-event"), ResilienceContext.Get(), string.Empty);
 
         Tags["dep-name"].Should().Be("my-dep");
         Tags["req-name"].Should().Be("my-req");


### PR DESCRIPTION
This PR adopts the latest `8.0.0-alpha.6` version. Additionally it also uses the new `Polly.Testing` package that simplifies the testing of resilience strategies.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4188)