### PR TITLE
Generator cleanup before updating code gen.

### DIFF
--- a/src/Generators/Microsoft.Gen.AutoClient/Microsoft.Gen.AutoClient.csproj
+++ b/src/Generators/Microsoft.Gen.AutoClient/Microsoft.Gen.AutoClient.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
   </ItemGroup>

--- a/src/Generators/Microsoft.Gen.ContextualOptions/Microsoft.Gen.ContextualOptions.csproj
+++ b/src/Generators/Microsoft.Gen.ContextualOptions/Microsoft.Gen.ContextualOptions.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
   </ItemGroup>

--- a/src/Generators/Microsoft.Gen.EnumStrings/Microsoft.Gen.EnumStrings.csproj
+++ b/src/Generators/Microsoft.Gen.EnumStrings/Microsoft.Gen.EnumStrings.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
   </ItemGroup>

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Utils.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Utils.cs
@@ -77,7 +77,7 @@ internal sealed partial class Emitter : EmitterBase
     internal static IReadOnlyCollection<string> GetLogPropertiesAttributes(LoggingMethod lm)
     {
         var result = new HashSet<string?>();
-        var parametersWithLogProps = lm.AllParameters.Where(x => x.HasProperties && !x.HasPropsProvider);
+        var parametersWithLogProps = lm.Parameters.Where(x => x.HasProperties && !x.HasPropsProvider);
         foreach (var parameter in parametersWithLogProps)
         {
             parameter.TraverseParameterPropertiesTransitively((_, property) => result.Add(property.ClassificationAttributeType));
@@ -96,7 +96,7 @@ internal sealed partial class Emitter : EmitterBase
 
         if (lm.Level == null)
         {
-            foreach (var p in lm.AllParameters)
+            foreach (var p in lm.Parameters)
             {
                 if (p.IsLogLevel)
                 {
@@ -150,4 +150,30 @@ internal sealed partial class Emitter : EmitterBase
     }
 
     internal static string EncodeTypeName(string typeName) => typeName.Replace("_", "__").Replace('.', '_');
+
+    internal static string PickUniqueName(string baseName, IEnumerable<string> potentialConflicts)
+    {
+        var name = baseName;
+        while (true)
+        {
+            bool conflict = false;
+            foreach (var potentialConflict in potentialConflicts)
+            {
+                if (name == potentialConflict)
+                {
+                    conflict = true;
+                    break;
+                }
+            }
+
+            if (!conflict)
+            {
+                return name;
+            }
+
+#pragma warning disable S1643 // Strings should not be concatenated using '+' in a loop
+            name += "_";
+#pragma warning restore S1643 // Strings should not be concatenated using '+' in a loop
+        }
+    }
 }

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.cs
@@ -18,12 +18,10 @@ internal sealed partial class Emitter : EmitterBase
 
     private readonly StringBuilderPool _sbPool = new();
     private bool _isRedactorProviderInTheInstance;
-    private int _memberCounter;
 
     public string Emit(IEnumerable<LoggingType> logTypes, CancellationToken cancellationToken)
     {
         _isRedactorProviderInTheInstance = false;
-        _memberCounter = 0;
 
         foreach (var lt in logTypes.OrderBy(static lt => lt.Namespace + "." + lt.Name))
         {
@@ -72,7 +70,7 @@ internal sealed partial class Emitter : EmitterBase
 
         var isRedactionRequired =
             lt.Methods
-                .SelectMany(static lm => lm.AllParameters)
+                .SelectMany(static lm => lm.Parameters)
                 .Any(static lp => lp.ClassificationAttributeType != null)
             || lt.Methods
                 .SelectMany(static lm => GetLogPropertiesAttributes(lm))
@@ -81,7 +79,7 @@ internal sealed partial class Emitter : EmitterBase
         if (isRedactionRequired)
         {
             _isRedactorProviderInTheInstance = lt.Methods
-                .SelectMany(static lm => lm.AllParameters)
+                .SelectMany(static lm => lm.Parameters)
                 .All(static lp => !lp.IsRedactorProvider);
 
             if (_isRedactorProviderInTheInstance)
@@ -105,7 +103,6 @@ internal sealed partial class Emitter : EmitterBase
             }
 
             GenLogMethod(lm);
-            _memberCounter++;
         }
 
         OutCloseBrace();
@@ -129,7 +126,7 @@ internal sealed partial class Emitter : EmitterBase
 
         var logPropsDataClasses = lt.Methods.SelectMany(lm => GetLogPropertiesAttributes(lm));
         var classificationAttributeTypes = lt.Methods
-            .SelectMany(static lm => lm.AllParameters)
+            .SelectMany(static lm => lm.Parameters)
             .Where(static lp => lp.ClassificationAttributeType is not null)
             .Select(static lp => lp.ClassificationAttributeType!)
             .Concat(logPropsDataClasses)
@@ -151,7 +148,7 @@ internal sealed partial class Emitter : EmitterBase
 
         var logPropsDataClasses = lt.Methods.SelectMany(lm => GetLogPropertiesAttributes(lm));
         var classificationAttributeTypes = lt.Methods
-            .SelectMany(static lm => lm.AllParameters)
+            .SelectMany(static lm => lm.Parameters)
             .Where(static lp => lp.ClassificationAttributeType is not null)
             .Select(static lp => lp.ClassificationAttributeType!)
             .Concat(logPropsDataClasses)

--- a/src/Generators/Microsoft.Gen.Logging/Microsoft.Gen.Logging.csproj
+++ b/src/Generators/Microsoft.Gen.Logging/Microsoft.Gen.Logging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Gen.Logging</RootNamespace>
     <Description>Code generator to support Microsoft.Extensions.Telemetry's logging features.</Description>
@@ -11,8 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Update="Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
+    <Compile Update="Parsing\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
     <Compile Include="..\Shared\*.cs" LinkBase="Shared" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Parsing\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethod.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethod.cs
@@ -11,9 +11,8 @@ namespace Microsoft.Gen.Logging.Model;
 /// </summary>
 internal sealed class LoggingMethod
 {
-    public readonly List<LoggingMethodParameter> AllParameters = new();
-    public readonly List<LoggingMethodParameter> TemplateParameters = new();
-    public readonly Dictionary<string, string> TemplateMap = new(StringComparer.OrdinalIgnoreCase);
+    public readonly List<LoggingMethodParameter> Parameters = new();
+    public readonly Dictionary<string, string> TemplateToParameterName = new(StringComparer.OrdinalIgnoreCase);
     public string Name = string.Empty;
     public string Message = string.Empty;
     public int? Level;
@@ -30,7 +29,7 @@ internal sealed class LoggingMethod
     public bool HasXmlDocumentation;
 
     public string GetParameterNameInTemplate(LoggingMethodParameter parameter)
-        => TemplateMap.TryGetValue(parameter.Name, out var value)
+        => TemplateToParameterName.TryGetValue(parameter.Name, out var value)
             ? value
             : parameter.Name;
 }

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
@@ -25,9 +25,10 @@ internal sealed class LoggingMethodParameter
     public bool IsNullable;
     public bool IsReference;
     public bool ImplementsIConvertible;
-    public bool ImplementsIFormatable;
+    public bool ImplementsIFormattable;
     public bool SkipNullProperties;
     public bool OmitParameterName;
+    public bool UsedAsTemplate;
     public string? ClassificationAttributeType;
     public List<LoggingProperty> PropertiesToLog = new();
     public LoggingPropertyProvider? LogPropertiesProvider;

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingProperty.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingProperty.cs
@@ -18,7 +18,7 @@ internal sealed record LoggingProperty(
     bool IsReference,
     bool IsEnumerable,
     bool ImplementsIConvertible,
-    bool ImplementsIFormatable,
+    bool ImplementsIFormattable,
     IReadOnlyCollection<LoggingProperty> TransitiveMembers)
 {
     public string NameWithAt => NeedsAtSign ? "@" + Name : Name;

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/DiagDescriptors.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/DiagDescriptors.cs
@@ -10,11 +10,7 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
 {
     private const string Category = "LogMethod";
 
-    public static DiagnosticDescriptor InvalidLoggingMethodName { get; } = Make(
-        id: "R9G000",
-        title: Resources.InvalidLoggingMethodNameTitle,
-        messageFormat: Resources.InvalidLoggingMethodNameMessage,
-        category: Category);
+    // R9G000 retired
 
     public static DiagnosticDescriptor ShouldntMentionLogLevelInMessage { get; } = Make(
         id: "R9G001",
@@ -23,13 +19,7 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         category: Category,
         DiagnosticSeverity.Warning);
 
-    public static DiagnosticDescriptor InvalidLoggingMethodParameterName { get; } = Make(
-        id: "R9G002",
-        title: Resources.InvalidLoggingMethodParameterNameTitle,
-        messageFormat: Resources.InvalidLoggingMethodParameterNameMessage,
-        category: Category);
-
-    // R9G003 is no longer in use
+    // R9G002,R9G003 retired
 
     public static DiagnosticDescriptor MissingRequiredType { get; } = Make(
         id: "R9G004",
@@ -50,10 +40,10 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         messageFormat: Resources.LoggingMethodMustReturnVoidMessage,
         category: Category);
 
-    public static DiagnosticDescriptor MissingLoggerArgument { get; } = Make(
+    public static DiagnosticDescriptor MissingLoggerParameter { get; } = Make(
         id: "R9G007",
-        title: Resources.MissingLoggerArgumentTitle,
-        messageFormat: Resources.MissingLoggerArgumentMessage,
+        title: Resources.MissingLoggerParameterTitle,
+        messageFormat: Resources.MissingLoggerParameterMessage,
         category: Category);
 
     public static DiagnosticDescriptor LoggingMethodShouldBeStatic { get; } = Make(
@@ -89,16 +79,16 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         category: Category,
         DiagnosticSeverity.Warning);
 
-    public static DiagnosticDescriptor TemplateHasNoCorrespondingArgument { get; } = Make(
+    public static DiagnosticDescriptor TemplateHasNoCorrespondingParameter { get; } = Make(
         id: "R9G013",
-        title: Resources.TemplateHasNoCorrespondingArgumentTitle,
-        messageFormat: Resources.TemplateHasNoCorrespondingArgumentMessage,
+        title: Resources.TemplateHasNoCorrespondingParameterTitle,
+        messageFormat: Resources.TemplateHasNoCorrespondingParameterMessage,
         category: Category);
 
-    public static DiagnosticDescriptor ArgumentHasNoCorrespondingTemplate { get; } = Make(
+    public static DiagnosticDescriptor ParameterHasNoCorrespondingTemplate { get; } = Make(
         id: "R9G014",
-        title: Resources.ArgumentHasNoCorrespondingTemplateTitle,
-        messageFormat: Resources.ArgumentHasNoCorrespondingTemplateMessage,
+        title: Resources.ParameterHasNoCorrespondingTemplateTitle,
+        messageFormat: Resources.ParameterHasNoCorrespondingTemplateMessage,
         category: Category,
         DiagnosticSeverity.Info);
 
@@ -139,16 +129,16 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         messageFormat: Resources.MultipleDataClassificationAttributesMessage,
         category: Category);
 
-    public static DiagnosticDescriptor MissingRedactorProviderArgument { get; } = Make(
+    public static DiagnosticDescriptor MissingRedactorProviderParameter { get; } = Make(
         id: "R9G021",
-        title: Resources.MissingRedactorProviderArgumentTitle,
-        messageFormat: Resources.MissingRedactorProviderArgumentMessage,
+        title: Resources.MissingRedactorProviderParameterTitle,
+        messageFormat: Resources.MissingRedactorProviderParameterMessage,
         category: Category);
 
-    public static DiagnosticDescriptor MissingDataClassificationArgument { get; } = Make(
+    public static DiagnosticDescriptor MissingDataClassificationParameter { get; } = Make(
         id: "R9G022",
-        title: Resources.MissingDataClassificationArgumentTitle,
-        messageFormat: Resources.MissingDataClassificationArgumentMessage,
+        title: Resources.MissingDataClassificationParameterTitle,
+        messageFormat: Resources.MissingDataClassificationParameterMessage,
         category: Category,
         DiagnosticSeverity.Warning);
 

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/ParsingUtilities.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/ParsingUtilities.cs
@@ -13,7 +13,7 @@ using Microsoft.Gen.Shared;
 
 namespace Microsoft.Gen.Logging.Parsing;
 
-internal static class LogParserUtilities
+internal static class ParsingUtilities
 {
     private static readonly HashSet<TypeKind> _allowedParameterTypeKinds = new() { TypeKind.Class, TypeKind.Struct, TypeKind.Interface };
 
@@ -41,7 +41,7 @@ internal static class LogParserUtilities
         return false;
     }
 
-    internal static bool ImplementsIFormatable(ITypeSymbol sym, SymbolHolder symbols)
+    internal static bool ImplementsIFormattable(ITypeSymbol sym, SymbolHolder symbols)
     {
         foreach (var member in sym.GetMembers("ToString"))
         {
@@ -178,7 +178,7 @@ internal static class LogParserUtilities
         Dictionary<LoggingMethodParameter, IParameterSymbol> parameterSymbols)
     {
         var names = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var parameter in lm.AllParameters)
+        foreach (var parameter in lm.Parameters)
         {
             var parameterName = lm.GetParameterNameInTemplate(parameter);
             if (!names.Add(parameterName))
@@ -319,7 +319,7 @@ internal static class LogParserUtilities
 
                     bool isEnumerable = IsEnumerable(propertyType, symbols);
                     bool implementsIConvertible = ImplementsIConvertible(propertyType, symbols);
-                    bool implementsIFormatable = ImplementsIFormatable(propertyType, symbols);
+                    bool implementsIFormattable = ImplementsIFormattable(propertyType, symbols);
 
                     bool propertyHasComplexType =
 #pragma warning disable CA1508 // Avoid dead conditional code
@@ -384,7 +384,7 @@ internal static class LogParserUtilities
                         propertyType.IsReferenceType,
                         isEnumerable,
                         implementsIConvertible,
-                        implementsIFormatable,
+                        implementsIFormattable,
                         transitiveMembers);
 
                     result.Add(propertyToLog);

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.Designer.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Gen.Logging {
+namespace Microsoft.Gen.Logging.Parsing {
     using System;
     
     
@@ -61,24 +61,6 @@ namespace Microsoft.Gen.Logging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter &quot;{0}&quot; is not referenced from the logging message.
-        /// </summary>
-        internal static string ArgumentHasNoCorrespondingTemplateMessage {
-            get {
-                return ResourceManager.GetString("ArgumentHasNoCorrespondingTemplateMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A parameter isn&apos;t referenced from the logging message.
-        /// </summary>
-        internal static string ArgumentHasNoCorrespondingTemplateTitle {
-            get {
-                return ResourceManager.GetString("ArgumentHasNoCorrespondingTemplateTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Logging method &quot;{0}&quot; doesn&apos;t have anything to be logged.
         /// </summary>
         internal static string EmptyLoggingMethodMessage {
@@ -93,42 +75,6 @@ namespace Microsoft.Gen.Logging {
         internal static string EmptyLoggingMethodTitle {
             get {
                 return ResourceManager.GetString("EmptyLoggingMethodTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Logging method names can&apos;t start with _.
-        /// </summary>
-        internal static string InvalidLoggingMethodNameMessage {
-            get {
-                return ResourceManager.GetString("InvalidLoggingMethodNameMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Logging method names can&apos;t start with an underscore.
-        /// </summary>
-        internal static string InvalidLoggingMethodNameTitle {
-            get {
-                return ResourceManager.GetString("InvalidLoggingMethodNameTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Logging method parameter names cannot start with _.
-        /// </summary>
-        internal static string InvalidLoggingMethodParameterNameMessage {
-            get {
-                return ResourceManager.GetString("InvalidLoggingMethodParameterNameMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Logging method parameter names can&apos;t start with an underscore.
-        /// </summary>
-        internal static string InvalidLoggingMethodParameterNameTitle {
-            get {
-                return ResourceManager.GetString("InvalidLoggingMethodParameterNameTitle", resourceCulture);
             }
         }
         
@@ -423,36 +369,18 @@ namespace Microsoft.Gen.Logging {
         /// <summary>
         ///   Looks up a localized string similar to One or more parameters of the logging method &quot;{0}&quot; must be annotated with a data classification attribute.
         /// </summary>
-        internal static string MissingDataClassificationArgumentMessage {
+        internal static string MissingDataClassificationParameterMessage {
             get {
-                return ResourceManager.GetString("MissingDataClassificationArgumentMessage", resourceCulture);
+                return ResourceManager.GetString("MissingDataClassificationParameterMessage", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Logging method parameters must be annotated with a data classification attribute.
         /// </summary>
-        internal static string MissingDataClassificationArgumentTitle {
+        internal static string MissingDataClassificationParameterTitle {
             get {
-                return ResourceManager.GetString("MissingDataClassificationArgumentTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to One of the parameters to a static logging method must implement the &quot;Microsoft.Extensions.Logging.ILogger&quot; interface.
-        /// </summary>
-        internal static string MissingLoggerArgumentMessage {
-            get {
-                return ResourceManager.GetString("MissingLoggerArgumentMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A static logging method must have a parameter that implements the &quot;Microsoft.Extensions.Logging.ILogger&quot; interface.
-        /// </summary>
-        internal static string MissingLoggerArgumentTitle {
-            get {
-                return ResourceManager.GetString("MissingLoggerArgumentTitle", resourceCulture);
+                return ResourceManager.GetString("MissingDataClassificationParameterTitle", resourceCulture);
             }
         }
         
@@ -475,6 +403,24 @@ namespace Microsoft.Gen.Logging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to One of the parameters to a static logging method must implement the &quot;Microsoft.Extensions.Logging.ILogger&quot; interface.
+        /// </summary>
+        internal static string MissingLoggerParameterMessage {
+            get {
+                return ResourceManager.GetString("MissingLoggerParameterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A static logging method must have a parameter that implements the &quot;Microsoft.Extensions.Logging.ILogger&quot; interface.
+        /// </summary>
+        internal static string MissingLoggerParameterTitle {
+            get {
+                return ResourceManager.GetString("MissingLoggerParameterTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A &quot;LogLevel&quot; value must be supplied in the &quot;LoggerMethod&quot; attribute or as a parameter to the logging method.
         /// </summary>
         internal static string MissingLogLevelMessage {
@@ -493,24 +439,6 @@ namespace Microsoft.Gen.Logging {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One of the parameters to a logging method that performs redaction must implement the Microsoft.Extensions.Redaction.IRedactorProvider interface.
-        /// </summary>
-        internal static string MissingRedactorProviderArgumentMessage {
-            get {
-                return ResourceManager.GetString("MissingRedactorProviderArgumentMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A parameter to a logging method must implement the &quot;IRedactorProvider&quot; interface.
-        /// </summary>
-        internal static string MissingRedactorProviderArgumentTitle {
-            get {
-                return ResourceManager.GetString("MissingRedactorProviderArgumentTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t find a field of type &quot;Microsoft.Extensions.Redaction.IRedactorProvider&quot; in type &quot;{0}&quot;.
         /// </summary>
         internal static string MissingRedactorProviderFieldMessage {
@@ -525,6 +453,24 @@ namespace Microsoft.Gen.Logging {
         internal static string MissingRedactorProviderFieldTitle {
             get {
                 return ResourceManager.GetString("MissingRedactorProviderFieldTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One of the parameters to a logging method that performs redaction must implement the Microsoft.Extensions.Redaction.IRedactorProvider interface.
+        /// </summary>
+        internal static string MissingRedactorProviderParameterMessage {
+            get {
+                return ResourceManager.GetString("MissingRedactorProviderParameterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A parameter to a logging method must implement the &quot;IRedactorProvider&quot; interface.
+        /// </summary>
+        internal static string MissingRedactorProviderParameterTitle {
+            get {
+                return ResourceManager.GetString("MissingRedactorProviderParameterTitle", resourceCulture);
             }
         }
         
@@ -597,6 +543,24 @@ namespace Microsoft.Gen.Logging {
         internal static string MultipleRedactorProviderFieldsTitle {
             get {
                 return ResourceManager.GetString("MultipleRedactorProviderFieldsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter &quot;{0}&quot; is not referenced from the logging message.
+        /// </summary>
+        internal static string ParameterHasNoCorrespondingTemplateMessage {
+            get {
+                return ResourceManager.GetString("ParameterHasNoCorrespondingTemplateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A parameter isn&apos;t referenced from the logging message.
+        /// </summary>
+        internal static string ParameterHasNoCorrespondingTemplateTitle {
+            get {
+                return ResourceManager.GetString("ParameterHasNoCorrespondingTemplateTitle", resourceCulture);
             }
         }
         
@@ -711,18 +675,18 @@ namespace Microsoft.Gen.Logging {
         /// <summary>
         ///   Looks up a localized string similar to Template &quot;{0}&quot; is not provided as parameter to the logging method.
         /// </summary>
-        internal static string TemplateHasNoCorrespondingArgumentMessage {
+        internal static string TemplateHasNoCorrespondingParameterMessage {
             get {
-                return ResourceManager.GetString("TemplateHasNoCorrespondingArgumentMessage", resourceCulture);
+                return ResourceManager.GetString("TemplateHasNoCorrespondingParameterMessage", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The logging template has no corresponding method parameter.
         /// </summary>
-        internal static string TemplateHasNoCorrespondingArgumentTitle {
+        internal static string TemplateHasNoCorrespondingParameterTitle {
             get {
-                return ResourceManager.GetString("TemplateHasNoCorrespondingArgumentTitle", resourceCulture);
+                return ResourceManager.GetString("TemplateHasNoCorrespondingParameterTitle", resourceCulture);
             }
         }
         

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.resx
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.resx
@@ -117,18 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="InvalidLoggingMethodNameTitle" xml:space="preserve">
-    <value>Logging method names can't start with an underscore</value>
-  </data>
-  <data name="InvalidLoggingMethodNameMessage" xml:space="preserve">
-    <value>Logging method names can't start with _</value>
-  </data>
-  <data name="InvalidLoggingMethodParameterNameTitle" xml:space="preserve">
-    <value>Logging method parameter names can't start with an underscore</value>
-  </data>
-  <data name="InvalidLoggingMethodParameterNameMessage" xml:space="preserve">
-    <value>Logging method parameter names cannot start with _</value>
-  </data>
   <data name="MissingRequiredTypeTitle" xml:space="preserve">
     <value>Couldn't find a required type definition</value>
   </data>
@@ -147,10 +135,10 @@
   <data name="LoggingMethodMustReturnVoidMessage" xml:space="preserve">
     <value>Logging methods must return void</value>
   </data>
-  <data name="MissingLoggerArgumentTitle" xml:space="preserve">
+  <data name="MissingLoggerParameterTitle" xml:space="preserve">
     <value>A static logging method must have a parameter that implements the "Microsoft.Extensions.Logging.ILogger" interface</value>
   </data>
-  <data name="MissingLoggerArgumentMessage" xml:space="preserve">
+  <data name="MissingLoggerParameterMessage" xml:space="preserve">
     <value>One of the parameters to a static logging method must implement the "Microsoft.Extensions.Logging.ILogger" interface</value>
   </data>
   <data name="LoggingMethodShouldBeStaticTitle" xml:space="preserve">
@@ -183,16 +171,16 @@
   <data name="RedundantQualifierInMessageTitle" xml:space="preserve">
     <value>Redundant qualifier in the logging message</value>
   </data>
-  <data name="ArgumentHasNoCorrespondingTemplateMessage" xml:space="preserve">
+  <data name="ParameterHasNoCorrespondingTemplateMessage" xml:space="preserve">
     <value>Parameter "{0}" is not referenced from the logging message</value>
   </data>
-  <data name="ArgumentHasNoCorrespondingTemplateTitle" xml:space="preserve">
+  <data name="ParameterHasNoCorrespondingTemplateTitle" xml:space="preserve">
     <value>A parameter isn't referenced from the logging message</value>
   </data>
-  <data name="TemplateHasNoCorrespondingArgumentMessage" xml:space="preserve">
+  <data name="TemplateHasNoCorrespondingParameterMessage" xml:space="preserve">
     <value>Template "{0}" is not provided as parameter to the logging method</value>
   </data>
-  <data name="TemplateHasNoCorrespondingArgumentTitle" xml:space="preserve">
+  <data name="TemplateHasNoCorrespondingParameterTitle" xml:space="preserve">
     <value>The logging template has no corresponding method parameter</value>
   </data>
   <data name="LoggingMethodHasBodyTitle" xml:space="preserve">
@@ -237,16 +225,16 @@
   <data name="MultipleDataClassificationAttributesTitle" xml:space="preserve">
     <value>Can't have multiple data classification attributes for a single data value</value>
   </data>
-  <data name="MissingRedactorProviderArgumentMessage" xml:space="preserve">
+  <data name="MissingRedactorProviderParameterMessage" xml:space="preserve">
     <value>One of the parameters to a logging method that performs redaction must implement the Microsoft.Extensions.Redaction.IRedactorProvider interface</value>
   </data>
-  <data name="MissingRedactorProviderArgumentTitle" xml:space="preserve">
+  <data name="MissingRedactorProviderParameterTitle" xml:space="preserve">
     <value>A parameter to a logging method must implement the "IRedactorProvider" interface</value>
   </data>
-  <data name="MissingDataClassificationArgumentMessage" xml:space="preserve">
+  <data name="MissingDataClassificationParameterMessage" xml:space="preserve">
     <value>One or more parameters of the logging method "{0}" must be annotated with a data classification attribute</value>
   </data>
-  <data name="MissingDataClassificationArgumentTitle" xml:space="preserve">
+  <data name="MissingDataClassificationParameterTitle" xml:space="preserve">
     <value>Logging method parameters must be annotated with a data classification attribute</value>
   </data>
   <data name="MissingRedactorProviderFieldMessage" xml:space="preserve">

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
@@ -78,27 +78,6 @@ internal static class SymbolLoader
             return null;
         }
 
-        var logMethodHelperSymbol = compilation.GetTypeByMetadataName(LogMethodHelper);
-        var enrichmentPropBagSymbol = compilation.GetTypeByMetadataName(IEnrichmentPropertyBag);
-
-        if (logMethodHelperSymbol != null)
-        {
-            bool found = false;
-            foreach (var iface in logMethodHelperSymbol.Interfaces)
-            {
-                if (SymbolEqualityComparer.Default.Equals(iface, enrichmentPropBagSymbol))
-                {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found)
-            {
-                logMethodHelperSymbol = null;
-            }
-        }
-
         var redactorProviderSymbol = compilation.GetTypeByMetadataName(IRedactorProviderType);
         var enumerableSymbol = compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
         var formatProviderSymbol = compilation.GetTypeByMetadataName(IFormatProviderType)!;

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/TemplateExtractor.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/TemplateExtractor.cs
@@ -13,7 +13,7 @@ internal static class TemplateExtractor
     /// <summary>
     /// Finds the template arguments contained in the message string.
     /// </summary>
-    internal static void ExtractTemplates(string? message, IDictionary<string, string> templateMap, out ICollection<string> templatesWithAtSymbol)
+    internal static void ExtractTemplates(string? message, IDictionary<string, string> templateToParameterName, out ICollection<string> templatesWithAtSymbol)
     {
         if (string.IsNullOrEmpty(message))
         {
@@ -46,7 +46,7 @@ internal static class TemplateExtractor
                     templateName = templateName.Substring(1);
                 }
 
-                templateMap[templateName] = templateName;
+                templateToParameterName[templateName] = templateName;
                 scanIndex = closeBraceIndex + 1;
             }
         }

--- a/src/Generators/Microsoft.Gen.Metering/Microsoft.Gen.Metering.csproj
+++ b/src/Generators/Microsoft.Gen.Metering/Microsoft.Gen.Metering.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
   </ItemGroup>

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/SignatureTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/SignatureTestExtensions.cs
@@ -16,6 +16,10 @@ namespace TestClasses
         // optional parameter
         [LogMethod(1, LogLevel.Debug, "{p1} {p2}")]
         internal static partial void M2(ILogger logger, string p1, string p2 = "World");
+
+        // parameter name potentially conflicting with generated symbol name
+        [LogMethod(2, LogLevel.Debug, "{helper}")]
+        internal static partial void M3(ILogger logger, string helper);
     }
 
     // test that particular method signature variations are generated correctly

--- a/test/Generators/Microsoft.Gen.Logging/Unit/AttributeParserTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/AttributeParserTests.cs
@@ -154,7 +154,7 @@ public class AttributeParserTests
             ");
 
         _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingLoggerArgument.Id, diagnostics[0].Id);
+        Assert.Equal(DiagDescriptors.MissingLoggerParameter.Id, diagnostics[0].Id);
     }
 
     [Theory]
@@ -169,7 +169,7 @@ public class AttributeParserTests
             }}");
 
         _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingRedactorProviderArgument.Id, diagnostics[0].Id);
+        Assert.Equal(DiagDescriptors.MissingRedactorProviderParameter.Id, diagnostics[0].Id);
     }
 
     [Theory]
@@ -231,7 +231,7 @@ public class AttributeParserTests
             ");
 
         _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingDataClassificationArgument.Id, diagnostics[0].Id);
+        Assert.Equal(DiagDescriptors.MissingDataClassificationParameter.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -261,7 +261,7 @@ public class AttributeParserTests
             }");
 
         var diagnostic = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingDataClassificationArgument.Id, diagnostic.Id);
+        Assert.Equal(DiagDescriptors.MissingDataClassificationParameter.Id, diagnostic.Id);
     }
 
     [Theory]

--- a/test/Generators/Microsoft.Gen.Logging/Unit/EmitterUtilsTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/EmitterUtilsTests.cs
@@ -43,13 +43,13 @@ public class EmitterUtilsTests
         var publicDataFullName = typeof(PublicDataAttribute).FullName!;
 
         var lm = new LoggingMethod();
-        lm.AllParameters.Add(new LoggingMethodParameter
+        lm.Parameters.Add(new LoggingMethodParameter
         {
             LogPropertiesProvider = new LoggingPropertyProvider(string.Empty, string.Empty),
             PropertiesToLog = new List<LoggingProperty> { new LoggingProperty("a", "b", publicDataFullName, false, false, false, false, false, false, Array.Empty<LoggingProperty>()) }
         });
 
-        lm.AllParameters.Add(new LoggingMethodParameter
+        lm.Parameters.Add(new LoggingMethodParameter
         {
             LogPropertiesProvider = null,
             PropertiesToLog = new List<LoggingProperty> { new LoggingProperty("c", "d", publicDataFullName, false, false, false, false, false, false, Array.Empty<LoggingProperty>()) }
@@ -80,7 +80,7 @@ public class EmitterUtilsTests
             Level = null
         };
 
-        lm.AllParameters.Add(new LoggingMethodParameter
+        lm.Parameters.Add(new LoggingMethodParameter
         {
             IsLogLevel = true,
             Name = ParamName

--- a/test/Generators/Microsoft.Gen.Logging/Unit/LogParserUtilitiesTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/LogParserUtilitiesTests.cs
@@ -38,7 +38,7 @@ public class LogParserUtilitiesTests
         };
 
         var diagMock = new Mock<Action<DiagnosticDescriptor, Location?, object?[]?>>();
-        var result = LogParserUtilities.ProcessLogPropertiesForParameter(null!, null!, loggerParameter, paramSymbolMock.Object, null!, diagMock.Object, null!, CancellationToken.None);
+        var result = ParsingUtilities.ProcessLogPropertiesForParameter(null!, null!, loggerParameter, paramSymbolMock.Object, null!, diagMock.Object, null!, CancellationToken.None);
 
         Assert.True(result == LogPropertiesProcessingResult.Fail);
         diagMock.Verify(
@@ -66,7 +66,7 @@ public class LogParserUtilitiesTests
             .Returns(paramTypeMock.Object);
 
         var diagMock = new Mock<Action<DiagnosticDescriptor, Location?, object?[]?>>();
-        var result = LogParserUtilities.ProcessLogPropertiesForParameter(null!, null!, new LoggingMethodParameter(), paramSymbolMock.Object, null!, diagMock.Object, null!, CancellationToken.None);
+        var result = ParsingUtilities.ProcessLogPropertiesForParameter(null!, null!, new LoggingMethodParameter(), paramSymbolMock.Object, null!, diagMock.Object, null!, CancellationToken.None);
 
         Assert.True(result == LogPropertiesProcessingResult.Fail);
         diagMock.Verify(
@@ -114,7 +114,7 @@ public class LogParserUtilitiesTests
         symbolMock.Setup(x => x.GetAttributes())
             .Returns(new[] { attributeMock.Object }.ToImmutableArray());
 
-        var result = LogParserUtilities.GetDataClassificationAttributes(symbolMock.Object, null!);
+        var result = ParsingUtilities.GetDataClassificationAttributes(symbolMock.Object, null!);
         Assert.Empty(result);
     }
 
@@ -129,7 +129,7 @@ public class LogParserUtilitiesTests
         properySymbol.SetupGet(x => x.DeclaringSyntaxReferences)
             .Returns(new[] { Mock.Of<SyntaxReference>() }.ToImmutableArray());
 
-        var identifier = LogParserUtilities.GetPropertyIdentifier(properySymbol.Object, CancellationToken.None);
+        var identifier = ParsingUtilities.GetPropertyIdentifier(properySymbol.Object, CancellationToken.None);
         Assert.Equal(PropertyName, identifier);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Unit/LoggingMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/LoggingMethodTests.cs
@@ -32,8 +32,8 @@ public class LoggingMethodTests
     {
         var p = new LoggingMethodParameter { Name = "paramName" };
         var method = new LoggingMethod();
-        method.TemplateMap[p.Name] = "Name from the map";
+        method.TemplateToParameterName[p.Name] = "Name from the map";
 
-        Assert.Equal(method.TemplateMap[p.Name], method.GetParameterNameInTemplate(p));
+        Assert.Equal(method.TemplateToParameterName[p.Name], method.GetParameterNameInTemplate(p));
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.LogProperties.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.LogProperties.cs
@@ -646,7 +646,7 @@ public partial class ParserTests
                 static partial void M/*0+*/(ILogger logger, [LogProperties] MyClass param)/*-0*/;
             }}";
 
-        await RunGenerator(source, DiagDescriptors.MissingRedactorProviderArgument);
+        await RunGenerator(source, DiagDescriptors.MissingRedactorProviderParameter);
     }
 
     [Theory]

--- a/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.cs
@@ -131,17 +131,17 @@ public partial class ParserTests
     }
 
     [Fact]
-    public async Task InvalidMethodName()
+    public async Task UnderscoresInMethodName()
     {
         const string Source = @"
                 partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M1"")]
-                    static partial void /*0+*/__M1/*-0*/(ILogger logger);
+                    static partial void __M1(ILogger logger);
                 }
             ";
 
-        await RunGenerator(Source, DiagDescriptors.InvalidLoggingMethodName);
+        await RunGenerator(Source);
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public partial class ParserTests
                 }
             ";
 
-        await RunGenerator(Source, DiagDescriptors.ArgumentHasNoCorrespondingTemplate);
+        await RunGenerator(Source, DiagDescriptors.ParameterHasNoCorrespondingTemplate);
     }
 
     [Fact]
@@ -215,7 +215,7 @@ public partial class ParserTests
                 }
             ";
 
-        await RunGenerator(Source, DiagDescriptors.TemplateHasNoCorrespondingArgument);
+        await RunGenerator(Source, DiagDescriptors.TemplateHasNoCorrespondingParameter);
     }
 
     [Theory]
@@ -317,17 +317,17 @@ public partial class ParserTests
     [InlineData("_foo")]
     [InlineData("__foo")]
     [InlineData("@_foo", "_foo")]
-    public async Task InvalidParameterName(string name, string? template = null)
+    public async Task UnderscoresInParameterName(string name, string? template = null)
     {
         string source = @$"
                 partial class C
                 {{
                     [LogMethod(0, LogLevel.Debug, ""M1 {{{template ?? name}}}"")]
-                    static partial void M1(ILogger logger, string /*0+*/{name}/*-0*/);
+                    static partial void M1(ILogger logger, string {name});
                 }}
             ";
 
-        await RunGenerator(source, DiagDescriptors.InvalidLoggingMethodParameterName);
+        await RunGenerator(source);
     }
 
     [Fact]
@@ -493,7 +493,7 @@ public partial class ParserTests
                 }
             ";
 
-        await RunGenerator(Source, DiagDescriptors.MissingLoggerArgument);
+        await RunGenerator(Source, DiagDescriptors.MissingLoggerParameter);
     }
 
     [Fact]
@@ -580,7 +580,7 @@ public partial class ParserTests
                 public partial void /*3+*/M4/*-3*/(IRedactorProvider provider);
             }";
 
-        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod, ignoreDiag: DiagDescriptors.MissingDataClassificationArgument);
+        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod, ignoreDiag: DiagDescriptors.MissingDataClassificationParameter);
     }
 
     [Fact]
@@ -604,7 +604,7 @@ public partial class ParserTests
                 public static partial void /*3+*/M4/*-3*/(ILogger logger, IRedactorProvider provider);
             }";
 
-        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod, ignoreDiag: DiagDescriptors.MissingDataClassificationArgument);
+        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod, ignoreDiag: DiagDescriptors.MissingDataClassificationParameter);
     }
 
     [Fact]


### PR DESCRIPTION
- Remove constraints about not starting log method names or log method parameters with _, the code now dynamically picks non-conflicting symbol names. There's still a potential conflict with the name of redactor instances, but I'll be removing all those in my follow-on PR.

- Simplified logic around handling of template parameters. I couldn't figure out what the code was doing, so it needed a bit of cleanup.

- Remove some dead code I stumbled on.

- Fix broken .resx file handling in the generators, I messed that up when simplifying the Roslyn dependencies last week.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4227)