### PR TITLE
Few logging fixes before the new code generator comes in.

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ModernCodeGen.cs
+++ b/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ModernCodeGen.cs
@@ -12,7 +12,7 @@ internal static class ModernCodeGen
     public static void RefTypes(global::Microsoft.Extensions.Logging.ILogger logger, string connectionId, string type, string streamId, string length, string flags, string other)
     {
         var state = global::Microsoft.Extensions.Telemetry.Logging.LoggerMessageHelper.ThreadLocalState;
-        var index = state.EnsurePropertySpace(7);
+        var index = state.ReservePropertySpace(7);
         var array = state.PropertyArray;
         array[index++] = new("connectionId", connectionId);
         array[index++] = new("type", type);
@@ -49,7 +49,7 @@ internal static class ModernCodeGen
     public static void ValueTypes(global::Microsoft.Extensions.Logging.ILogger logger, long start, long end, int options, global::System.Guid guid)
     {
         var state = global::Microsoft.Extensions.Telemetry.Logging.LoggerMessageHelper.ThreadLocalState;
-        var index = state.EnsurePropertySpace(5);
+        var index = state.ReservePropertySpace(5);
         var array = state.PropertyArray;
         array[index++] = new("start", start);
         array[index++] = new("end", end);

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.EnrichmentPropertyBag.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.EnrichmentPropertyBag.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System;
+using Microsoft.Extensions.Compliance.Classification;
+using Microsoft.Extensions.Telemetry.Enrichment;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.Telemetry.Logging;
+
+public partial class LoggerMessageState : IEnrichmentPropertyBag
+{
+    /// <inheritdoc/>
+    void IEnrichmentPropertyBag.Add(string key, object value)
+    {
+        AddProperty(key, value);
+    }
+
+    /// <inheritdoc/>
+    void IEnrichmentPropertyBag.Add(string key, string value)
+    {
+        AddProperty(key, value);
+    }
+
+    /// <inheritdoc/>
+    void IEnrichmentPropertyBag.Add(ReadOnlySpan<KeyValuePair<string, object>> properties)
+    {
+        foreach (var p in properties)
+        {
+            AddProperty(p.Key, p.Value);
+        }
+    }
+
+    /// <inheritdoc/>
+    void IEnrichmentPropertyBag.Add(ReadOnlySpan<KeyValuePair<string, string>> properties)
+    {
+        foreach (var p in properties)
+        {
+            AddProperty(p.Key, p.Value);
+        }
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.PropertyCollector.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.PropertyCollector.cs
@@ -10,17 +10,15 @@ public partial class LoggerMessageState : ILogPropertyCollector
     /// <inheritdoc />
     void ILogPropertyCollector.Add(string propertyName, object? propertyValue)
     {
-        string fullName = PropertyNamePrefix.Length > 0 ? PropertyNamePrefix + propertyName : propertyName;
-        var index = EnsurePropertySpace(1);
-        _properties[index] = new(fullName, propertyValue);
+        string fullName = PropertyNamePrefix.Length > 0 ? PropertyNamePrefix + "_" + propertyName : propertyName;
+        AddProperty(fullName, propertyValue);
     }
 
     /// <inheritdoc />
     void ILogPropertyCollector.Add(string propertyName, object? propertyValue, DataClassification classification)
     {
-        string fullName = PropertyNamePrefix.Length > 0 ? PropertyNamePrefix + propertyName : propertyName;
-        var index = EnsureClassifiedPropertySpace(1);
-        _classifiedProperties[index] = new(fullName, propertyValue, classification);
+        string fullName = PropertyNamePrefix.Length > 0 ? PropertyNamePrefix + "_" + propertyName : propertyName;
+        AddClassifiedProperty(fullName, propertyValue, classification);
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Compliance.Classification;
 using Microsoft.Extensions.Logging;
 using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Pools;
@@ -44,7 +45,7 @@ public sealed partial class LoggerMessageState
     /// </summary>
     /// <param name="count">The amount of space to allocate.</param>
     /// <returns>The index in the <see cref="PropertyArray"/> where to store the properties.</returns>
-    public int EnsurePropertySpace(int count)
+    public int ReservePropertySpace(int count)
     {
         int avail = _properties.Length - NumProperties;
         if (count > avail)
@@ -63,7 +64,7 @@ public sealed partial class LoggerMessageState
     /// </summary>
     /// <param name="count">The amount of space to allocate.</param>
     /// <returns>The index in the <see cref="RedactedPropertyArray"/> where to store the properties.</returns>
-    public int EnsureRedactedPropertySpace(int count)
+    public int ReserveRedactedPropertySpace(int count)
     {
         int avail = _redactedProperties.Length - NumRedactedProperties;
         if (count > avail)
@@ -82,7 +83,7 @@ public sealed partial class LoggerMessageState
     /// </summary>
     /// <param name="count">The amount of space to allocate.</param>
     /// <returns>The index in the <see cref="ClassifiedPropertyArray"/> where to store the classified properties.</returns>
-    public int EnsureClassifiedPropertySpace(int count)
+    public int ReserveClassifiedPropertySpace(int count)
     {
         int avail = _classifiedProperties.Length - NumClassifiedProperties;
         if (count > avail)
@@ -94,6 +95,29 @@ public sealed partial class LoggerMessageState
         var index = NumClassifiedProperties;
         NumClassifiedProperties += count;
         return index;
+    }
+
+    /// <summary>
+    /// Adds a property to the array.
+    /// </summary>
+    /// <param name="name">The name of the property.</param>
+    /// <param name="value">The value.</param>
+    public void AddProperty(string name, object? value)
+    {
+        var index = ReservePropertySpace(1);
+        PropertyArray[index] = new(name, value);
+    }
+
+    /// <summary>
+    /// Adds a classified property to the array.
+    /// </summary>
+    /// <param name="name">The name of the property.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="classification">The data classification of the property.</param>
+    public void AddClassifiedProperty(string name, object? value, DataClassification classification)
+    {
+        var index = ReserveClassifiedPropertySpace(1);
+        ClassifiedPropertyArray[index] = new(name, value, classification);
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/JustInTimeRedactor.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/JustInTimeRedactor.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Extensions.Telemetry.Logging;
 internal sealed class JustInTimeRedactor : IResettable
 #if NET6_0_OR_GREATER
     , ISpanFormattable
+#else
+    , IFormattable
 #endif
 {
     public static JustInTimeRedactor Get() => _pool.Get();

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Logging/ExtendedLoggerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Logging/ExtendedLoggerTests.cs
@@ -59,11 +59,12 @@ public static class ExtendedLoggerTests
         logger.Log(LogLevel.Error, new EventId(1, "ID1"), lmh, null, (_, _) => "MSG1");
 
         var lms = LoggerMessageHelper.ThreadLocalState;
-        var index = lms.EnsurePropertySpace(1);
+        var index = lms.ReservePropertySpace(1);
         lms.PropertyArray[index] = new("PK2", "PV2");
 
-        index = lms.EnsureClassifiedPropertySpace(1);
+        index = lms.ReserveClassifiedPropertySpace(2);
         lms.ClassifiedPropertyArray[index] = new("PK3", "PV3", SimpleClassifications.PrivateData);
+        lms.ClassifiedPropertyArray[index + 1] = new("PK4", null, SimpleClassifications.PrivateData);
 
         logger.Log(LogLevel.Warning, new EventId(2, "ID2"), lms, null, (_, _) => "MSG2");
 
@@ -95,6 +96,7 @@ public static class ExtendedLoggerTests
         Assert.Equal("MSG2", snap[2].Message);
         Assert.Equal("PV2", snap[2].StructuredState!.GetValue("PK2"));
         Assert.Equal("REDACTED<PV3>", snap[2].StructuredState!.GetValue("PK3"));
+        Assert.Null(snap[2].StructuredState!.GetValue("PK4"));
         Assert.Equal("EV1", snap[2].StructuredState!.GetValue("EK1"));
         Assert.Equal("SEV1", snap[2].StructuredState!.GetValue("SEK1"));
     }
@@ -132,7 +134,7 @@ public static class ExtendedLoggerTests
         logger.Log(LogLevel.Error, new EventId(1, "ID1"), lmh, null, (_, _) => "MSG1");
 
         var lms = LoggerMessageHelper.ThreadLocalState;
-        var index = lms.EnsurePropertySpace(1);
+        var index = lms.ReservePropertySpace(1);
         lms.PropertyArray[index] = new("PK2", "PV2");
         logger.Log(LogLevel.Warning, new EventId(2, "ID2"), lms, null, (_, _) => "MSG2");
 


### PR DESCRIPTION
- Implement IEnrichmentPropertyBag on LoggerMessageState to allow more efficient use in the HttpClient logging paths.

- Fix handling of redaction of null values in the extended logger. It was returning "" instead of null in that case.

- Add a few utility functions to LoggerMessageState to make code gen nicer.

- Fix missing _ separator in the implementation of ILogPropertyCollector in LoggerMessageState.