### PR TITLE
Remove naming constraints in auto-client.

### DIFF
--- a/src/Generators/Microsoft.Gen.AutoClient/DiagDescriptors.cs
+++ b/src/Generators/Microsoft.Gen.AutoClient/DiagDescriptors.cs
@@ -53,17 +53,7 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         messageFormat: Resources.ErrorStaticMethodMessage,
         category: Category);
 
-    public static DiagnosticDescriptor ErrorInvalidMethodName { get; } = Make(
-        id: "R9G308",
-        title: Resources.ErrorInvalidMethodNameTitle,
-        messageFormat: Resources.ErrorInvalidMethodNameMessage,
-        category: Category);
-
-    public static DiagnosticDescriptor ErrorInvalidParameterName { get; } = Make(
-        id: "R9G309",
-        title: Resources.ErrorInvalidParameterNameTitle,
-        messageFormat: Resources.ErrorInvalidParameterNameMessage,
-        category: Category);
+    // R9G308..R9G309 retired
 
     public static DiagnosticDescriptor ErrorMissingMethodAttribute { get; } = Make(
         id: "R9G310",

--- a/src/Generators/Microsoft.Gen.AutoClient/Parser.cs
+++ b/src/Generators/Microsoft.Gen.AutoClient/Parser.cs
@@ -456,14 +456,6 @@ internal sealed class Parser
     {
         var hasErrors = false;
 
-        if (methodSymbol.Name[0] == '_')
-        {
-            // can't have method names that start with _ since that can lead to conflicting symbol names
-            // because the generated symbols start with _
-            Diag(DiagDescriptors.ErrorInvalidMethodName, methodSymbol.GetLocation());
-            hasErrors = true;
-        }
-
         if (methodSymbol.Arity > 0)
         {
             // we don't currently support generic methods
@@ -579,14 +571,6 @@ internal sealed class Parser
             if (paramTypeSymbol is IErrorTypeSymbol)
             {
                 // semantic problem, just bail quietly
-                hasErrors = true;
-            }
-
-            if (paramName[0] == '_')
-            {
-                // can't have method parameter names that start with _ since that can lead to conflicting symbol names
-                // because all generated symbols start with _
-                Diag(DiagDescriptors.ErrorInvalidParameterName, paramSymbol.Locations[0]);
                 hasErrors = true;
             }
 

--- a/src/Generators/Microsoft.Gen.AutoClient/Resources.Designer.cs
+++ b/src/Generators/Microsoft.Gen.AutoClient/Resources.Designer.cs
@@ -259,42 +259,6 @@ namespace Microsoft.Gen.AutoClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API method names cannot start with _.
-        /// </summary>
-        internal static string ErrorInvalidMethodNameMessage {
-            get {
-                return ResourceManager.GetString("ErrorInvalidMethodNameMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to API method names can&apos;t start with an underscore.
-        /// </summary>
-        internal static string ErrorInvalidMethodNameTitle {
-            get {
-                return ResourceManager.GetString("ErrorInvalidMethodNameTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to API parameter names cannot start with _.
-        /// </summary>
-        internal static string ErrorInvalidParameterNameMessage {
-            get {
-                return ResourceManager.GetString("ErrorInvalidParameterNameMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to API parameter names can&apos;t start with an underscore.
-        /// </summary>
-        internal static string ErrorInvalidParameterNameTitle {
-            get {
-                return ResourceManager.GetString("ErrorInvalidParameterNameTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to An unsupported character was used in the REST method path.
         /// </summary>
         internal static string ErrorInvalidPathMessage {

--- a/src/Generators/Microsoft.Gen.AutoClient/Resources.resx
+++ b/src/Generators/Microsoft.Gen.AutoClient/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -182,18 +182,6 @@
   </data>
   <data name="ErrorInvalidHttpClientNameTitle" xml:space="preserve">
     <value>Invalid HttpClient name</value>
-  </data>
-  <data name="ErrorInvalidMethodNameMessage" xml:space="preserve">
-    <value>API method names cannot start with _</value>
-  </data>
-  <data name="ErrorInvalidMethodNameTitle" xml:space="preserve">
-    <value>API method names can't start with an underscore</value>
-  </data>
-  <data name="ErrorInvalidParameterNameMessage" xml:space="preserve">
-    <value>API parameter names cannot start with _</value>
-  </data>
-  <data name="ErrorInvalidParameterNameTitle" xml:space="preserve">
-    <value>API parameter names can't start with an underscore</value>
   </data>
   <data name="ErrorInvalidPathMessage" xml:space="preserve">
     <value>An unsupported character was used in the REST method path</value>

--- a/test/Generators/Microsoft.Gen.AutoClient/TestClasses/INameConflictTestClient.cs
+++ b/test/Generators/Microsoft.Gen.AutoClient/TestClasses/INameConflictTestClient.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+#pragma warning disable IDE1006
+
+namespace TestClasses
+{
+    [AutoClient("MyClient")]
+    public interface INameConflictTestClient
+    {
+        [Get("/api/users")]
+        public Task<string> Statics(CancellationToken cancellationToken);
+
+        [Get("/api/users")]
+        public Task<string> _httpClient(CancellationToken cancellationToken);
+
+        [Get("/api/users")]
+        public Task<string> _autoClientOptions(CancellationToken cancellationToken);
+
+        [Get("/api/users")]
+        public Task<string> GetUsers1([Header("X-MyHeader")] string? httpRequestMessage, CancellationToken cancellationToken = default);
+
+        [Get("/api/users")]
+        public Task<string> GetUsers2([Header("X-MyHeader")] string? _autoClientOptions, CancellationToken cancellationToken = default);
+
+        [Get("/api/users")]
+        public Task<string> GetUsers3([Header("X-MyHeader")] string? _httpClient, CancellationToken cancellationToken = default);
+
+        [Get("/api/users")]
+        public Task<string> GetUsers4([Header("X-MyHeader")] string? Statics, CancellationToken cancellationToken = default);
+    }
+}

--- a/test/Generators/Microsoft.Gen.AutoClient/Unit/ParserTests.cs
+++ b/test/Generators/Microsoft.Gen.AutoClient/Unit/ParserTests.cs
@@ -231,20 +231,6 @@ public class ParserTests
     }
 
     [Fact]
-    public async Task InvalidMethodName()
-    {
-        var ds = await RunGenerator(@"
-            [AutoClient(""MyClient"")]
-            public interface IClient
-            {
-                [Get(""/api/users"")]
-                public Task<string> _GetUsers(CancellationToken cancellationToken);
-            }");
-
-        Assert.Contains(DiagDescriptors.ErrorInvalidMethodName.Id, ds.Select(x => x.Id));
-    }
-
-    [Fact]
     public async Task GenericMethodUnsupported()
     {
         var ds = await RunGenerator(@"
@@ -298,20 +284,6 @@ public class ParserTests
             }");
 
         Assert.Contains(DiagDescriptors.ErrorMissingMethodAttribute.Id, ds.Select(x => x.Id));
-    }
-
-    [Fact]
-    public async Task InvalidParameterName()
-    {
-        var ds = await RunGenerator(@"
-            [AutoClient(""MyClient"")]
-            public interface IClient
-            {
-                [Get(""/api/users"")]
-                public Task<string> GetUsers(string _param, CancellationToken cancellationToken);
-            }");
-
-        Assert.Contains(DiagDescriptors.ErrorInvalidParameterName.Id, ds.Select(x => x.Id));
     }
 
     [Fact]


### PR DESCRIPTION
- The auto-client generator no longer disallows method names and parameter names that start with _. This was previously done to avoid naming conflicts with identifiers created by the generator. Now, the generator dynamically picks new names if there are conflicts with user-defined symbols.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4237)