### PR TITLE
Revamp the logging generator to use the new redaction model.

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ClassicCodeGen.cs
+++ b/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ClassicCodeGen.cs
@@ -6,11 +6,34 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Telemetry.Bench;
 
-internal static partial class ClassicCodeGen
-{
-    [LoggerMessage(LogLevel.Error, @"Connection id '{connectionId}' received {type} frame for stream ID {streamId} with length {length} and flags {flags} and {other}")]
-    public static partial void RefTypes(ILogger logger, string connectionId, string type, string streamId, string length, string flags, string other);
+#pragma warning disable S103
+#pragma warning disable SA1121
+#pragma warning disable S2148
+#pragma warning disable IDE0055
+#pragma warning disable IDE1006
+#pragma warning disable S3235
 
-    [LoggerMessage(LogLevel.Error, @"Range [{start}..{end}], options {options}, guid {guid}")]
-    public static partial void ValueTypes(ILogger logger, long start, long end, int options, Guid guid);
+internal static class ClassicCodeGen
+{
+    private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::System.String, global::System.String, global::System.String, global::System.String, global::System.String, global::System.String, global::System.Exception?> __RefTypesCallback =
+        global::Microsoft.Extensions.Logging.LoggerMessage.Define<global::System.String, global::System.String, global::System.String, global::System.String, global::System.String, global::System.String>(global::Microsoft.Extensions.Logging.LogLevel.Error, new global::Microsoft.Extensions.Logging.EventId(2037881459, nameof(RefTypes)), "Connection id '{connectionId}' received {type} frame for stream ID {streamId} with length {length} and flags {flags} and {other}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true }); 
+
+    public static void RefTypes(global::Microsoft.Extensions.Logging.ILogger logger, global::System.String connectionId, global::System.String type, global::System.String streamId, global::System.String length, global::System.String flags, global::System.String other)
+    {
+        if (logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Error))
+        {
+            __RefTypesCallback(logger, connectionId, type, streamId, length, flags, other, null);
+        }
+    }
+
+    private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::System.Int64, global::System.Int64, global::System.Int32, global::System.Guid, global::System.Exception?> __ValueTypesCallback =
+        global::Microsoft.Extensions.Logging.LoggerMessage.Define<global::System.Int64, global::System.Int64, global::System.Int32, global::System.Guid>(global::Microsoft.Extensions.Logging.LogLevel.Error, new global::Microsoft.Extensions.Logging.EventId(558429541, nameof(ValueTypes)), "Range [{start}..{end}], options {options}, guid {guid}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true }); 
+
+    public static void ValueTypes(global::Microsoft.Extensions.Logging.ILogger logger, global::System.Int64 start, global::System.Int64 end, global::System.Int32 options, global::System.Guid guid)
+    {
+        if (logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Error))
+        {
+            __ValueTypesCallback(logger, start, end, options, guid, null);
+        }
+    }
 }

--- a/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ModernCodeGen.cs
+++ b/bench/Libraries/Microsoft.Extensions.Telemetry.PerformanceTests/ModernCodeGen.cs
@@ -12,35 +12,33 @@ internal static class ModernCodeGen
     public static void RefTypes(global::Microsoft.Extensions.Logging.ILogger logger, string connectionId, string type, string streamId, string length, string flags, string other)
     {
         var state = global::Microsoft.Extensions.Telemetry.Logging.LoggerMessageHelper.ThreadLocalState;
-        var index = state.ReservePropertySpace(7);
-        var array = state.PropertyArray;
-        array[index++] = new("connectionId", connectionId);
-        array[index++] = new("type", type);
-        array[index++] = new("streamId", streamId);
-        array[index++] = new("length", length);
-        array[index++] = new("flags", flags);
-        array[index++] = new("other", other);
-        array[index] = new("{OriginalFormat}", "Connection id '{connectionId}' received {type} frame for stream ID {streamId} with length {length} and flags {flags} and {other}");
+
+        _ = state.ReservePropertySpace(7);
+        state.PropertyArray[6] = new("connectionId", connectionId);
+        state.PropertyArray[5] = new("type", type);
+        state.PropertyArray[4] = new("streamId", streamId);
+        state.PropertyArray[3] = new("length", length);
+        state.PropertyArray[2] = new("flags", flags);
+        state.PropertyArray[1] = new("other", other);
+        state.PropertyArray[0] = new("{OriginalFormat}", "Connection id '{connectionId}' received {type} frame for stream ID {streamId} with length {length} and flags {flags} and {other}");
 
         logger.Log(
             global::Microsoft.Extensions.Logging.LogLevel.Error,
             new global::Microsoft.Extensions.Logging.EventId(0, nameof(RefTypes)),
             state,
-            null, // Refer to our docs to learn how to pass exception here
-            __FMT_0_RefTypes_Error);
+            null,
+            static (s, _) =>
+            {
+                var connectionId = s.PropertyArray[6].Value ?? "(null)";
+                var type = s.PropertyArray[5].Value ?? "(null)";
+                var streamId = s.PropertyArray[4].Value ?? "(null)";
+                var length = s.PropertyArray[3].Value ?? "(null)";
+                var flags = s.PropertyArray[2].Value ?? "(null)";
+                var other = s.PropertyArray[1].Value ?? "(null)";
+                return global::System.FormattableString.Invariant($"Connection id '{connectionId}' received {type} frame for stream ID {streamId} with length {length} and flags {flags} and {other}");
+            });
 
         state.Clear();
-    }
-
-    private static string __FMT_0_RefTypes_Error(global::Microsoft.Extensions.Telemetry.Logging.LoggerMessageState _h, global::System.Exception? _)
-    {
-        var connectionId = _h.PropertyArray[0].Value ?? "(null)";
-        var type = _h.PropertyArray[1].Value ?? "(null)";
-        var streamId = _h.PropertyArray[2].Value ?? "(null)";
-        var length = _h.PropertyArray[3].Value ?? "(null)";
-        var flags = _h.PropertyArray[4].Value ?? "(null)";
-        var other = _h.PropertyArray[5].Value ?? "(null)";
-        return global::System.FormattableString.Invariant($"Connection id '{connectionId}' received {type} frame for stream ID {streamId} with length {length} and flags {flags} and {other}");
     }
 
     /// <summary>
@@ -49,30 +47,28 @@ internal static class ModernCodeGen
     public static void ValueTypes(global::Microsoft.Extensions.Logging.ILogger logger, long start, long end, int options, global::System.Guid guid)
     {
         var state = global::Microsoft.Extensions.Telemetry.Logging.LoggerMessageHelper.ThreadLocalState;
-        var index = state.ReservePropertySpace(5);
-        var array = state.PropertyArray;
-        array[index++] = new("start", start);
-        array[index++] = new("end", end);
-        array[index++] = new("options", options);
-        array[index++] = new("guid", guid.ToString());
-        array[index] = new("{OriginalFormat}", "Range [{start}..{end}], options {options}, guid {guid}");
+
+        _ = state.ReservePropertySpace(5);
+        state.PropertyArray[4] = new("start", start);
+        state.PropertyArray[3] = new("end", end);
+        state.PropertyArray[2] = new("options", options);
+        state.PropertyArray[1] = new("guid", guid.ToString());
+        state.PropertyArray[0] = new("{OriginalFormat}", "Range [{start}..{end}], options {options}, guid {guid}");
 
         logger.Log(
             global::Microsoft.Extensions.Logging.LogLevel.Error,
             new global::Microsoft.Extensions.Logging.EventId(0, nameof(ValueTypes)),
             state,
-            null, // Refer to our docs to learn how to pass exception here
-            __FMT_2_ValueTypes_Error);
+            null,
+            static (s, _) =>
+            {
+                var start = s.PropertyArray[4].Value;
+                var end = s.PropertyArray[3].Value;
+                var options = s.PropertyArray[2].Value;
+                var guid = s.PropertyArray[1].Value;
+                return global::System.FormattableString.Invariant($"Range [{start}..{end}], options {options}, guid {guid}");
+            });
 
         state.Clear();
-    }
-
-    private static string __FMT_2_ValueTypes_Error(global::Microsoft.Extensions.Telemetry.Logging.LoggerMessageState _h, global::System.Exception? _)
-    {
-        var start = _h.PropertyArray[0].Value;
-        var end = _h.PropertyArray[1].Value;
-        var options = _h.PropertyArray[2].Value;
-        var guid = _h.PropertyArray[3].Value;
-        return global::System.FormattableString.Invariant($"Range [{start}..{end}], options {options}, guid {guid}");
     }
 }

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -20,7 +20,7 @@ internal sealed partial class Emitter : EmitterBase
         string level = GetLoggerMethodLogLevel(lm);
         string extension = lm.IsExtensionMethod ? "this " : string.Empty;
         string eventName = string.IsNullOrWhiteSpace(lm.EventName) ? $"nameof({lm.Name})" : $"\"{lm.EventName}\"";
-        string exceptionArg = GetException(lm);
+        (string exceptionArg, string exceptionLambdaName) = GetException(lm);
         (string logger, bool isNullableLogger) = GetLogger(lm);
 
         if (!lm.HasXmlDocumentation)
@@ -73,122 +73,12 @@ internal sealed partial class Emitter : EmitterBase
             OutLn();
         }
 
-        var redactorProviderAccess = string.Empty;
-        var parametersToRedact = lm.Parameters.Where(lp => lp.ClassificationAttributeType != null);
-        if (parametersToRedact.Any() || logPropsDataClasses.Count > 0)
-        {
-            (string redactorProvider, bool isNullableRedactorProvider) = GetRedactorProvider(lm);
-            if (isNullableRedactorProvider)
-            {
-                redactorProviderAccess = "?";
-            }
+        var stateName = PickUniqueName("state", lm.Parameters.Select(p => p.Name));
 
-            var classifications = parametersToRedact
-                .Select(static p => p.ClassificationAttributeType)
-                .Concat(logPropsDataClasses)
-                .Distinct()
-                .Where(static p => p != null)
-                .Select(static p => p!);
-
-            GenRedactorsFetchingCode(_isRedactorProviderInTheInstance, classifications, redactorProvider, isNullableRedactorProvider);
-            OutLn();
-        }
-
-        Dictionary<LoggingMethodParameter, int> holderMap = new();
-
-        var helperName = PickUniqueName("helper", lm.Parameters.Select(p => p.Name));
-        var tmpName = PickUniqueName("tmp", lm.Parameters.Select(p => p.Name));
-
-        OutLn($"var {helperName} = {LogMethodHelperType}.GetHelper();");
-
-        foreach (var p in lm.Parameters)
-        {
-            if (!p.HasPropsProvider && !p.HasProperties && p.IsNormalParameter)
-            {
-                GenHelperAdd(lm, holderMap, p, redactorProviderAccess, helperName, tmpName);
-            }
-        }
-
-        foreach (var p in lm.Parameters.Where(p => p.UsedAsTemplate))
-        {
-            if (!holderMap.ContainsKey(p))
-            {
-                GenHelperAdd(lm, holderMap, p, redactorProviderAccess, helperName, tmpName);
-            }
-        }
-
-        if (!string.IsNullOrEmpty(lm.Message))
-        {
-            OutLn($"{helperName}.Add(\"{{OriginalFormat}}\", \"{EscapeMessageString(lm.Message)}\");");
-        }
-
-        foreach (var p in lm.Parameters)
-        {
-            if (p.HasPropsProvider)
-            {
-                if (p.OmitParameterName)
-                {
-                    OutLn($"{helperName}.ParameterName = string.Empty;");
-                }
-                else
-                {
-                    OutLn($"{helperName}.ParameterName = nameof({p.NameWithAt});");
-                }
-
-                OutLn($"{p.LogPropertiesProvider!.ContainingType}.{p.LogPropertiesProvider.MethodName}({helperName}, {p.NameWithAt});");
-            }
-            else if (p.HasProperties)
-            {
-                OutLn($"{helperName}.ParameterName = string.Empty;");
-
-                p.TraverseParameterPropertiesTransitively((propertyChain, member) =>
-                {
-                    var propName = PropertyChainToString(propertyChain, member, "_", omitParameterName: p.OmitParameterName);
-                    var accessExpression = PropertyChainToString(propertyChain, member, "?.", nonNullSeparator: ".");
-
-                    var skipNull = p.SkipNullProperties && member.PotentiallyNull
-                        ? $"if ({accessExpression} != null) "
-                        : string.Empty;
-
-                    if (member.ClassificationAttributeType != null)
-                    {
-                        var stringifiedProperty = ConvertPropertyToString(member, accessExpression);
-                        var value = $"_{EncodeTypeName(member.ClassificationAttributeType)}Redactor{redactorProviderAccess}.Redact(global::System.MemoryExtensions.AsSpan({stringifiedProperty}))";
-
-                        if (member.PotentiallyNull)
-                        {
-                            if (p.SkipNullProperties || accessExpression == value)
-                            {
-                                OutLn($"{skipNull}{helperName}.Add(\"{propName}\", {value});");
-                            }
-                            else
-                            {
-                                OutLn($"{helperName}.Add(\"{propName}\", {accessExpression} != null ? {value} : null);");
-                            }
-                        }
-                        else
-                        {
-                            OutLn($"{helperName}.Add(\"{propName}\", {value});");
-                        }
-                    }
-                    else
-                    {
-                        var ts = ShouldStringify(member.Type)
-                            ? ConvertPropertyToString(member, accessExpression)
-                            : accessExpression;
-
-                        var value = member.IsEnumerable
-                            ? $"global::Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.Stringify({accessExpression})"
-                            : ts;
-
-                        OutLn($"{skipNull}{helperName}.Add(\"{propName}\", {value});");
-                    }
-                });
-            }
-        }
+        OutLn($"var {stateName} = {LoggerMessageHelperType}.ThreadLocalState;");
+        GenPropertyLoads(lm, stateName, out int numReservedUnclassifiedProps, out int numReservedClassifiedProps);
 
         OutLn();
-
         OutLn($"{logger}.Log(");
 
         Indent();
@@ -203,15 +93,15 @@ internal sealed partial class Emitter : EmitterBase
             OutLn($"new(0, {eventName}),");
         }
 
-        OutLn($"{helperName},");
+        OutLn($"{stateName},");
         OutLn($"{exceptionArg},");
 
-        var lambdaHelperName = PickUniqueName("helper", lm.TemplateToParameterName.Select(kvp => kvp.Key));
+        var lambdaStateName = PickUniqueName("s", lm.TemplateToParameterName.Select(kvp => kvp.Key));
 
-        OutLn($"static ({lambdaHelperName}, _) =>");
+        OutLn($"static ({lambdaStateName}, {exceptionLambdaName}) =>");
         OutOpenBrace();
 
-        if (GenVariableAssignments(lm, holderMap, lambdaHelperName))
+        if (GenVariableAssignments(lm, lambdaStateName, numReservedUnclassifiedProps, numReservedClassifiedProps))
         {
             var template = EscapeMessageString(lm.Message);
             template = AddAtSymbolsToTemplates(template, lm.Parameters);
@@ -230,8 +120,7 @@ internal sealed partial class Emitter : EmitterBase
         Unindent();
 
         OutLn();
-        OutLn($"{LogMethodHelperType}.ReturnHelper({helperName});");
-
+        OutLn($"{stateName}.Clear();");
         OutCloseBrace();
 
         static bool ShouldStringify(string typeName)
@@ -276,59 +165,299 @@ internal sealed partial class Emitter : EmitterBase
             return $"{arg}{question}.ToString()";
         }
 
-        static string GetException(LoggingMethod lm)
+        static (string exceptionArg, string exceptionLambdaArg) GetException(LoggingMethod lm)
         {
             string exceptionArg = "null";
+            string exceptionLambdaArg = "_";
+
             foreach (var p in lm.Parameters)
             {
                 if (p.IsException)
                 {
                     exceptionArg = p.Name;
+
+                    if (p.UsedAsTemplate)
+                    {
+                        exceptionLambdaArg = lm.GetParameterNameInTemplate(p);
+                    }
+
                     break;
                 }
             }
 
-            return exceptionArg;
+            return (exceptionArg, exceptionLambdaArg);
         }
 
-        bool GenVariableAssignments(LoggingMethod lm, Dictionary<LoggingMethodParameter, int> holderMap, string lambdaHelperName)
+        static bool NeedsASlot(LoggingMethodParameter p)
         {
-            var result = false;
-
-            var templateParameters = lm.Parameters.Where(p => p.UsedAsTemplate).ToArray();
-            foreach (var t in lm.TemplateToParameterName)
+            if (p.UsedAsTemplate && !p.IsException)
             {
-                int index = 0;
-                foreach (var p in templateParameters)
-                {
-                    if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        break;
-                    }
+                return true;
+            }
 
-                    index++;
-                }
+            return p.IsNormalParameter && !p.HasPropsProvider && !p.HasProperties;
+        }
 
-                // check for an index that's too big, this can happen in some cases of malformed input
-                if (index < templateParameters.Length)
+        void GenPropertyLoads(LoggingMethod lm, string stateName, out int numReservedUnclassifiedProps, out int numReservedClassifiedProps)
+        {
+            int numUnclassifiedProps = 0;
+            int numClassifiedProps = 0;
+
+            foreach (var p in lm.Parameters)
+            {
+                if (NeedsASlot(p))
                 {
-                    var parameter = templateParameters[index];
-                    var atSign = parameter.NeedsAtSign ? "@" : string.Empty;
-                    if (parameter.PotentiallyNull)
+                    if (p.ClassificationAttributeType != null)
                     {
-                        const string Null = "\"(null)\"";
-                        OutLn($"var {atSign}{t.Key} = {lambdaHelperName}[{holderMap[parameter]}].Value ?? {Null};");
-                        result = true;
+                        numClassifiedProps++;
                     }
                     else
                     {
-                        OutLn($"var {atSign}{t.Key} = {lambdaHelperName}[{holderMap[parameter]}].Value;");
-                        result = true;
+                        numUnclassifiedProps++;
+                    }
+                }
+
+                if (p.HasProperties && !p.SkipNullProperties)
+                {
+                    p.TraverseParameterPropertiesTransitively((_, member) =>
+                    {
+                        if (member.ClassificationAttributeType != null)
+                        {
+                            numClassifiedProps++;
+                        }
+                        else
+                        {
+                            numUnclassifiedProps++;
+                        }
+                    });
+                }
+            }
+
+            if (!string.IsNullOrEmpty(lm.Message))
+            {
+                numUnclassifiedProps++;
+            }
+
+            numReservedUnclassifiedProps = numUnclassifiedProps;
+            numReservedClassifiedProps = numClassifiedProps;
+
+            if (numReservedUnclassifiedProps > 0)
+            {
+                OutLn();
+                OutLn($"_ = {stateName}.ReservePropertySpace({numReservedUnclassifiedProps});");
+                int count = numReservedUnclassifiedProps;
+                foreach (var p in lm.Parameters)
+                {
+                    if (NeedsASlot(p) && p.ClassificationAttributeType == null)
+                    {
+                        var key = $"\"{lm.GetParameterNameInTemplate(p)}\"";
+
+                        if (p.IsEnumerable)
+                        {
+                            var value = p.PotentiallyNull
+                                ? $"{p.NameWithAt} != null ? {LoggerMessageHelperType}.Stringify({p.NameWithAt}) : null"
+                                : $"{LoggerMessageHelperType}.Stringify({p.NameWithAt})";
+
+                            OutLn($"{stateName}.PropertyArray[{--count}] = new({key}, {value});");
+                        }
+                        else
+                        {
+                            var value = ShouldStringify(p.Type)
+                                ? ConvertToString(p, p.NameWithAt)
+                                : p.NameWithAt;
+
+                            OutLn($"{stateName}.PropertyArray[{--count}] = new({key}, {value});");
+                        }
+                    }
+                }
+
+                foreach (var p in lm.Parameters)
+                {
+                    if (p.HasProperties && !p.SkipNullProperties)
+                    {
+                        p.TraverseParameterPropertiesTransitively((propertyChain, member) =>
+                        {
+                            if (member.ClassificationAttributeType == null)
+                            {
+                                var propName = PropertyChainToString(propertyChain, member, "_", omitParameterName: p.OmitParameterName);
+                                var accessExpression = PropertyChainToString(propertyChain, member, "?.", nonNullSeparator: ".");
+
+                                var ts = ShouldStringify(member.Type)
+                                    ? ConvertPropertyToString(member, accessExpression)
+                                    : accessExpression;
+
+                                var value = member.IsEnumerable
+                                    ? $"{LoggerMessageHelperType}.Stringify({accessExpression})"
+                                    : ts;
+
+                                OutLn($"{stateName}.PropertyArray[{--count}] = new(\"{propName}\", {value});");
+                            }
+                        });
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(lm.Message))
+                {
+                    OutLn($"{stateName}.PropertyArray[{--count}] = new(\"{{OriginalFormat}}\", \"{EscapeMessageString(lm.Message)}\");");
+                }
+            }
+
+            if (numReservedClassifiedProps > 0)
+            {
+                OutLn();
+                OutLn($"_ = {stateName}.ReserveClassifiedPropertySpace({numReservedClassifiedProps});");
+                int count = numReservedClassifiedProps;
+                foreach (var p in lm.Parameters)
+                {
+                    if (NeedsASlot(p) && p.ClassificationAttributeType != null)
+                    {
+                        var key = $"\"{lm.GetParameterNameInTemplate(p)}\"";
+                        var classification = $"_{EncodeTypeName(p.ClassificationAttributeType)}_Classification";
+
+                        var value = ShouldStringify(p.Type)
+                            ? ConvertToString(p, p.NameWithAt)
+                            : p.NameWithAt;
+
+                        OutLn($"{stateName}.ClassifiedPropertyArray[{--count}] = new({key}, {value}, {classification});");
+                    }
+                }
+
+                foreach (var p in lm.Parameters)
+                {
+                    if (p.HasProperties && !p.SkipNullProperties)
+                    {
+                        p.TraverseParameterPropertiesTransitively((propertyChain, member) =>
+                        {
+                            if (member.ClassificationAttributeType != null)
+                            {
+                                var propName = PropertyChainToString(propertyChain, member, "_", omitParameterName: p.OmitParameterName);
+                                var accessExpression = PropertyChainToString(propertyChain, member, "?.", nonNullSeparator: ".");
+
+                                var value = ConvertPropertyToString(member, accessExpression);
+                                var classification = $"_{EncodeTypeName(member.ClassificationAttributeType)}_Classification";
+
+                                OutLn($"{stateName}.ClassifiedPropertyArray[{--count}] = new(\"{propName}\", {value}, {classification});");
+                            }
+                        });
                     }
                 }
             }
 
-            return result;
+            foreach (var p in lm.Parameters)
+            {
+                if (p.HasProperties && p.SkipNullProperties)
+                {
+                    p.TraverseParameterPropertiesTransitively((propertyChain, member) =>
+                    {
+                        if (member.ClassificationAttributeType == null)
+                        {
+                            var propName = PropertyChainToString(propertyChain, member, "_", omitParameterName: p.OmitParameterName);
+                            var accessExpression = PropertyChainToString(propertyChain, member, "?.", nonNullSeparator: ".");
+
+                            var ts = ShouldStringify(member.Type)
+                                ? ConvertPropertyToString(member, accessExpression)
+                                : accessExpression;
+
+                            var value = member.IsEnumerable ? $"{LoggerMessageHelperType}.Stringify({accessExpression})" : ts;
+
+                            var skipNull = member.PotentiallyNull && !member.IsEnumerable
+                                ? $"if ({value} != null) "
+                                : string.Empty;
+
+                            OutLn($"{skipNull}{stateName}.AddProperty(\"{propName}\", {value});");
+                        }
+                        else
+                        {
+                            var propName = PropertyChainToString(propertyChain, member, "_", omitParameterName: p.OmitParameterName);
+                            var accessExpression = PropertyChainToString(propertyChain, member, "?.", nonNullSeparator: ".");
+
+                            var value = ConvertPropertyToString(member, accessExpression);
+                            var classification = $"_{EncodeTypeName(member.ClassificationAttributeType)}_Classification";
+
+                            var skipNull = member.PotentiallyNull
+                                ? $"if ({value} != null) "
+                                : string.Empty;
+
+                            OutLn($"{skipNull}{stateName}.AddClassifiedProperty(\"{propName}\", {value}, {classification});");
+                        }
+                    });
+                }
+
+                if (p.HasPropsProvider)
+                {
+                    if (p.OmitParameterName)
+                    {
+                        OutLn($"{stateName}.PropertyNamePrefix = string.Empty;");
+                    }
+                    else
+                    {
+                        OutLn($"{stateName}.PropertyNamePrefix = nameof({p.NameWithAt});");
+                    }
+
+                    OutLn($"{p.LogPropertiesProvider!.ContainingType}.{p.LogPropertiesProvider.MethodName}({stateName}, {p.NameWithAt});");
+                }
+            }
+        }
+
+        bool GenVariableAssignments(LoggingMethod lm, string lambdaStateName, int numReservedUnclassifiedProps, int numReservedClassifiedProps)
+        {
+            bool generatedAssignments = false;
+
+            int index = numReservedUnclassifiedProps - 1;
+            foreach (var p in lm.Parameters)
+            {
+                if (NeedsASlot(p) && p.ClassificationAttributeType == null)
+                {
+                    if (p.UsedAsTemplate)
+                    {
+                        var key = lm.GetParameterNameInTemplate(p);
+
+                        var atSign = p.NeedsAtSign ? "@" : string.Empty;
+                        if (p.PotentiallyNull)
+                        {
+                            const string Null = "\"(null)\"";
+                            OutLn($"var {atSign}{key} = {lambdaStateName}.PropertyArray[{index}].Value ?? {Null};");
+                        }
+                        else
+                        {
+                            OutLn($"var {atSign}{key} = {lambdaStateName}.PropertyArray[{index}].Value;");
+                        }
+
+                        generatedAssignments = true;
+                    }
+
+                    index--;
+                }
+            }
+
+            index = numReservedClassifiedProps - 1;
+            foreach (var p in lm.Parameters)
+            {
+                if (NeedsASlot(p) && p.ClassificationAttributeType != null)
+                {
+                    if (p.UsedAsTemplate)
+                    {
+                        var key = lm.GetParameterNameInTemplate(p);
+
+                        var atSign = p.NeedsAtSign ? "@" : string.Empty;
+                        if (p.PotentiallyNull)
+                        {
+                            const string Null = "\"(null)\"";
+                            OutLn($"var {atSign}{key} = {lambdaStateName}.RedactedPropertyArray[{index}].Value ?? {Null};");
+                        }
+                        else
+                        {
+                            OutLn($"var {atSign}{key} = {lambdaStateName}.RedactedPropertyArray[{index}].Value;");
+                        }
+
+                        generatedAssignments = true;
+                    }
+
+                    index--;
+                }
+            }
+
+            return generatedAssignments;
         }
 
         static (string name, bool isNullable) GetLogger(LoggingMethod lm)
@@ -347,61 +476,6 @@ internal sealed partial class Emitter : EmitterBase
             }
 
             return (logger, isNullable);
-        }
-
-        static (string name, bool isNullable) GetRedactorProvider(LoggingMethod lm)
-        {
-            string redactorProvider = lm.RedactorProviderField;
-            bool isNullable = lm.RedactorProviderFieldNullable;
-
-            foreach (var p in lm.Parameters)
-            {
-                if (p.IsRedactorProvider)
-                {
-                    redactorProvider = p.Name;
-                    isNullable = p.IsNullable;
-                    break;
-                }
-            }
-
-            return (redactorProvider, isNullable);
-        }
-
-        void GenHelperAdd(LoggingMethod lm, Dictionary<LoggingMethodParameter, int> holderMap, LoggingMethodParameter p, string redactorProviderAccess, string helperName, string tmpName)
-        {
-            string key = $"\"{lm.GetParameterNameInTemplate(p)}\"";
-
-            if (p.ClassificationAttributeType != null)
-            {
-                var dataClassVariableName = EncodeTypeName(p.ClassificationAttributeType);
-
-                OutOpenBrace();
-                OutLn($"var {tmpName} = {ConvertToString(p, p.NameWithAt)};");
-                var value = $"{tmpName} != null ? _{dataClassVariableName}Redactor{redactorProviderAccess}.Redact(global::System.MemoryExtensions.AsSpan({tmpName})) : null";
-                OutLn($"{helperName}.Add({key}, {value});");
-                OutCloseBrace();
-            }
-            else
-            {
-                if (p.IsEnumerable)
-                {
-                    var value = p.PotentiallyNull
-                        ? $"{p.NameWithAt} != null ? global::Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.Stringify({p.NameWithAt}) : null"
-                        : $"global::Microsoft.Extensions.Telemetry.Logging.LogMethodHelper.Stringify({p.NameWithAt})";
-
-                    OutLn($"{helperName}.Add({key}, {value});");
-                }
-                else
-                {
-                    var value = ShouldStringify(p.Type)
-                        ? ConvertToString(p, p.NameWithAt)
-                        : p.NameWithAt;
-
-                    OutLn($"{helperName}.Add({key}, {value});");
-                }
-            }
-
-            holderMap.Add(p, holderMap.Count);
         }
     }
 
@@ -483,40 +557,6 @@ internal sealed partial class Emitter : EmitterBase
         finally
         {
             _sbPool.ReturnStringBuilder(localStringBuilder);
-        }
-    }
-
-    private void GenRedactorsFetchingCode(
-        bool isRedactorProviderInTheInstance,
-        IEnumerable<string> classificationAttributeTypes,
-        string redactorProvider,
-        bool isNullableRedactorProvider)
-    {
-        if (isRedactorProviderInTheInstance)
-        {
-            foreach (var classificationAttributeType in classificationAttributeTypes)
-            {
-                var classificationVariableName = EncodeTypeName(classificationAttributeType);
-
-                OutLn($"var _{classificationVariableName}Redactor = __{classificationVariableName}Redactor;");
-            }
-        }
-        else
-        {
-            foreach (var classificationAttributeType in classificationAttributeTypes)
-            {
-                var classificationVariableName = EncodeTypeName(classificationAttributeType);
-                var attrClassificationFieldName = GetAttributeClassification(classificationAttributeType);
-
-                if (isNullableRedactorProvider)
-                {
-                    OutLn($"var _{classificationVariableName}Redactor = {redactorProvider}?.GetRedactor({attrClassificationFieldName});");
-                }
-                else
-                {
-                    OutLn($"var _{classificationVariableName}Redactor = {redactorProvider}.GetRedactor({attrClassificationFieldName});");
-                }
-            }
         }
     }
 }

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.cs
@@ -65,7 +65,7 @@ internal sealed partial class Emitter : EmitterBase
         OutOpenBrace();
 
         var isRedactionRequired =
-            lt.Methods.SelectMany(static lm => lm.Parameters).Any(static lp => lp.ClassificationAttributeType != null)
+            lt.Methods.SelectMany(static lm => lm.Parameters).Any(static lp => lp.HasDataClassification)
             || lt.Methods.SelectMany(static lm => GetLogPropertiesAttributes(lm)).Any();
 
         if (isRedactionRequired)

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethod.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethod.cs
@@ -23,9 +23,7 @@ internal sealed class LoggingMethod
     public bool IsStatic;
     public string Modifiers = string.Empty;
     public string LoggerField = "_logger";
-    public string RedactorProviderField = "_redactorProvider";
     public bool LoggerFieldNullable;
-    public bool RedactorProviderFieldNullable;
     public bool HasXmlDocumentation;
 
     public string GetParameterNameInTemplate(LoggingMethodParameter parameter)

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
@@ -18,7 +18,6 @@ internal sealed class LoggingMethodParameter
     public string? Qualifier;
     public bool NeedsAtSign;
     public bool IsLogger;
-    public bool IsRedactorProvider;
     public bool IsException;
     public bool IsLogLevel;
     public bool IsEnumerable;
@@ -42,9 +41,9 @@ internal sealed class LoggingMethodParameter
 
     // A parameter flagged as 'normal' is not going to be taken care of specially as an argument to ILogger.Log
     // but instead is supposed to be taken as a normal parameter.
-    public bool IsNormalParameter => !IsLogger && !IsRedactorProvider && !IsException && !IsLogLevel;
+    public bool IsNormalParameter => !IsLogger && !IsException && !IsLogLevel;
 
     public bool HasProperties => PropertiesToLog.Count > 0;
     public bool HasPropsProvider => LogPropertiesProvider is not null;
-    public bool PotentiallyNull => (IsReference && !IsLogger && !IsRedactorProvider) || IsNullable;
+    public bool PotentiallyNull => (IsReference && !IsLogger) || IsNullable;
 }

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
@@ -43,6 +43,7 @@ internal sealed class LoggingMethodParameter
     // but instead is supposed to be taken as a normal parameter.
     public bool IsNormalParameter => !IsLogger && !IsException && !IsLogLevel;
 
+    public bool HasDataClassification => ClassificationAttributeType != null;
     public bool HasProperties => PropertiesToLog.Count > 0;
     public bool HasPropsProvider => LogPropertiesProvider is not null;
     public bool PotentiallyNull => (IsReference && !IsLogger) || IsNullable;

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingProperty.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingProperty.cs
@@ -21,6 +21,7 @@ internal sealed record LoggingProperty(
     bool ImplementsIFormattable,
     IReadOnlyCollection<LoggingProperty> TransitiveMembers)
 {
+    public bool HasDataClassification => ClassificationAttributeType != null;
     public string NameWithAt => NeedsAtSign ? "@" + Name : Name;
     public bool PotentiallyNull => IsReference || IsNullable;
 }

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/DiagDescriptors.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/DiagDescriptors.cs
@@ -129,30 +129,7 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         messageFormat: Resources.MultipleDataClassificationAttributesMessage,
         category: Category);
 
-    public static DiagnosticDescriptor MissingRedactorProviderParameter { get; } = Make(
-        id: "R9G021",
-        title: Resources.MissingRedactorProviderParameterTitle,
-        messageFormat: Resources.MissingRedactorProviderParameterMessage,
-        category: Category);
-
-    public static DiagnosticDescriptor MissingDataClassificationParameter { get; } = Make(
-        id: "R9G022",
-        title: Resources.MissingDataClassificationParameterTitle,
-        messageFormat: Resources.MissingDataClassificationParameterMessage,
-        category: Category,
-        DiagnosticSeverity.Warning);
-
-    public static DiagnosticDescriptor MissingRedactorProviderField { get; } = Make(
-        id: "R9G023",
-        title: Resources.MissingRedactorProviderFieldTitle,
-        messageFormat: Resources.MissingRedactorProviderFieldMessage,
-        category: Category);
-
-    public static DiagnosticDescriptor MultipleRedactorProviderFields { get; } = Make(
-        id: "R9G024",
-        title: Resources.MultipleRedactorProviderFieldsTitle,
-        messageFormat: Resources.MultipleRedactorProviderFieldsMessage,
-        category: Category);
+    // R9G021..R9G024 retired
 
     public static DiagnosticDescriptor InvalidTypeToLogProperties { get; } = Make(
         id: "R9G025",

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.Designer.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.Designer.cs
@@ -367,24 +367,6 @@ namespace Microsoft.Gen.Logging.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more parameters of the logging method &quot;{0}&quot; must be annotated with a data classification attribute.
-        /// </summary>
-        internal static string MissingDataClassificationParameterMessage {
-            get {
-                return ResourceManager.GetString("MissingDataClassificationParameterMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Logging method parameters must be annotated with a data classification attribute.
-        /// </summary>
-        internal static string MissingDataClassificationParameterTitle {
-            get {
-                return ResourceManager.GetString("MissingDataClassificationParameterTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t find a field of type &quot;Microsoft.Extensions.Logging.ILogger&quot; in type &quot;{0}&quot;.
         /// </summary>
         internal static string MissingLoggerFieldMessage {
@@ -439,42 +421,6 @@ namespace Microsoft.Gen.Logging.Parsing {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Couldn&apos;t find a field of type &quot;Microsoft.Extensions.Redaction.IRedactorProvider&quot; in type &quot;{0}&quot;.
-        /// </summary>
-        internal static string MissingRedactorProviderFieldMessage {
-            get {
-                return ResourceManager.GetString("MissingRedactorProviderFieldMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Couldn&apos;t find a field of type &quot;Microsoft.Extensions.Redaction.IRedactorProvider&quot;.
-        /// </summary>
-        internal static string MissingRedactorProviderFieldTitle {
-            get {
-                return ResourceManager.GetString("MissingRedactorProviderFieldTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to One of the parameters to a logging method that performs redaction must implement the Microsoft.Extensions.Redaction.IRedactorProvider interface.
-        /// </summary>
-        internal static string MissingRedactorProviderParameterMessage {
-            get {
-                return ResourceManager.GetString("MissingRedactorProviderParameterMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A parameter to a logging method must implement the &quot;IRedactorProvider&quot; interface.
-        /// </summary>
-        internal static string MissingRedactorProviderParameterTitle {
-            get {
-                return ResourceManager.GetString("MissingRedactorProviderParameterTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t find a definition for required type &quot;{0}&quot;.
         /// </summary>
         internal static string MissingRequiredTypeMessage {
@@ -525,24 +471,6 @@ namespace Microsoft.Gen.Logging.Parsing {
         internal static string MultipleLoggerFieldsTitle {
             get {
                 return ResourceManager.GetString("MultipleLoggerFieldsTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Found multiple fields of type &quot;Microsoft.Extensions.Redaction.IRedactorProvider&quot; in type &quot;{0}&quot;.
-        /// </summary>
-        internal static string MultipleRedactorProviderFieldsMessage {
-            get {
-                return ResourceManager.GetString("MultipleRedactorProviderFieldsMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Multiple fields of type &quot;Microsoft.Extensions.Redaction.IRedactorProvider&quot; were found.
-        /// </summary>
-        internal static string MultipleRedactorProviderFieldsTitle {
-            get {
-                return ResourceManager.GetString("MultipleRedactorProviderFieldsTitle", resourceCulture);
             }
         }
         

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.resx
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Resources.resx
@@ -225,30 +225,6 @@
   <data name="MultipleDataClassificationAttributesTitle" xml:space="preserve">
     <value>Can't have multiple data classification attributes for a single data value</value>
   </data>
-  <data name="MissingRedactorProviderParameterMessage" xml:space="preserve">
-    <value>One of the parameters to a logging method that performs redaction must implement the Microsoft.Extensions.Redaction.IRedactorProvider interface</value>
-  </data>
-  <data name="MissingRedactorProviderParameterTitle" xml:space="preserve">
-    <value>A parameter to a logging method must implement the "IRedactorProvider" interface</value>
-  </data>
-  <data name="MissingDataClassificationParameterMessage" xml:space="preserve">
-    <value>One or more parameters of the logging method "{0}" must be annotated with a data classification attribute</value>
-  </data>
-  <data name="MissingDataClassificationParameterTitle" xml:space="preserve">
-    <value>Logging method parameters must be annotated with a data classification attribute</value>
-  </data>
-  <data name="MissingRedactorProviderFieldMessage" xml:space="preserve">
-    <value>Couldn't find a field of type "Microsoft.Extensions.Redaction.IRedactorProvider" in type "{0}"</value>
-  </data>
-  <data name="MissingRedactorProviderFieldTitle" xml:space="preserve">
-    <value>Couldn't find a field of type "Microsoft.Extensions.Redaction.IRedactorProvider"</value>
-  </data>
-  <data name="MultipleRedactorProviderFieldsMessage" xml:space="preserve">
-    <value>Found multiple fields of type "Microsoft.Extensions.Redaction.IRedactorProvider" in type "{0}"</value>
-  </data>
-  <data name="MultipleRedactorProviderFieldsTitle" xml:space="preserve">
-    <value>Multiple fields of type "Microsoft.Extensions.Redaction.IRedactorProvider" were found</value>
-  </data>
   <data name="InvalidTypeToLogPropertiesMessage" xml:space="preserve">
     <value>Can't log properties of parameters of type "{0}"</value>
   </data>

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolHolder.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolHolder.cs
@@ -15,7 +15,6 @@ internal sealed record class SymbolHolder(
     INamedTypeSymbol? LogPropertyIgnoreAttribute,
     INamedTypeSymbol ILogPropertyCollectorSymbol,
     INamedTypeSymbol ILoggerSymbol,
-    INamedTypeSymbol? RedactorProviderSymbol,
     INamedTypeSymbol LogLevelSymbol,
     INamedTypeSymbol ExceptionSymbol,
     HashSet<INamedTypeSymbol> IgnorePropertiesSymbols,

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
@@ -14,11 +14,9 @@ internal static class SymbolLoader
     internal const string LogPropertyIgnoreAttribute = "Microsoft.Extensions.Telemetry.Logging.LogPropertyIgnoreAttribute";
     internal const string ILogPropertyCollectorType = "Microsoft.Extensions.Telemetry.Logging.ILogPropertyCollector";
     internal const string ILoggerType = "Microsoft.Extensions.Logging.ILogger";
-    internal const string IRedactorProviderType = "Microsoft.Extensions.Compliance.Redaction.IRedactorProvider";
     internal const string LogLevelType = "Microsoft.Extensions.Logging.LogLevel";
     internal const string ExceptionType = "System.Exception";
     internal const string DataClassificationAttribute = "Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute";
-    internal const string LogMethodHelper = "Microsoft.Extensions.Telemetry.Logging.LogMethodHelper";
     internal const string IEnrichmentPropertyBag = "Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentPropertyBag";
     internal const string IFormatProviderType = "System.IFormatProvider";
 
@@ -78,7 +76,6 @@ internal static class SymbolLoader
             return null;
         }
 
-        var redactorProviderSymbol = compilation.GetTypeByMetadataName(IRedactorProviderType);
         var enumerableSymbol = compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
         var formatProviderSymbol = compilation.GetTypeByMetadataName(IFormatProviderType)!;
 
@@ -100,7 +97,6 @@ internal static class SymbolLoader
             logPropertyIgnoreAttributeSymbol,
             logPropertyCollectorSymbol,
             loggerSymbol,
-            redactorProviderSymbol,
             logLevelSymbol,
             exceptionSymbol,
             ignorePropsSymbols,

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodAttributeTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodAttributeTests.cs
@@ -10,130 +10,151 @@ namespace Microsoft.Gen.Logging.Test;
 
 public class LogMethodAttributeTests
 {
-    private readonly FakeLogger _logger = new();
-    private readonly StarRedactorProvider _redactorProvider = new();
-
     [Fact]
     public void AllowsAttributesStaticMethod()
     {
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M0(_logger, "arg0");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M0 arg0", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
+        collector.Clear();
+        AttributeTestExtensions.M0(logger, "arg0");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0 arg0", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void AllowsAttributesInstanceMethod()
     {
-        _logger.Collector.Clear();
-        new NonStaticTestClass(_logger, null!).M0("arg0");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M0 arg0", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
+        collector.Clear();
+        new NonStaticTestClass(logger).M0("arg0");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0 arg0", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void RedactsArgumentsOnlyWithDataClassificationAttributes()
     {
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M1(_logger, _redactorProvider, "arg0", "arg1");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M1 **** arg1", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M2(_logger, _redactorProvider, "arg0", "arg1");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M2 **** arg1", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        collector.Clear();
+        AttributeTestExtensions.M1(logger, "arg0", "arg1");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M1 **** arg1", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+
+        collector.Clear();
+        AttributeTestExtensions.M2(logger, "arg0", "arg1");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M2 **** arg1", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void RedactsArgumentsWithToString()
     {
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M8(_logger, _redactorProvider, 123456);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M8 ******", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M9(_logger, _redactorProvider, new CustomToStringTestClass());
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M9 ****", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        collector.Clear();
+        AttributeTestExtensions.M8(logger, 123456);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M8 ******", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+
+        collector.Clear();
+        AttributeTestExtensions.M9(logger, new CustomToStringTestClass());
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M9 ****", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void HandlesAvailableDataClassificationAttributes()
     {
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M3(_logger, _redactorProvider, "arg0", "arg1", "arg2", "arg3");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M3 **** **** **** ****", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M4(_logger, _redactorProvider, "arg0", "arg1", "arg2");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M4 **** **** ****", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        collector.Clear();
+        AttributeTestExtensions.M3(logger, "arg0", "arg1", "arg2", "arg3");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M3 **** **** **** ****", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+
+        collector.Clear();
+        AttributeTestExtensions.M4(logger, "arg0", "arg1", "arg2");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M4 **** **** ****", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void RedactsWhenExceedsMaxLogMethodDefineArguments()
     {
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M5(_logger, _redactorProvider, "arg0", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M5 **** **** **** **** **** **** **** **** **** **** *****", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
+        collector.Clear();
+        AttributeTestExtensions.M5(logger, "arg0", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M5 **** **** **** **** **** **** **** **** **** **** *****", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void RedactsWhenDefaultLogMethodCtor()
     {
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M6(_logger, LogLevel.Critical, _redactorProvider, "arg0", "arg1");
-        AssertWhenDefaultLogMethodCtor(LogLevel.Critical, ("p0", "****"), ("p1", "arg1"));
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        _logger.Collector.Clear();
-        AttributeTestExtensions.M7(_logger, LogLevel.Warning, _redactorProvider, "arg_0", "arg_1");
-        AssertWhenDefaultLogMethodCtor(LogLevel.Warning, ("p0", "*****"), ("p1", "arg_1"));
+        collector.Clear();
+        AttributeTestExtensions.M6(logger, LogLevel.Critical, "arg0", "arg1");
+        AssertWhenDefaultLogMethodCtor(collector, LogLevel.Critical, ("p0", "****"), ("p1", "arg1"));
+
+        collector.Clear();
+        AttributeTestExtensions.M7(logger, LogLevel.Warning, "arg_0", "arg_1");
+        AssertWhenDefaultLogMethodCtor(collector, LogLevel.Warning, ("p0", "*****"), ("p1", "arg_1"));
     }
 
     [Fact]
     public void RedactsWhenRedactorProviderIsAvailableInTheInstance()
     {
-        _logger.Collector.Clear();
-        new NonStaticTestClass(_logger, _redactorProvider).M1("arg0");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M1 ****", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        _logger.Collector.Clear();
-        new NonStaticTestClass(_logger, _redactorProvider).M2("arg0", "arg1", "arg2");
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("M2 **** **** ****", _logger.LatestRecord.Message);
-        Assert.Equal(1, _logger.Collector.Count);
+        collector.Clear();
+        new NonStaticTestClass(logger).M1("arg0");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M1 ****", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        _logger.Collector.Clear();
-        new NonStaticTestClass(_logger, _redactorProvider).M3(LogLevel.Information, "arg_0");
-        AssertWhenDefaultLogMethodCtor(LogLevel.Information, ("p0", "*****"));
+        collector.Clear();
+        new NonStaticTestClass(logger).M2("arg0", "arg1", "arg2");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M2 **** **** ****", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+
+        collector.Clear();
+        new NonStaticTestClass(logger).M3(LogLevel.Information, "arg_0");
+        AssertWhenDefaultLogMethodCtor(collector, LogLevel.Information, ("p0", "*****"));
     }
 
-    private void AssertWhenDefaultLogMethodCtor(LogLevel expectedLevel, params (string key, string value)[] expectedState)
+    private static void AssertWhenDefaultLogMethodCtor(FakeLogCollector collector, LogLevel expectedLevel, params (string key, string value)[] expectedState)
     {
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, _logger.LatestRecord.Message);
-        Assert.Equal(expectedLevel, _logger.LatestRecord.Level);
-        Assert.NotNull(_logger.LatestRecord.StructuredState);
-        Assert.Equal(expectedState.Length, _logger.LatestRecord.StructuredState!.Count);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(expectedLevel, collector.LatestRecord.Level);
+        Assert.NotNull(collector.LatestRecord.StructuredState);
+        Assert.Equal(expectedState.Length, collector.LatestRecord.StructuredState!.Count);
         foreach ((string key, string value) in expectedState)
         {
-            Assert.Contains(_logger.LatestRecord.StructuredState, x => x.Key == key && x.Value == value);
+            Assert.Contains(collector.LatestRecord.StructuredState, x => x.Key == key && x.Value == value);
         }
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
@@ -18,51 +18,56 @@ public class LogMethodTests
     [Fact]
     public void BasicTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         NoNamespace.CouldNotOpenSocket(logger, "microsoft.com");
-        Assert.Equal(LogLevel.Critical, logger.LatestRecord.Level);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("Could not open socket to `microsoft.com`", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Critical, collector.LatestRecord.Level);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("Could not open socket to `microsoft.com`", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         Level1.OneLevelNamespace.CouldNotOpenSocket(logger, "microsoft.com");
-        Assert.Equal(LogLevel.Critical, logger.LatestRecord.Level);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("Could not open socket to `microsoft.com`", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Critical, collector.LatestRecord.Level);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("Could not open socket to `microsoft.com`", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         Level1.Level2.TwoLevelNamespace.CouldNotOpenSocket(logger, "microsoft.com");
-        Assert.Equal(LogLevel.Critical, logger.LatestRecord.Level);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("Could not open socket to `microsoft.com`", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Critical, collector.LatestRecord.Level);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("Could not open socket to `microsoft.com`", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void FileScopedNamespaceTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         FileScopedNamespace.Log.CouldNotOpenSocket(logger, "microsoft.com");
-        Assert.Equal(LogLevel.Critical, logger.LatestRecord.Level);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("Could not open socket to `microsoft.com`", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Critical, collector.LatestRecord.Level);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("Could not open socket to `microsoft.com`", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void EnableTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+        var fakeLogger = logger.FakeLogger;
 
-        logger.ControlLevel(LogLevel.Trace, false);
-        logger.ControlLevel(LogLevel.Debug, false);
-        logger.ControlLevel(LogLevel.Information, false);
-        logger.ControlLevel(LogLevel.Warning, false);
-        logger.ControlLevel(LogLevel.Error, false);
-        logger.ControlLevel(LogLevel.Critical, false);
+        fakeLogger.ControlLevel(LogLevel.Trace, false);
+        fakeLogger.ControlLevel(LogLevel.Debug, false);
+        fakeLogger.ControlLevel(LogLevel.Information, false);
+        fakeLogger.ControlLevel(LogLevel.Warning, false);
+        fakeLogger.ControlLevel(LogLevel.Error, false);
+        fakeLogger.ControlLevel(LogLevel.Critical, false);
 
         LevelTestExtensions.M8(logger, LogLevel.Trace);
         LevelTestExtensions.M8(logger, LogLevel.Debug);
@@ -71,209 +76,209 @@ public class LogMethodTests
         LevelTestExtensions.M8(logger, LogLevel.Error);
         LevelTestExtensions.M8(logger, LogLevel.Critical);
 
-        Assert.Equal(0, logger.Collector.Count);
+        Assert.Equal(0, collector.Count);
     }
 
     [Fact]
     public void OptionalArgTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         SignatureTestExtensions.M2(logger, "Hello");
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("Hello World", logger.LatestRecord.Message);
-        Assert.Equal(3, logger.LatestRecord.StructuredState!.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState[0].Key);
-        Assert.Equal("Hello", logger.LatestRecord.StructuredState[0].Value);
-        Assert.Equal("p2", logger.LatestRecord.StructuredState[1].Key);
-        Assert.Equal("World", logger.LatestRecord.StructuredState[1].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("Hello World", collector.LatestRecord.Message);
+        Assert.Equal(3, collector.LatestRecord.StructuredState!.Count);
+        Assert.Equal("Hello", collector.LatestRecord.StructuredState!.GetValue("p1"));
+        Assert.Equal("World", collector.LatestRecord.StructuredState!.GetValue("p2"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         SignatureTestExtensions.M2(logger, "Hello", "World");
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("Hello World", logger.LatestRecord.Message);
-        Assert.Equal(3, logger.LatestRecord.StructuredState!.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState[0].Key);
-        Assert.Equal("Hello", logger.LatestRecord.StructuredState[0].Value);
-        Assert.Equal("p2", logger.LatestRecord.StructuredState[1].Key);
-        Assert.Equal("World", logger.LatestRecord.StructuredState[1].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("Hello World", collector.LatestRecord.Message);
+        Assert.Equal(3, collector.LatestRecord.StructuredState!.Count);
+        Assert.Equal("Hello", collector.LatestRecord.StructuredState!.GetValue("p1"));
+        Assert.Equal("World", collector.LatestRecord.StructuredState!.GetValue("p2"));
     }
 
     [Fact]
     public void ArgTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method1(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M1", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M1", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method2(logger, "arg1");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M2 arg1", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M2 arg1", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method3(logger, "arg1", 2);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M3 arg1 2", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M3 arg1 2", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method4(logger, new InvalidOperationException("A"));
-        Assert.Equal("A", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M4", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("A", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M4", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method5(logger, new InvalidOperationException("A"), new InvalidOperationException("B"));
-        Assert.Equal("A", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M5 System.InvalidOperationException: B", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("A", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M5 System.InvalidOperationException: B", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method6(logger, new InvalidOperationException("A"), 2);
-        Assert.Equal("A", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M6 2", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("A", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M6 2", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method7(logger, 1, new InvalidOperationException("B"));
-        Assert.Equal("B", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M7 1", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("B", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M7 1", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method8(logger, 1, 2, 3, 4, 5, 6, 7);
-        Assert.Equal("M81234567", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("M81234567", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method9(logger, 1, 2, 3, 4, 5, 6, 7);
-        Assert.Equal("M9 1 2 3 4 5 6 7", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("M9 1 2 3 4 5 6 7", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ArgTestExtensions.Method10(logger, 1);
-        Assert.Equal("M101", logger.LatestRecord.Message);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("M101", collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void CollectionTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M0(logger);
-        TestCollection(1, logger);
+        TestCollection(1, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M1(logger, 0);
-        TestCollection(2, logger);
+        TestCollection(2, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M2(logger, 0, 1);
-        TestCollection(3, logger);
+        TestCollection(3, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M3(logger, 0, 1, 2);
-        TestCollection(4, logger);
+        TestCollection(4, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M4(logger, 0, 1, 2, 3);
-        TestCollection(5, logger);
+        TestCollection(5, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M5(logger, 0, 1, 2, 3, 4);
-        TestCollection(6, logger);
+        TestCollection(6, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M6(logger, 0, 1, 2, 3, 4, 5);
-        TestCollection(7, logger);
+        TestCollection(7, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M7(logger, 0, 1, 2, 3, 4, 5, 6);
-        TestCollection(8, logger);
+        TestCollection(8, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M8(logger, 0, 1, 2, 3, 4, 5, 6, 7);
-        TestCollection(9, logger);
+        TestCollection(9, collector);
 
-        logger.Collector.Clear();
+        collector.Clear();
         CollectionTestExtensions.M9(logger, LogLevel.Critical, 0, new ArgumentException("Foo"), 1);
-        TestCollection(3, logger);
+        TestCollection(3, collector);
     }
 
     [Fact]
     public void ConstructorVariationsTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         ConstructorVariationsTestExtensions.M0(logger, "Zero");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0 Zero", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(0, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0 Zero", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        ConstructorVariationsTestExtensions.M1(logger, LogLevel.Trace, "One");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M1 One", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        ConstructorVariationsTestExtensions.M1(logger, LogLevel.Error, "One");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M1 One", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ConstructorVariationsTestExtensions.M2(logger, "Two");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(2, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(2, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        ConstructorVariationsTestExtensions.M3(logger, LogLevel.Trace, "Three");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(3, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        ConstructorVariationsTestExtensions.M3(logger, LogLevel.Error, "Three");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(3, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ConstructorVariationsTestExtensions.M4(logger, "Four");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M4 Four", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(0, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M4 Four", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        ConstructorVariationsTestExtensions.M5(logger, LogLevel.Trace, "Five");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M5 Five", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(0, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        ConstructorVariationsTestExtensions.M5(logger, LogLevel.Error, "Five");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M5 Five", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ConstructorVariationsTestExtensions.M6(logger, "Six");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(0, logger.LatestRecord.Id.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ConstructorVariationsTestExtensions.M7(logger, LogLevel.Information, "Seven");
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(1, collector.Count);
 
-        var logRecord = logger.LatestRecord;
+        var logRecord = collector.LatestRecord;
         Assert.Null(logRecord.Exception);
         Assert.Equal(string.Empty, logRecord.Message);
         Assert.Equal(LogLevel.Information, logRecord.Level);
@@ -284,78 +289,81 @@ public class LogMethodTests
     [Fact]
     public void MessageTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         MessageTestExtensions.M0(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Trace, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         MessageTestExtensions.M1(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         MessageTestExtensions.M2(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         MessageTestExtensions.M5(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("\"Hello\" World", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("\"Hello\" World", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        MessageTestExtensions.M6(logger, LogLevel.Trace, "p", "q");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("\"p\" -> \"q\"", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(6, logger.LatestRecord.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        MessageTestExtensions.M6(logger, LogLevel.Warning, "p", "q");
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("\"p\" -> \"q\"", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Warning, collector.LatestRecord.Level);
+        Assert.Equal(6, collector.LatestRecord.Id);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         MessageTestExtensions.M7(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("\"\n\r\\", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(7, logger.LatestRecord.Id);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("\"\n\r\\", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(7, collector.LatestRecord.Id);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void InstanceTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         var o = new TestInstances(logger);
 
-        logger.Collector.Clear();
+        collector.Clear();
         o.M0();
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         o.M1("Foo");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M1 Foo", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M1 Foo", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Trace, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         o.M2(LogLevel.Warning, "param");
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(1, collector.Count);
 
-        var logRecord = logger.LatestRecord;
+        var logRecord = collector.LatestRecord;
         Assert.Null(logRecord.Exception);
         Assert.Equal(string.Empty, logRecord.Message);
         Assert.Equal(LogLevel.Warning, logRecord.Level);
@@ -368,202 +376,194 @@ public class LogMethodTests
     [Fact]
     public void LevelTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M0(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M1(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M1", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M2(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M2", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M2", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Information, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M3(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M3", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M3", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Warning, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M4(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M4", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M4", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M5(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M5", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Critical, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M5", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Critical, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M6(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M6", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.None, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M6", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.None, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M7(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M7", logger.LatestRecord.Message);
-        Assert.Equal((LogLevel)42, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M7", collector.LatestRecord.Message);
+        Assert.Equal((LogLevel)42, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         LevelTestExtensions.M8(logger, LogLevel.Critical);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M8", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Critical, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M8", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Critical, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        LevelTestExtensions.M9(LogLevel.Trace, logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M9", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        LevelTestExtensions.M9(LogLevel.Information, logger);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M9", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Information, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        LevelTestExtensions.M10(logger, LogLevel.Trace);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M10 Trace", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        LevelTestExtensions.M10(logger, LogLevel.Warning);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M10 Warning", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Warning, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
-        LevelTestExtensions.M11(logger, LogLevel.Trace);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M11 Microsoft.Extensions.Telemetry.Testing.Logging.FakeLogger", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        LevelTestExtensions.M11(logger, LogLevel.Error);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void LevelTests_ForNonStatic()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         var redactorProvider = new StarRedactorProvider();
-        var instance = new NonStaticTestClass(logger, redactorProvider);
+        var instance = new NonStaticTestClass(logger);
 
         instance.NoParams();
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("No params here...", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("No params here...", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Warning, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         instance.NoParamsWithLevel(LogLevel.Information);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("No params here as well...", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("No params here as well...", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Information, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         instance.NoParamsWithLevel(LogLevel.Error);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("No params here as well...", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("No params here as well...", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void NonStaticNullable()
     {
-        var logger = new FakeLogger();
-        var redactorProvider = new StarRedactorProvider();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        var instance = new NonStaticNullableTestClass(logger, redactorProvider);
+        var instance = new NonStaticNullableTestClass(logger);
         instance.M2("One", "Two", "Three");
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M2 *** *** *****", logger.LatestRecord.Message);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M2 *** *** *****", collector.LatestRecord.Message);
 
-        logger.Collector.Clear();
-        instance = new NonStaticNullableTestClass(null, redactorProvider);
+        collector.Clear();
+        instance = new NonStaticNullableTestClass(null);
         instance.M2("One", "Two", "Three");
-        Assert.Equal(0, logger.Collector.Count);
-
-        logger.Collector.Clear();
-        instance = new NonStaticNullableTestClass(logger, null);
-        instance.M2("One", "Two", "Three");
-        Assert.Equal("M2 (null) (null) (null)", logger.LatestRecord.Message);
+        Assert.Equal(0, collector.Count);
     }
 
     [Fact]
     public void ExceptionTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         ExceptionTestExtensions.M0(logger, new ArgumentException("Foo"), new ArgumentException("Bar"));
-        Assert.Equal("Foo", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M0 System.ArgumentException: Bar", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("Foo", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M0 System.ArgumentException: Bar", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Trace, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ExceptionTestExtensions.M1(new ArgumentException("Foo"), logger, new ArgumentException("Bar"));
-        Assert.Equal("Foo", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M1 System.ArgumentException: Bar", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("Foo", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M1 System.ArgumentException: Bar", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         ExceptionTestExtensions.M2(logger, "One", new ArgumentException("Foo"));
-        Assert.Equal("Foo", logger.LatestRecord.Exception!.Message);
-        Assert.Equal("M2 One: System.ArgumentException: Foo", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal("Foo", collector.LatestRecord.Exception!.Message);
+        Assert.Equal("M2 One: System.ArgumentException: Foo", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         var exception = new ArgumentException("Foo");
         ExceptionTestExtensions.M3(exception, logger, LogLevel.Error);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.NotNull(logger.LatestRecord.Exception);
-        Assert.Equal(exception.Message, logger.LatestRecord.Exception!.Message);
-        Assert.Equal(exception.GetType(), logger.LatestRecord.Exception!.GetType());
-        Assert.Equal(string.Empty, logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
+        Assert.NotNull(collector.LatestRecord.Exception);
+        Assert.Equal(exception.Message, collector.LatestRecord.Exception!.Message);
+        Assert.Equal(exception.GetType(), collector.LatestRecord.Exception!.GetType());
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
     }
 
     [Fact]
     public void EventNameTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         EventNameTestExtensions.M0(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Trace, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("CustomEventName", logger.LatestRecord.Id.Name);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Trace, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("CustomEventName", collector.LatestRecord.Id.Name);
 
-        logger.Collector.Clear();
-        EventNameTestExtensions.M1(LogLevel.Trace, logger, "Eight");
-        Assert.Equal(1, logger.Collector.Count);
+        collector.Clear();
+        EventNameTestExtensions.M1(LogLevel.Warning, logger, "Eight");
+        Assert.Equal(1, collector.Count);
 
-        var logRecord = logger.LatestRecord;
+        var logRecord = collector.LatestRecord;
         Assert.Null(logRecord.Exception);
         Assert.Equal(string.Empty, logRecord.Message);
-        Assert.Equal(LogLevel.Trace, logRecord.Level);
+        Assert.Equal(LogLevel.Warning, logRecord.Level);
         Assert.Equal(0, logRecord.Id.Id);
         Assert.Equal("M1_Event", logRecord.Id.Name);
     }
@@ -571,70 +571,72 @@ public class LogMethodTests
     [Fact]
     public void NestedClassTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         NestedClassTestExtensions<Alien.Abc>.NestedMiddleParentClass.NestedClass.M8(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M8", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M8", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         NonStaticNestedClassTestExtensions<Alien.Abc>.NonStaticNestedMiddleParentClass.NestedClass.M9(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M9", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M9", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         NestedStruct.Logger.M10(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M10", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M10", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         NestedRecord.Logger.M11(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M11", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M11", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
 
-        logger.Collector.Clear();
+        collector.Clear();
         MultiLevelNestedClass.NestedStruct.NestedRecord.Logger.M12(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M12", logger.LatestRecord.Message);
-        Assert.Equal(LogLevel.Debug, logger.LatestRecord.Level);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M12", collector.LatestRecord.Message);
+        Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
     public void TemplateTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         TemplateTestExtensions.M0(logger, 0);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0 0", logger.LatestRecord.Message);
-        AssertLastState(logger,
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0 0", collector.LatestRecord.Message);
+        AssertLastState(collector,
             new KeyValuePair<string, string?>("A1", "0"),
             new KeyValuePair<string, string?>("{OriginalFormat}", "M0 {A1}"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         TemplateTestExtensions.M1(logger, 42);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M1 42 42", logger.LatestRecord.Message);
-        AssertLastState(logger,
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M1 42 42", collector.LatestRecord.Message);
+        AssertLastState(collector,
             new KeyValuePair<string, string?>("A1", "42"),
             new KeyValuePair<string, string?>("{OriginalFormat}", "M1 {A1} {A1}"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         TemplateTestExtensions.M2(logger, 42, 43, 44, 45, 46, 47, 48);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M2 42 43 44 45 46 47 48", logger.LatestRecord.Message);
-        AssertLastState(logger,
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M2 42 43 44 45 46 47 48", collector.LatestRecord.Message);
+        AssertLastState(collector,
             new KeyValuePair<string, string?>("A1", "42"),
             new KeyValuePair<string, string?>("a2", "43"),
             new KeyValuePair<string, string?>("A3", "44"),
@@ -644,11 +646,11 @@ public class LogMethodTests
             new KeyValuePair<string, string?>("A7", "48"),
             new KeyValuePair<string, string?>("{OriginalFormat}", "M2 {A1} {a2} {A3} {a4} {A5} {a6} {A7}"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         TemplateTestExtensions.M3(logger, 42, 43);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M3 43 42", logger.LatestRecord.Message);
-        AssertLastState(logger,
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M3 43 42", collector.LatestRecord.Message);
+        AssertLastState(collector,
             new KeyValuePair<string, string?>("A1", "42"),
             new KeyValuePair<string, string?>("a2", "43"),
             new KeyValuePair<string, string?>("{OriginalFormat}", "M3 {a2} {A1}"));
@@ -657,125 +659,132 @@ public class LogMethodTests
     [Fact]
     public void StructTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         StructTestExtensions.M0(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0", logger.LatestRecord.Message);
-        AssertLastState(logger,
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0", collector.LatestRecord.Message);
+        AssertLastState(collector,
             new KeyValuePair<string, string?>("{OriginalFormat}", "M0"));
     }
 
     [Fact]
     public void RecordTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        collector.Clear();
         RecordTestExtensions.M0(logger);
-        Assert.Null(logger.LatestRecord.Exception);
-        Assert.Equal("M0", logger.LatestRecord.Message);
-        AssertLastState(logger,
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("M0", collector.LatestRecord.Message);
+        AssertLastState(collector,
             new KeyValuePair<string, string?>("{OriginalFormat}", "M0"));
     }
 
     [Fact]
     public void SkipEnabledCheckTests()
     {
-        var logger = new FakeLogger();
-        logger.ControlLevel(LogLevel.Information, false);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+        var fakeLogger = logger.FakeLogger;
+
+        fakeLogger.ControlLevel(LogLevel.Information, false);
 
         SkipEnabledCheckTestExtensions.LoggerMethodWithFalseSkipEnabledCheck(logger);
-        Assert.Equal(0, logger.Collector.Count);
+        Assert.Equal(0, collector.Count);
 
         SkipEnabledCheckTestExtensions.LoggerMethodWithFalseSkipEnabledCheck(logger, LogLevel.Information, "p1");
-        Assert.Equal(0, logger.Collector.Count);
+        Assert.Equal(0, collector.Count);
 
 #if NET6_0_OR_GREATER
         SkipEnabledCheckTestExtensions.LoggerMethodWithTrueSkipEnabledCheck(logger);
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(1, collector.Count);
 #endif
     }
 
     [Fact]
     public void InParameterTests()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         InParameterTestExtensions.S s;
         InParameterTestExtensions.M0(logger, in s);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Contains("Hello from S", logger.Collector.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Contains("Hello from S", collector.LatestRecord.Message);
     }
 
     [Fact]
     public void AtSymbolsTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         AtSymbolsTestExtensions.M0(logger, "Test");
-        var record = Assert.Single(logger.Collector.GetSnapshot());
+        var record = Assert.Single(collector.GetSnapshot());
         Assert.Equal("M0 Test", record.Message);
         Assert.NotNull(record.StructuredState);
         Assert.Contains(record.StructuredState, x => x.Key == "event");
         Assert.DoesNotContain(record.StructuredState, x => x.Key == "@event");
 
-        AtSymbolsTestExtensions.M1(logger, new StarRedactorProvider(), "Test");
-        Assert.Equal(2, logger.Collector.Count);
+        AtSymbolsTestExtensions.M1(logger, "Test");
+        Assert.Equal(2, collector.Count);
     }
 
     [Fact]
     public void OverloadsTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         OverloadsTestExtensions.M0(logger, "Test");
         OverloadsTestExtensions.M0(logger, 42);
-        Assert.Equal(2, logger.Collector.Count);
+        Assert.Equal(2, collector.Count);
     }
 
     [Fact]
     public void NullableTests()
     {
-        var logger = new FakeLogger();
-        var redactorProvider = new StarRedactorProvider();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         NullableTestExtensions.M0(logger, null);
-        Assert.Equal("M0 (null)", logger.LatestRecord.Message);
+        Assert.Equal("M0 (null)", collector.LatestRecord.Message);
 
         NullableTestExtensions.M1(logger, null);
-        Assert.Equal("M1 (null)", logger.LatestRecord.Message);
+        Assert.Equal("M1 (null)", collector.LatestRecord.Message);
 
-        NullableTestExtensions.M3(logger, redactorProvider, null);
-        Assert.Equal("M3 (null)", logger.LatestRecord.Message);
+        NullableTestExtensions.M3(logger, null);
+        Assert.Equal("M3 (null)", collector.LatestRecord.Message);
 
         NullableTestExtensions.M4(logger, null, null, null, null, null, null, null, null, null);
-        Assert.Equal("M4 (null) (null) (null) (null) (null) (null) (null) (null) (null)", logger.LatestRecord.Message);
+        Assert.Equal("M4 (null) (null) (null) (null) (null) (null) (null) (null) (null)", collector.LatestRecord.Message);
 
         NullableTestExtensions.M5(logger, null, null, null, null, null, null, null, null, null);
-        Assert.Equal("M5 (null) (null) (null) (null) (null) (null) (null) (null) (null)", logger.LatestRecord.Message);
+        Assert.Equal("M5 (null) (null) (null) (null) (null) (null) (null) (null) (null)", collector.LatestRecord.Message);
 
-        logger.Collector.Clear();
-        NullableTestExtensions.M6(null, null, "Nothing");
-        Assert.Equal(0, logger.Collector.Count);
-
-        NullableTestExtensions.M6(logger, null, "Nothing");
-        Assert.Equal("M6 (null)", logger.LatestRecord.Message);
+        collector.Clear();
+        NullableTestExtensions.M6(null, "Nothing");
+        Assert.Equal(0, collector.Count);
     }
 
     [Fact]
     public void InvariantTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         var dt = new DateTime(2022, 5, 22);
 
         var oldCulture = Thread.CurrentThread.CurrentCulture;
         Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fr-CA");
 
         InvariantTestExtensions.M0(logger, dt);
-        Assert.Equal(dt.ToString(CultureInfo.InvariantCulture), logger.LatestRecord.StructuredState![0].Value);
-        Assert.Equal("M0 " + dt.ToString(CultureInfo.InvariantCulture), logger.LatestRecord.Message);
+        Assert.Equal(dt.ToString(CultureInfo.InvariantCulture), collector.LatestRecord.StructuredState!.GetValue("p0"));
+        Assert.Equal("M0 " + dt.ToString(CultureInfo.InvariantCulture), collector.LatestRecord.Message);
 
         Thread.CurrentThread.CurrentCulture = oldCulture;
     }
@@ -783,7 +792,8 @@ public class LogMethodTests
     [Fact]
     public void EnumerableTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         EnumerableTestExtensions.M10(logger,
             new[] { 1, 2, 3 },
@@ -795,99 +805,87 @@ public class LogMethodTests
                 { "Nine", 9 }
             });
 
-        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(1, collector.Count);
 
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Equal("[\"1\",\"2\",\"3\"]", logger.LatestRecord.StructuredState[0].Value);
-
-        Assert.Equal("p2", logger.LatestRecord.StructuredState[1].Key);
-        Assert.Equal("[\"4\",\"5\",\"6\"]", logger.LatestRecord.StructuredState[1].Value);
-
-        Assert.Equal("p3", logger.LatestRecord.StructuredState[2].Key);
-        Assert.Equal("{\"Seven\"=\"7\",\"Eight\"=\"8\",\"Nine\"=\"9\"}", logger.LatestRecord.StructuredState[2].Value);
+        Assert.Equal("[\"1\",\"2\",\"3\"]", collector.LatestRecord.StructuredState!.GetValue("p1"));
+        Assert.Equal("[\"4\",\"5\",\"6\"]", collector.LatestRecord.StructuredState!.GetValue("p2"));
+        Assert.Equal("{\"Seven\"=\"7\",\"Eight\"=\"8\",\"Nine\"=\"9\"}", collector.LatestRecord.StructuredState!.GetValue("p3"));
     }
 
     [Fact]
     public void NullableEnumerableTest()
     {
-        var logger = new FakeLogger();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         EnumerableTestExtensions.M11(logger, null);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Null(logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.StructuredState!.GetValue("p1"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         EnumerableTestExtensions.M11(logger, new[] { 1, 2, 3 });
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Equal("[\"1\",\"2\",\"3\"]", logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("[\"1\",\"2\",\"3\"]", collector.LatestRecord.StructuredState!.GetValue("p1"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         EnumerableTestExtensions.M12(logger, null);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("class", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Null(logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.StructuredState!.GetValue("class"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         EnumerableTestExtensions.M12(logger, new[] { 1, 2, 3 });
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("class", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Equal("[\"1\",\"2\",\"3\"]", logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("[\"1\",\"2\",\"3\"]", collector.LatestRecord.StructuredState!.GetValue("class"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         EnumerableTestExtensions.M13(logger, default);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Equal("[\"1\",\"2\",\"3\"]", logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("[\"1\",\"2\",\"3\"]", collector.LatestRecord.StructuredState!.GetValue("p1"));
 
-        logger.Collector.Clear();
+        collector.Clear();
 #pragma warning disable SA1129 // Do not use default value type constructor
         EnumerableTestExtensions.M14(logger, new StructEnumerable());
 #pragma warning restore SA1129 // Do not use default value type constructor
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Equal("[\"1\",\"2\",\"3\"]", logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("[\"1\",\"2\",\"3\"]", collector.LatestRecord.StructuredState!.GetValue("p1"));
 
-        logger.Collector.Clear();
+        collector.Clear();
         EnumerableTestExtensions.M14(logger, default);
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Null(logger.LatestRecord.StructuredState[0].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.StructuredState!.GetValue("p1"));
     }
 
     [Fact]
     public void FormattableTest()
     {
-        var logger = new FakeLogger();
-        FormattableTestExtensions.Method1(logger, new FormattableTestExtensions.Formattable());
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1", logger.LatestRecord.StructuredState![0].Key);
-        Assert.Equal("Formatted!", logger.LatestRecord.StructuredState[0].Value);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
-        logger.Collector.Clear();
+        FormattableTestExtensions.Method1(logger, new FormattableTestExtensions.Formattable());
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("Formatted!", collector.LatestRecord.StructuredState!.GetValue("p1"));
+
+        collector.Clear();
         FormattableTestExtensions.Method2(logger, new FormattableTestExtensions.ComplexObj());
-        Assert.Equal(1, logger.Collector.Count);
-        Assert.Equal("p1_P1", logger.LatestRecord.StructuredState![1].Key);
-        Assert.Equal("Formatted!", logger.LatestRecord.StructuredState[1].Value);
+        Assert.Equal(1, collector.Count);
+        Assert.Equal("Formatted!", collector.LatestRecord.StructuredState!.GetValue("p1_P1"));
     }
 
-    private static void AssertLastState(FakeLogger logger, params KeyValuePair<string, string?>[] expected)
+    private static void AssertLastState(FakeLogCollector collector, params KeyValuePair<string, string?>[] expected)
     {
-        var rol = (IReadOnlyList<KeyValuePair<string, string?>>)logger.LatestRecord.State!;
+        var rol = (IReadOnlyList<KeyValuePair<string, string>>)collector.LatestRecord.State!;
         int count = 0;
         foreach (var kvp in expected)
         {
-            Assert.Equal(kvp.Key, rol[count].Key);
-            Assert.Equal(kvp.Value, rol[count].Value);
+            Assert.Equal(kvp.Value, rol.GetValue(kvp.Key));
             count++;
         }
     }
 
     [SuppressMessage("Minor Code Smell", "S4056:Overloads with a \"CultureInfo\" or an \"IFormatProvider\" parameter should be used", Justification = "Not appropriate here")]
-    private static void TestCollection(int expected, FakeLogger logger)
+    private static void TestCollection(int expected, FakeLogCollector collector)
     {
-        var rol = (logger.LatestRecord.State as IReadOnlyList<KeyValuePair<string, string?>>)!;
+        var rol = (collector.LatestRecord.State as IReadOnlyList<KeyValuePair<string, string?>>)!;
         Assert.NotNull(rol);
 
         Assert.Equal(expected, rol.Count);
@@ -896,23 +894,8 @@ public class LogMethodTests
             if (i != expected - 1)
             {
                 var kvp = new KeyValuePair<string, string?>($"p{i}", i.ToString());
-                Assert.Equal(kvp, rol[i]);
+                Assert.Equal(kvp.Value, rol!.GetValue(kvp.Key));
             }
         }
-
-        int count = 0;
-        foreach (var actual in rol)
-        {
-            if (count != expected - 1)
-            {
-                var kvp = new KeyValuePair<string, string?>($"p{count}", count.ToString());
-                Assert.Equal(kvp, actual);
-            }
-
-            count++;
-        }
-
-        Assert.Equal(expected, count);
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => _ = rol[expected]);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesProviderTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesProviderTests.cs
@@ -50,7 +50,7 @@ public class LogPropertiesProviderTests
         const string StringParamValue = "Value for a string";
 
         var classToLog = new ClassToLog { MyIntProperty = 0 };
-        new NonStaticTestClass(_logger, null!).LogPropertiesWithProvider(StringParamValue, classToLog);
+        new NonStaticTestClass(_logger).LogPropertiesWithProvider(StringParamValue, classToLog);
 
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
@@ -75,7 +75,7 @@ public class LogPropertiesProviderTests
         const string StringParamValue = "Value for a string";
 
         var classToLog = new ClassToLog { MyIntProperty = ushort.MaxValue };
-        new NonStaticTestClass(_logger, null!).DefaultAttrCtorLogPropertiesWithProvider(LogLevel.Debug, StringParamValue, classToLog);
+        new NonStaticTestClass(_logger).DefaultAttrCtorLogPropertiesWithProvider(LogLevel.Debug, StringParamValue, classToLog);
 
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesRedactionTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesRedactionTests.cs
@@ -15,20 +15,20 @@ namespace Microsoft.Gen.Logging.Test;
 
 public class LogPropertiesRedactionTests
 {
-    private readonly FakeLogger _logger = new();
-    private readonly StarRedactorProvider _redactorProvider = new();
-
     [Fact]
     public void RedactsWhenRedactorProviderIsAvailableInTheInstance()
     {
-        var instance = new NonStaticTestClass(_logger, _redactorProvider);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
+        var instance = new NonStaticTestClass(logger);
         var classToRedact = new MyBaseClassToRedact();
 
         instance.LogPropertiesWithRedaction("arg0", classToRedact);
 
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("LogProperties with redaction: ****", _logger.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("LogProperties with redaction: ****", collector.LatestRecord.Message);
 
         var expectedState = new Dictionary<string, string?>
         {
@@ -37,21 +37,24 @@ public class LogPropertiesRedactionTests
             ["{OriginalFormat}"] = "LogProperties with redaction: {P0}"
         };
 
-        _logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
 
     [Fact]
     public void RedactsWhenDefaultAttrCtorAndRedactorProviderIsInTheInstance()
     {
-        var instance = new NonStaticTestClass(_logger, _redactorProvider);
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
+        var instance = new NonStaticTestClass(logger);
         var classToRedact = new MyBaseClassToRedact();
 
         instance.DefaultAttrCtorLogPropertiesWithRedaction(LogLevel.Information, "arg0", classToRedact);
 
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal(LogLevel.Information, _logger.LatestRecord.Level);
-        Assert.Equal(string.Empty, _logger.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(LogLevel.Information, collector.LatestRecord.Level);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
 
         var expectedState = new Dictionary<string, string?>
         {
@@ -59,19 +62,22 @@ public class LogPropertiesRedactionTests
             ["p1_StringPropertyBase"] = new('*', classToRedact.StringPropertyBase.Length),
         };
 
-        _logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
 
     [Fact]
     public void RedactsWhenLogMethodIsStaticNoParams()
     {
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         var classToRedact = new ClassToRedact();
 
-        LogNoParams(_logger, _redactorProvider, classToRedact);
+        LogNoParams(logger, classToRedact);
 
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("No template params", _logger.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("No template params", collector.LatestRecord.Message);
 
         var expectedState = new Dictionary<string, string?>
         {
@@ -86,20 +92,23 @@ public class LogPropertiesRedactionTests
             ["{OriginalFormat}"] = "No template params"
         };
 
-        _logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
 
     [Fact]
     public void RedactsWhenDefaultAttrCtorAndIsStaticNoParams()
     {
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         var classToRedact = new ClassToRedact();
 
-        LogNoParamsDefaultCtor(_logger, LogLevel.Warning, _redactorProvider, classToRedact);
+        LogNoParamsDefaultCtor(logger, LogLevel.Warning, classToRedact);
 
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal(LogLevel.Warning, _logger.LatestRecord.Level);
-        Assert.Equal(string.Empty, _logger.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(LogLevel.Warning, collector.LatestRecord.Level);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
 
         var expectedState = new Dictionary<string, string?>
         {
@@ -113,19 +122,22 @@ public class LogPropertiesRedactionTests
             ["classToLog_NoRedactionProp"] = classToRedact.NoRedactionProp,
         };
 
-        _logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
 
     [Fact]
     public void RedactsWhenLogMethodIsStaticTwoParams()
     {
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         var classToRedact = new MyTransitiveClass();
 
-        LogTwoParams(_logger, _redactorProvider, "string_prop", classToRedact);
+        LogTwoParams(logger, "string_prop", classToRedact);
 
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal("Only *********** as param", _logger.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal("Only *********** as param", collector.LatestRecord.Message);
 
         var expectedState = new Dictionary<string, string?>
         {
@@ -135,20 +147,23 @@ public class LogPropertiesRedactionTests
             ["{OriginalFormat}"] = "Only {StringProperty} as param"
         };
 
-        _logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
 
     [Fact]
     public void RedactsWhenDefaultAttrCtorAndIsStaticTwoParams()
     {
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
+
         var classToRedact = new MyTransitiveClass();
 
-        LogTwoParamsDefaultCtor(_logger, _redactorProvider, LogLevel.None, "string_prop", classToRedact);
+        LogTwoParamsDefaultCtor(logger, LogLevel.None, "string_prop", classToRedact);
 
-        Assert.Equal(1, _logger.Collector.Count);
-        Assert.Null(_logger.LatestRecord.Exception);
-        Assert.Equal(LogLevel.None, _logger.LatestRecord.Level);
-        Assert.Equal(string.Empty, _logger.LatestRecord.Message);
+        Assert.Equal(1, collector.Count);
+        Assert.Null(collector.LatestRecord.Exception);
+        Assert.Equal(LogLevel.None, collector.LatestRecord.Level);
+        Assert.Equal(string.Empty, collector.LatestRecord.Message);
 
         var expectedState = new Dictionary<string, string?>
         {
@@ -157,6 +172,6 @@ public class LogPropertiesRedactionTests
             ["complexParam_TransitiveStringProp"] = new('*', classToRedact.TransitiveStringProp.Length),
         };
 
-        _logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Numerics;
 using FluentAssertions;
@@ -42,14 +43,10 @@ public class LogPropertiesTests
 
         Assert.Equal(1, _logger.Collector.Count);
 
-        Assert.Equal("myProps_P5", _logger.LatestRecord.StructuredState![7].Key);
-        Assert.Equal("[\"1\",\"2\",\"3\"]", _logger.LatestRecord.StructuredState[7].Value);
-
-        Assert.Equal("myProps_P6", _logger.LatestRecord.StructuredState[8].Key);
-        Assert.Equal("[\"4\",\"5\",\"6\"]", _logger.LatestRecord.StructuredState[8].Value);
-
-        Assert.Equal("myProps_P7", _logger.LatestRecord.StructuredState[9].Key);
-        Assert.Equal("{\"Seven\"=\"7\",\"Eight\"=\"8\",\"Nine\"=\"9\"}", _logger.LatestRecord.StructuredState[9].Value);
+        var ss = _logger.LatestRecord.StructuredState!.ToDictionary(x => x.Key, x => x.Value);
+        Assert.Equal("[\"1\",\"2\",\"3\"]", ss["myProps_P5"]);
+        Assert.Equal("[\"4\",\"5\",\"6\"]", ss["myProps_P6"]);
+        Assert.Equal("{\"Seven\"=\"7\",\"Eight\"=\"8\",\"Nine\"=\"9\"}", ss["myProps_P7"]);
     }
 
     [Fact]
@@ -65,10 +62,8 @@ public class LogPropertiesTests
 
         var state = _logger.LatestRecord.StructuredState!;
         Assert.Equal(2, state.Count);
-        Assert.Equal("P0", state[0].Key);
-        Assert.Equal(props.P0.ToString(CultureInfo.InvariantCulture), state[0].Value);
-        Assert.Equal("P1", state[1].Key);
-        Assert.Equal(props.P1, state[1].Value);
+        Assert.Equal(props.P0.ToString(CultureInfo.InvariantCulture), state!.GetValue("P0"));
+        Assert.Equal(props.P1, state!.GetValue("P1"));
     }
 
     [Fact]
@@ -84,10 +79,8 @@ public class LogPropertiesTests
 
         var state = _logger.LatestRecord.StructuredState!;
         Assert.Equal(2, state.Count);
-        Assert.Equal("P0", state[0].Key);
-        Assert.Equal(props.P0.ToString(CultureInfo.InvariantCulture), state[0].Value);
-        Assert.Equal("P1", state[1].Key);
-        Assert.Equal(props.P1, state[1].Value);
+        Assert.Equal(props.P0.ToString(CultureInfo.InvariantCulture), state!.GetValue("P0"));
+        Assert.Equal(props.P1, state!.GetValue("P1"));
     }
 
     [Fact]
@@ -130,50 +123,29 @@ public class LogPropertiesTests
         Assert.Equal(19, state.Count);
 #endif
 
-        Assert.Equal("p_P0", state[0].Key);
-        Assert.Equal(props.P0.ToString(CultureInfo.InvariantCulture), state[0].Value);
-        Assert.Equal("p_P1", state[1].Key);
-        Assert.Equal(props.P1.ToString(CultureInfo.InvariantCulture), state[1].Value);
-        Assert.Equal("p_P2", state[2].Key);
-        Assert.Equal(props.P2.ToString(null, CultureInfo.InvariantCulture), state[2].Value);
-        Assert.Equal("p_P3", state[3].Key);
-        Assert.Equal(props.P3.ToString(), state[3].Value);
-        Assert.Equal("p_P4", state[4].Key);
-        Assert.Equal(props.P4.ToString(), state[4].Value);
-        Assert.Equal("p_P5", state[5].Key);
-        Assert.Equal(props.P5.ToString(), state[5].Value);
-        Assert.Equal("p_P6", state[6].Key);
-        Assert.Equal(props.P6.ToString(), state[6].Value);
-        Assert.Equal("p_P7", state[7].Key);
-        Assert.Equal(props.P7.ToString(), state[7].Value);
-        Assert.Equal("p_P8", state[8].Key);
-        Assert.Equal(props.P8.ToString(), state[8].Value);
-        Assert.Equal("p_P9", state[9].Key);
-        Assert.Equal(props.P9.ToString(), state[9].Value);
-        Assert.Equal("p_P10", state[10].Key);
-        Assert.Equal(props.P10.ToString(CultureInfo.InvariantCulture), state[10].Value);
-        Assert.Equal("p_P11", state[11].Key);
-        Assert.Equal(props.P11.ToString(CultureInfo.InvariantCulture), state[11].Value);
-        Assert.Equal("p_P12", state[12].Key);
-        Assert.Equal(props.P12.ToString(), state[12].Value);
-        Assert.Equal("p_P13", state[13].Key);
-        Assert.Equal(props.P13.ToString(), state[13].Value);
-        Assert.Equal("p_P14", state[14].Key);
-        Assert.Equal(props.P14.ToString(), state[14].Value);
-        Assert.Equal("p_P15", state[15].Key);
-        Assert.Equal(props.P15.ToString(), state[15].Value);
-        Assert.Equal("p_P16", state[16].Key);
-        Assert.Equal(props.P16.ToString(), state[16].Value);
-        Assert.Equal("p_P17", state[17].Key);
-        Assert.Equal(props.P17.ToString(), state[17].Value);
-        Assert.Equal("p_P18", state[18].Key);
-        Assert.Equal(props.P18.ToString(), state[18].Value);
+        Assert.Equal(props.P0.ToString(CultureInfo.InvariantCulture), state!.GetValue("p_P0"));
+        Assert.Equal(props.P1.ToString(CultureInfo.InvariantCulture), state!.GetValue("p_P1"));
+        Assert.Equal(props.P2.ToString(null, CultureInfo.InvariantCulture), state!.GetValue("p_P2"));
+        Assert.Equal(props.P3.ToString(), state!.GetValue("p_P3"));
+        Assert.Equal(props.P4.ToString(), state!.GetValue("p_P4"));
+        Assert.Equal(props.P5.ToString(), state!.GetValue("p_P5"));
+        Assert.Equal(props.P6.ToString(), state!.GetValue("p_P6"));
+        Assert.Equal(props.P7.ToString(), state!.GetValue("p_P7"));
+        Assert.Equal(props.P8.ToString(), state!.GetValue("p_P8"));
+        Assert.Equal(props.P9.ToString(), state!.GetValue("p_P9"));
+        Assert.Equal(props.P10.ToString(CultureInfo.InvariantCulture), state!.GetValue("p_P10"));
+        Assert.Equal(props.P11.ToString(CultureInfo.InvariantCulture), state!.GetValue("p_P11"));
+        Assert.Equal(props.P12.ToString(), state!.GetValue("p_P12"));
+        Assert.Equal(props.P13.ToString(), state!.GetValue("p_P13"));
+        Assert.Equal(props.P14.ToString(), state!.GetValue("p_P14"));
+        Assert.Equal(props.P15.ToString(), state!.GetValue("p_P15"));
+        Assert.Equal(props.P16.ToString(), state!.GetValue("p_P16"));
+        Assert.Equal(props.P17.ToString(), state!.GetValue("p_P17"));
+        Assert.Equal(props.P18.ToString(), state!.GetValue("p_P18"));
 
 #if NET6_0_OR_GREATER
-        Assert.Equal("p_P19", state[19].Key);
-        Assert.Equal(props.P19.ToString(CultureInfo.InvariantCulture), state[19].Value);
-        Assert.Equal("p_P20", state[20].Key);
-        Assert.Equal(props.P20.ToString(CultureInfo.InvariantCulture), state[20].Value);
+        Assert.Equal(props.P19.ToString(CultureInfo.InvariantCulture), state!.GetValue("p_P19"));
+        Assert.Equal(props.P20.ToString(CultureInfo.InvariantCulture), state!.GetValue("p_P20"));
 #endif
 
     }
@@ -181,7 +153,8 @@ public class LogPropertiesTests
     [Fact]
     public void LogPropertiesNullHandling()
     {
-        var provider = new StarRedactorProvider();
+        using var logger = Utils.GetLogger();
+        var collector = logger.FakeLogCollector;
 
         var props = new LogPropertiesNullHandlingExtensions.MyProps
         {
@@ -191,26 +164,24 @@ public class LogPropertiesTests
             P3 = null,
         };
 
-        LogPropertiesNullHandlingExtensions.M0(_logger, provider, props);
-        Assert.Equal(5, _logger.LatestRecord.StructuredState!.Count);
-        Assert.Equal("p_P0", _logger.LatestRecord.StructuredState[0].Key);
-        Assert.Null(_logger.LatestRecord.StructuredState[0].Value);
-        Assert.Equal("p_P1", _logger.LatestRecord.StructuredState[1].Key);
-        Assert.Null(_logger.LatestRecord.StructuredState[1].Value);
-        Assert.Equal("p_P2", _logger.LatestRecord.StructuredState[2].Key);
-        Assert.Equal(props.P2.ToString(null, CultureInfo.InvariantCulture), _logger.LatestRecord.StructuredState[2].Value);
-        Assert.Equal("p_P3", _logger.LatestRecord.StructuredState[3].Key);
-        Assert.Null(_logger.LatestRecord.StructuredState[3].Value);
-        Assert.Equal("p_P4", _logger.LatestRecord.StructuredState[4].Key);
-        Assert.Null(_logger.LatestRecord.StructuredState[4].Value);
-        Assert.Equal(1, _logger.Collector.Count);
+        LogPropertiesNullHandlingExtensions.M0(logger, props);
+        Assert.Equal(5, collector.LatestRecord.StructuredState!.Count);
 
-        _logger.Collector.Clear();
-        LogPropertiesNullHandlingExtensions.M1(_logger, provider, props);
-        Assert.Equal(1, _logger.LatestRecord.StructuredState!.Count);
-        Assert.Equal("p_P2", _logger.LatestRecord.StructuredState[0].Key);
-        Assert.Equal(props.P2.ToString(null, CultureInfo.InvariantCulture), _logger.LatestRecord.StructuredState[0].Value);
-        Assert.Equal(1, _logger.Collector.Count);
+        var ss = collector.LatestRecord.StructuredState!.ToDictionary(x => x.Key, x => x.Value);
+        Assert.Null(ss["p_P0"]);
+        Assert.Null(ss["p_P1"]);
+        Assert.Equal(props.P2.ToString(null, CultureInfo.InvariantCulture), ss["p_P2"]);
+        Assert.Null(ss["p_P3"]);
+        Assert.Null(ss["p_P4"]);
+        Assert.Equal(1, collector.Count);
+
+        collector.Clear();
+        LogPropertiesNullHandlingExtensions.M1(logger, props);
+        Assert.Equal(1, collector.LatestRecord.StructuredState!.Count);
+
+        ss = collector.LatestRecord.StructuredState!.ToDictionary(x => x.Key, x => x.Value);
+        Assert.Equal(props.P2.ToString(null, CultureInfo.InvariantCulture), ss["p_P2"]);
+        Assert.Equal(1, collector.Count);
     }
 
     [Fact]
@@ -333,7 +304,7 @@ public class LogPropertiesTests
         const string StringParamValue = "Value for a string";
 
         var classToLog = new ClassToLog { MyIntProperty = 0 };
-        new NonStaticTestClass(_logger, null!).LogProperties(StringParamValue, classToLog);
+        new NonStaticTestClass(_logger).LogProperties(StringParamValue, classToLog);
 
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;

--- a/test/Generators/Microsoft.Gen.Logging/Generated/Microsoft.Gen.Logging.Generated.Tests.csproj
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/Microsoft.Gen.Logging.Generated.Tests.csproj
@@ -22,5 +22,7 @@
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Abstractions\Microsoft.Extensions.Compliance.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Telemetry.Testing\Microsoft.Extensions.Telemetry.Testing.csproj" />
     <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Testing\Microsoft.Extensions.Compliance.Testing.csproj"  />
+    <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Redaction\Microsoft.Extensions.Compliance.Redaction.csproj"  />
+    <ProjectReference Include="..\..\..\..\src\Libraries\Microsoft.Extensions.Telemetry\Microsoft.Extensions.Telemetry.csproj" />
   </ItemGroup>  
 </Project>

--- a/test/Generators/Microsoft.Gen.Logging/Generated/Utils.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/Utils.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Compliance.Redaction;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Telemetry.Logging;
+using Microsoft.Extensions.Telemetry.Testing.Logging;
+using TestClasses;
+
+namespace Microsoft.Gen.Logging.Test;
+
+internal static class Utils
+{
+    private class Provider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        public Provider(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _logger;
+        }
+
+        public void Dispose()
+        {
+            // nothing
+        }
+    }
+
+    public class TestLogger : ILogger, IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly ServiceProvider _serviceProvider;
+
+        public TestLogger(ILogger logger, ServiceProvider serviceProvider, FakeLogger fakeLogger)
+        {
+            _logger = logger;
+            _serviceProvider = serviceProvider;
+            FakeLogger = fakeLogger;
+            FakeLogCollector = fakeLogger.Collector;
+        }
+
+        public FakeLogCollector FakeLogCollector { get; }
+        public FakeLogger FakeLogger { get; }
+
+        public void Dispose()
+        {
+            _serviceProvider.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => _logger.BeginScope(state);
+        public bool IsEnabled(LogLevel logLevel) => _logger.IsEnabled(logLevel);
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => _logger.Log(logLevel, eventId, state, exception, formatter);
+    }
+
+    public static TestLogger GetLogger()
+    {
+        var fakeLogger = new FakeLogger();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(new Provider(fakeLogger));
+            builder.EnableRedaction();
+        });
+
+        serviceCollection.AddRedaction(builder =>
+        {
+            builder.SetFallbackRedactor<StarRedactor>();
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(Utils));
+        return new TestLogger(logger, serviceProvider, fakeLogger);
+    }
+
+    public static string? GetValue(this IReadOnlyList<KeyValuePair<string, string>> state, string key)
+    {
+        foreach (var kvp in state)
+        {
+            if (kvp.Key == key)
+            {
+                return kvp.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/AtSymbolsTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/AtSymbolsTestExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -14,7 +13,7 @@ namespace TestClasses
         internal static partial void M0(ILogger logger, string @event);
 
         [LogMethod(1, LogLevel.Information, "M1 {event}")]
-        internal static partial void M1(ILogger logger, IRedactorProvider redactorProvider, [PrivateData] string @event);
+        internal static partial void M1(ILogger logger, [PrivateData] string @event);
 
         [LogMethod(int.MaxValue, "M2 {Event}")]
         internal static partial void M2(ILogger logger, LogLevel level, string @event);

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/AttributeTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/AttributeTestExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -16,15 +15,14 @@ namespace TestClasses
         public static partial void M0(ILogger logger, [In] string p0);
 
         [LogMethod(1, LogLevel.Debug, "M1 {p0} {p1}")]
-        public static partial void M1(ILogger logger, IRedactorProvider redactorProvider, [PrivateData] string p0, string p1);
+        public static partial void M1(ILogger logger, [PrivateData] string p0, string p1);
 
         [LogMethod(2, LogLevel.Debug, "M2 {p0} {p1}")]
-        public static partial void M2(ILogger logger, IRedactorProvider redactorProvider, [PrivateData] string p0, [In] string p1);
+        public static partial void M2(ILogger logger, [PrivateData] string p0, [In] string p1);
 
         [LogMethod(3, LogLevel.Debug, "M3 {p0} {p1} {p2} {p3}")]
         public static partial void M3(
             ILogger logger,
-            IRedactorProvider redactorProvider,
             [PrivateData] string p0,
             [PrivateData] string p1,
             [PrivateData] string p2,
@@ -33,7 +31,6 @@ namespace TestClasses
         [LogMethod(4, LogLevel.Debug, "M4 {p0} {p1} {p2}")]
         public static partial void M4(
             ILogger logger,
-            IRedactorProvider redactorProvider,
             [PrivateData] string p0,
             [PrivateData] string p1,
             [PrivateData] string p2);
@@ -42,7 +39,6 @@ namespace TestClasses
         [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Testing.")]
         public static partial void M5(
             ILogger logger,
-            IRedactorProvider redactorProvider,
             [PrivateData] string p0,
             [PrivateData] string p1,
             [PrivateData] string p2,
@@ -57,17 +53,17 @@ namespace TestClasses
 
         // Parameterless ctor:
         [LogMethod]
-        public static partial void M6(ILogger logger, LogLevel level, IRedactorProvider redactorProvider,
+        public static partial void M6(ILogger logger, LogLevel level,
             [PrivateData] string p0, string p1);
 
         [LogMethod]
-        public static partial void M7(ILogger logger, LogLevel level, IRedactorProvider redactorProvider,
+        public static partial void M7(ILogger logger, LogLevel level,
             [PrivateData] string p0, string p1);
 
         [LogMethod(8, LogLevel.Debug, "M8 {p0}")]
-        public static partial void M8(ILogger logger, IRedactorProvider redactorProvider, [PrivateData] int p0);
+        public static partial void M8(ILogger logger, [PrivateData] int p0);
 
         [LogMethod(9, LogLevel.Debug, "M9 {p0}")]
-        public static partial void M9(ILogger logger, IRedactorProvider redactorProvider, [PrivateData] CustomToStringTestClass p0);
+        public static partial void M9(ILogger logger, [PrivateData] CustomToStringTestClass p0);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesNullHandlingExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesNullHandlingExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -22,9 +21,9 @@ namespace TestClasses
         }
 
         [LogMethod(LogLevel.Debug)]
-        public static partial void M0(ILogger logger, IRedactorProvider provider, [LogProperties] MyProps p);
+        public static partial void M0(ILogger logger, [LogProperties] MyProps p);
 
         [LogMethod(LogLevel.Debug)]
-        public static partial void M1(ILogger logger, IRedactorProvider provider, [LogProperties(SkipNullProperties = true)] MyProps p);
+        public static partial void M1(ILogger logger, [LogProperties(SkipNullProperties = true)] MyProps p);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesRedactionExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/LogPropertiesRedactionExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -51,27 +50,26 @@ namespace TestClasses
         }
 
         [LogMethod(1, LogLevel.Debug, "No template params")]
-        public static partial void LogNoParams(ILogger logger, IRedactorProvider redactionProvider, [LogProperties] ClassToRedact classToLog);
+        public static partial void LogNoParams(ILogger logger, [LogProperties] ClassToRedact classToLog);
 
         [LogMethod(2, LogLevel.Information, "Only {StringProperty} as param")]
         public static partial void LogTwoParams(
-            ILogger logger, IRedactorProvider redactionProvider,
+            ILogger logger,
             [PrivateData] string stringProperty, [LogProperties] MyTransitiveClass? complexParam);
 
         // Default ctors:
         [LogMethod]
         public static partial void LogNoParamsDefaultCtor(ILogger logger, LogLevel level,
-            IRedactorProvider redactionProvider, [LogProperties] ClassToRedact classToLog);
+            [LogProperties] ClassToRedact classToLog);
 
         [LogMethod]
         public static partial void LogTwoParamsDefaultCtor(
-            ILogger logger, IRedactorProvider redactionProvider, LogLevel level,
+            ILogger logger, LogLevel level,
             [PrivateData] string stringProperty, [LogProperties] MyTransitiveClass? complexParam);
 
         [LogMethod(LogLevel.Debug, "User {userId} has now different status")]
         public static partial void UserAvailabilityChanged(
             this ILogger logger,
-            IRedactorProvider redactorProvider,
             [PrivateData] string userId,
             [LogProperties] ClassWithPrivateData param);
     }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/NestedClassTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/NestedClassTestExtensions.cs
@@ -19,7 +19,7 @@ namespace TestClasses
         {
             internal static partial class NestedClass
             {
-                [LogMethod(8, LogLevel.Debug, "M8")]
+                [LogMethod(8, LogLevel.Error, "M8")]
                 public static partial void M8(ILogger logger);
             }
         }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/NonStaticNullableTestClass.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/NonStaticNullableTestClass.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -11,12 +10,10 @@ namespace TestClasses
     public partial class NonStaticNullableTestClass
     {
         private readonly ILogger? _logger;
-        private readonly IRedactorProvider? _redactorProvider;
 
-        public NonStaticNullableTestClass(ILogger? logger, IRedactorProvider? redactorProvider)
+        public NonStaticNullableTestClass(ILogger? logger)
         {
             _logger = logger;
-            _redactorProvider = redactorProvider;
         }
 
         [LogMethod(2, LogLevel.Debug, "M2 {p0} {p1} {p2}")]

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/NonStaticTestClass.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/NonStaticTestClass.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -12,12 +11,10 @@ namespace TestClasses
     public partial class NonStaticTestClass
     {
         private readonly ILogger _logger;
-        private readonly IRedactorProvider _redactorProvider;
 
-        public NonStaticTestClass(ILogger logger, IRedactorProvider redactorProvider)
+        public NonStaticTestClass(ILogger logger)
         {
             _logger = logger;
-            _redactorProvider = redactorProvider;
         }
 
         [LogMethod(0, LogLevel.Debug, "M0 {p0}")]

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/NullableTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/NullableTestExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Compliance.Redaction;
 using Microsoft.Extensions.Compliance.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Logging;
@@ -17,7 +16,7 @@ namespace TestClasses
         internal static partial void M1(ILogger logger, int? p0);
 
         [LogMethod(3, LogLevel.Debug, "M3 {p0}")]
-        internal static partial void M3(ILogger logger, IRedactorProvider redactorProvider, [PrivateData] string? p0);
+        internal static partial void M3(ILogger logger, [PrivateData] string? p0);
 
 #pragma warning disable S107 // Methods should not have too many parameters
         [LogMethod(4, LogLevel.Debug, "M4 {p0} {p1} {p2} {p3} {p4} {p5} {p6} {p7} {p8}")]
@@ -28,6 +27,6 @@ namespace TestClasses
 #pragma warning restore S107 // Methods should not have too many parameters
 
         [LogMethod(6, LogLevel.Debug, "M6 {p0}")]
-        internal static partial void M6(ILogger? logger, IRedactorProvider? redactorProvider, [PrivateData] string? p0);
+        internal static partial void M6(ILogger? logger, [PrivateData] string? p0);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Unit/AttributeParserTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/AttributeParserTests.cs
@@ -56,7 +56,7 @@ public class AttributeParserTests
                 internal static partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(ILogger logger, IRedactorProvider provider, [PrivateDataAttribute] string p0);
+                    static partial void M(ILogger logger, [PrivateDataAttribute] string p0);
                 }
             ");
 
@@ -70,7 +70,7 @@ public class AttributeParserTests
                 internal static partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(ILogger logger, IRedactorProvider provider, [PrivateData] string p0);
+                    static partial void M(ILogger logger, [PrivateData] string p0);
                 }
             ");
 
@@ -84,7 +84,7 @@ public class AttributeParserTests
                 internal static partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(ILogger logger, IRedactorProvider provider, [Test][PrivateData] string p0);
+                    static partial void M(ILogger logger, [Test][PrivateData] string p0);
                 }
             ");
 
@@ -121,7 +121,7 @@ public class AttributeParserTests
                 internal static partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(ILogger logger, IRedactorProvider provider, [PrivateData] int p0);
+                    static partial void M(ILogger logger, [PrivateData] int p0);
                 }
             ");
 
@@ -149,89 +149,12 @@ public class AttributeParserTests
                 internal static partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(IRedactorProvider provider, [PrivateData] string p0);
+                    static partial void M([PrivateData] string p0);
                 }
             ");
 
         _ = Assert.Single(diagnostics);
         Assert.Equal(DiagDescriptors.MissingLoggerParameter.Id, diagnostics[0].Id);
-    }
-
-    [Theory]
-    [InlineData("[PrivateData] string")]
-    public async Task MissingRedactorProviderStaticMethod(string type)
-    {
-        var diagnostics = await RunGenerator(@$"
-            internal static partial class C
-            {{
-                [LogMethod(0, LogLevel.Debug, ""M {{p0}}"")]
-                static partial void M(ILogger logger, {type} p0);
-            }}");
-
-        _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingRedactorProviderParameter.Id, diagnostics[0].Id);
-    }
-
-    [Theory]
-    [InlineData("[PrivateData] string")]
-    public async Task MissingRedactorProviderInstanceMethod(string type)
-    {
-        var diagnostics = await RunGenerator(@$"
-            internal partial class TestInstance
-            {{
-                private readonly ILogger _logger;
-
-                public TestInstance(ILogger logger)
-                {{
-                    _logger = logger;
-                }}
-
-                [LogMethod(0, LogLevel.Debug, ""M0 {{p0}}"")]
-                public partial void M0({type} p0);
-            }}");
-
-        _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingRedactorProviderField.Id, diagnostics[0].Id);
-    }
-
-    [Fact]
-    public async Task MultipleRedactorProviders()
-    {
-        var diagnostics = await RunGenerator(@"
-                internal partial class TestInstance
-                {
-                    private readonly ILogger _logger;
-                    private readonly IRedactorProvider _redactorProvider;
-                    private readonly IRedactorProvider _redactorProvider2;
-
-                    public TestInstance(ILogger logger, IRedactorProvider redactorProvider)
-                    {
-                        _logger = logger;
-                        _redactorProvider = redactorProvider;
-                    }
-
-                    [LogMethod(0, LogLevel.Debug, ""M0 {p0}"")]
-                    public partial void M0([PrivateData] string p0);
-                }
-            ");
-
-        _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MultipleRedactorProviderFields.Id, diagnostics[0].Id);
-    }
-
-    [Fact]
-    public async Task MissingDataClassificationAttributeInStatic()
-    {
-        var diagnostics = await RunGenerator(@"
-                internal static partial class C
-                {
-                    [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(ILogger logger, IRedactorProvider provider, string p0);
-                }
-            ");
-
-        _ = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingDataClassificationParameter.Id, diagnostics[0].Id);
     }
 
     [Fact]
@@ -241,7 +164,7 @@ public class AttributeParserTests
                 internal static partial class C
                 {
                     [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                    static partial void M(ILogger logger, IRedactorProvider provider, [PublicData] string p0);
+                    static partial void M(ILogger logger, [PublicData] string p0);
                 }
             ");
 
@@ -249,30 +172,13 @@ public class AttributeParserTests
     }
 
     [Fact]
-    public async Task MissingDataClassificationAttributeInInstance()
-    {
-        var diagnostics = await RunGenerator(@"
-            partial class C
-            {
-                private ILogger _logger;
-
-                [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                partial void M(IRedactorProvider provider, string p0);
-            }");
-
-        var diagnostic = Assert.Single(diagnostics);
-        Assert.Equal(DiagDescriptors.MissingDataClassificationParameter.Id, diagnostic.Id);
-    }
-
-    [Theory]
-    [InlineData("[PrivateData] string")]
-    public async Task MethodNotStatic(string type)
+    public async Task MethodNotStatic()
     {
         var diagnostics = await RunGenerator(@$"
             internal partial class C
             {{
                 [LogMethod(0, LogLevel.Debug, ""M {{p0}}"")]
-                partial void M(ILogger logger, IRedactorProvider provider, {type} p0);
+                partial void M(ILogger logger, [PrivateData] string p0);
             }}");
 
         _ = Assert.Single(diagnostics);

--- a/test/Generators/Microsoft.Gen.Logging/Unit/LogParserUtilitiesTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/LogParserUtilitiesTests.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Gen.Logging.Test;
 public class LogParserUtilitiesTests
 {
     [Theory]
-    [InlineData(false, false, false, true)]
-    [InlineData(false, false, true, false)]
-    [InlineData(false, true, false, false)]
-    [InlineData(true, false, false, false)]
-    public void ShouldSkipLoggingMethodWhenParameterIsSpecial(bool isLogger, bool isRedactorProvider, bool isException, bool isLogLevel)
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    public void ShouldSkipLoggingMethodWhenParameterIsSpecial(bool isLogger, bool isException, bool isLogLevel)
     {
         const string ParamName = "param name";
 
@@ -32,7 +31,6 @@ public class LogParserUtilitiesTests
         var loggerParameter = new LoggingMethodParameter
         {
             IsLogger = isLogger,
-            IsRedactorProvider = isRedactorProvider,
             IsException = isException,
             IsLogLevel = isLogLevel
         };

--- a/test/Generators/Microsoft.Gen.Logging/Unit/LoggingMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/LoggingMethodTests.cs
@@ -16,7 +16,6 @@ public class LoggingMethodTests
         Assert.Empty(instance.Message);
         Assert.Empty(instance.Modifiers);
         Assert.Equal("_logger", instance.LoggerField);
-        Assert.Equal("_redactorProvider", instance.RedactorProviderField);
     }
 
     [Fact]

--- a/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.LogProperties.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.LogProperties.cs
@@ -606,7 +606,6 @@ public partial class ParserTests
     public async Task MultipleDataClassificationAttributes()
     {
         const string Source = @"
-            using Microsoft.Extensions.Compliance.Redaction;
             using Microsoft.Extensions.Compliance.Testing;
 
             class MyClass
@@ -619,34 +618,10 @@ public partial class ParserTests
             internal static partial class C
             {
                 [LogMethod(0, LogLevel.Debug, ""Only {A}"")]
-                static partial void M(ILogger logger, IRedactorProvider provider, [FeedbackData] string a, [LogProperties] MyClass param);
+                static partial void M(ILogger logger, [FeedbackData] string a, [LogProperties] MyClass param);
             }";
 
         await RunGenerator(Source, DiagDescriptors.MultipleDataClassificationAttributes);
-    }
-
-    [Theory]
-    [InlineData("[PrivateData]", "string")]
-    [InlineData("[PrivateData]", "int")]
-    public async Task MissingRedactorProvider(string attribute, string type)
-    {
-        string source = @$"
-            using Microsoft.Extensions.Compliance.Redaction;
-            using Microsoft.Extensions.Compliance.Testing;
-
-            class MyClass
-            {{
-                {attribute}
-                public {type} A {{ get; set; }}
-            }}
-
-            internal static partial class C
-            {{
-                [LogMethod(0, LogLevel.Debug, ""Template..."")]
-                static partial void M/*0+*/(ILogger logger, [LogProperties] MyClass param)/*-0*/;
-            }}";
-
-        await RunGenerator(source, DiagDescriptors.MissingRedactorProviderParameter);
     }
 
     [Theory]

--- a/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.cs
@@ -525,22 +525,6 @@ public partial class ParserTests
     }
 
     [Fact]
-    public async Task NoILoggerFieldWithRedactionProvider()
-    {
-        const string Source = @"
-            using Microsoft.Extensions.Compliance.Redaction;
-            using Microsoft.Extensions.Compliance.Testing;
-
-            internal partial class C
-            {
-                [LogMethod(0, LogLevel.Debug, ""M {p0}"")]
-                partial void /*0+*/M/*-0*/(IRedactorProvider provider, [PrivateData] string p0);
-            }";
-
-        await RunGenerator(Source, DiagDescriptors.MissingLoggerField);
-    }
-
-    [Fact]
     public async Task MultipleILoggerFields()
     {
         const string Source = @"
@@ -561,8 +545,6 @@ public partial class ParserTests
     public async Task InstanceEmptyLoggingMethod()
     {
         const string Source = @"
-            using Microsoft.Extensions.Compliance.Redaction;
-
             partial class C
             {
                 public ILogger _logger;
@@ -572,23 +554,15 @@ public partial class ParserTests
 
                 [LogMethod(LogLevel.Debug)]
                 public partial void /*1+*/M2/*-1*/();
-
-                [LogMethod]
-                public partial void /*2+*/M3/*-2*/(LogLevel level, IRedactorProvider provider);
-
-                [LogMethod(LogLevel.Debug)]
-                public partial void /*3+*/M4/*-3*/(IRedactorProvider provider);
             }";
 
-        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod, ignoreDiag: DiagDescriptors.MissingDataClassificationParameter);
+        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod);
     }
 
     [Fact]
     public async Task StaticEmptyLoggingMethod()
     {
         const string Source = @"
-            using Microsoft.Extensions.Compliance.Redaction;
-
             partial class C
             {
                 [LogMethod]
@@ -596,15 +570,9 @@ public partial class ParserTests
 
                 [LogMethod(LogLevel.Debug)]
                 public static partial void /*1+*/M2/*-1*/(ILogger logger);
-
-                [LogMethod]
-                public static partial void /*2+*/M3/*-2*/(ILogger logger, LogLevel level, IRedactorProvider provider);
-
-                [LogMethod(LogLevel.Debug)]
-                public static partial void /*3+*/M4/*-3*/(ILogger logger, IRedactorProvider provider);
             }";
 
-        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod, ignoreDiag: DiagDescriptors.MissingDataClassificationParameter);
+        await RunGenerator(Source, DiagDescriptors.EmptyLoggingMethod);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Logging/FakeLoggerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Testing.Tests/Logging/FakeLoggerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Telemetry.Testing.Logging;
@@ -84,15 +85,11 @@ public class FakeLoggerTests
 
         Assert.Equal(1, logger.Collector.Count);
 
-        var stateList = (List<KeyValuePair<string, string>>)logger.LatestRecord.State!;
-        Assert.Equal("K0", stateList[0].Key);
-        Assert.Equal("V0", stateList[0].Value);
-        Assert.Equal("K1", stateList[1].Key);
-        Assert.Equal("V1", stateList[1].Value);
-        Assert.Equal("K2", stateList[2].Key);
-        Assert.Null(stateList[2].Value);
-        Assert.Equal("K3", stateList[3].Key);
-        Assert.Equal("[\"0\",\"1\",\"2\"]", stateList[3].Value);
+        var ss = logger.LatestRecord.StructuredState!.ToDictionary(x => x.Key, x => x.Value);
+        Assert.Equal("V0", ss["K0"]);
+        Assert.Equal("V1", ss["K1"]);
+        Assert.Null(ss["K2"]);
+        Assert.Equal("[\"0\",\"1\",\"2\"]", ss["K3"]);
 
         logger = new FakeLogger();
         logger.Log<object?>(LogLevel.Error, new EventId(0), null, null, (_, _) => "MESSAGE");
@@ -100,11 +97,9 @@ public class FakeLoggerTests
 
         logger = new FakeLogger();
         TestLog.Hello(logger, "Bob");
-        var ss = logger.LatestRecord.StructuredState!;
-        Assert.Equal("name", ss[0].Key);
-        Assert.Equal("Bob", ss[0].Value);
-        Assert.Equal("{OriginalFormat}", ss[1].Key);
-        Assert.Equal("Hello {name}", ss[1].Value);
+        ss = logger.LatestRecord.StructuredState!.ToDictionary(x => x.Key, x => x.Value);
+        Assert.Equal("Bob", ss["name"]);
+        Assert.Equal("Hello {name}", ss["{OriginalFormat}"]);
     }
 
     [Fact]


### PR DESCRIPTION
- This new code leverages LoggerMessageState to take advantage of the new ExtendedLogger design.

- The tests were updated for three reasons:

    * Stopped using IRedactorProvider in here, this is handled by
      the ExtendedLogger

    * Fixed brittle test logic assuming the order of the name/value pairs
      produced by the logging code generator. The tests are now order-
      independent.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4233)