### PR TITLE
Enable CS1591 errors for undocumented API

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,8 @@
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <!-- Enabling this rule will cause build failures on undocumented public APIs. -->
+    <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>
   </PropertyGroup>
   <!--
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HttpClientBuilderExtensions.Hedging.cs
@@ -14,6 +14,9 @@ using Polly;
 
 namespace Microsoft.Extensions.Http.Resilience;
 
+/// <summary>
+/// Extensions for <see cref="IHttpClientBuilder"/>.
+/// </summary>
 public static partial class HttpClientBuilderExtensions
 {
     internal const string StandardInnerHandlerPostfix = "standard-hedging-endpoint";

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/HttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/HttpClientBuilderExtensions.Resilience.cs
@@ -15,6 +15,9 @@ using Polly.Registry;
 
 namespace Microsoft.Extensions.Http.Resilience;
 
+/// <summary>
+/// Extensions for <see cref="IHttpClientBuilder"/>.
+/// </summary>
 public static partial class HttpClientBuilderExtensions
 {
     /// <summary>


### PR DESCRIPTION
Arcade by default NoWarns CS1591 errors. While that default is questionable, our team added a condition to not suppress that compiler error. Use that to enable CS1591 errors.

... and document the HttpClientBuilderExtensions class that was missing a class summary.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4230)