### PR TITLE
Revert "Don't publish Microsoft.AspNetCore.Testing (#4058)"

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Libraries/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.csproj
@@ -6,12 +6,6 @@
     <PackageTags>$(PackageTags);Testing</PackageTags>
   </PropertyGroup>
 
-  <!-- See https://github.com/dotnet/extensions/issues/4057 -->
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsShipping>false</IsShipping>
-  </PropertyGroup>
-
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreTargetFrameworks)</TargetFrameworks>
     <InjectExperimentalAttributeOnLegacy>true</InjectExperimentalAttributeOnLegacy>


### PR DESCRIPTION
This reverts commit 163e2932e43353fbaf29f939ec78815c862e4d3e.

Resolves #4057

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4234)