### PR TITLE
Test PR to investigate MetricCollector disposing test failure

### DIFF
--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
@@ -366,9 +366,22 @@ public static class MetricCollectorTests
         await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1));
         await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1, TimeSpan.FromSeconds(1)));
 
-        // HACK: there seems to be something executing asynchronously which takes a while to finish. This needs to be tracked on
-        //       I'm adding the sleep here to keep the test from being flaky.
-        Thread.Sleep(2000);
+        if (!wait.IsCompleted)
+        {
+            try
+            {
+                await wait;
+            }
+            catch (Exception e)
+            {
+                Assert.True(false, Environment.StackTrace + Environment.NewLine + e);
+                throw;
+            }
+            finally
+            {
+                Assert.True(false, Environment.StackTrace);
+            }
+        }
 
         Assert.True(wait.IsCompleted);
         Assert.True(wait.IsFaulted);

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Metering/MetricCollectorTests.cs
@@ -363,14 +363,14 @@ public static class MetricCollectorTests
         Assert.Throws<ObjectDisposedException>(() => collector.LastMeasurement);
         Assert.Throws<ObjectDisposedException>(() => collector.RecordObservableInstruments());
 
-        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1));
-        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1, TimeSpan.FromSeconds(1)));
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1).ConfigureAwait(false)).ConfigureAwait(false);
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await collector.WaitForMeasurementsAsync(1, TimeSpan.FromSeconds(1)).ConfigureAwait(false)).ConfigureAwait(false);
 
         if (!wait.IsCompleted)
         {
             try
             {
-                await wait;
+                await wait.ConfigureAwait(false);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4191)