### PR TITLE
Remove experimental label from FakeTimeProvider

### DIFF
--- a/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/ApiLifecycleAnalyzer.cs
+++ b/src/Analyzers/Microsoft.Analyzers.Local/ApiLifecycle/ApiLifecycleAnalyzer.cs
@@ -67,7 +67,8 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
         var compilation = context.Compilation;
         var obsoleteAttribute = compilation.GetTypeByMetadataName(ObsoleteAttributeFullName);
 
-        // flag symbols found in the code, but not in the model
+        // #1. flag symbols found in the code, but not in the model
+
         foreach (var symbol in assemblyAnalysis.NotFoundInBaseline)
         {
             if (!symbol.IsContaminated(ExperimentalAttributeFullName))
@@ -76,7 +77,7 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        // flag any stable or deprecated API in the model, but not in the assembly
+        // #2. flag any stable or deprecated API in the model, but not in the assembly
 
         foreach (var type in assemblyAnalysis.MissingTypes.Where(x => x.Stage != Stage.Experimental))
         {
@@ -98,7 +99,8 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
             context.ReportDiagnostic(Diagnostic.Create(DiagDescriptors.PublishedSymbolsCantBeDeleted, null, field.Member));
         }
 
-        // now make sure attributes are applied correctly
+        // #3. make sure attributes are applied correctly
+
         foreach (var (symbol, stage) in assemblyAnalysis.FoundInBaseline)
         {
             var isMarkedExperimental = symbol.IsContaminated(ExperimentalAttributeFullName);
@@ -106,11 +108,6 @@ public sealed class ApiLifecycleAnalyzer : DiagnosticAnalyzer
 
             if (stage == Stage.Experimental)
             {
-                if (!isMarkedExperimental)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(DiagDescriptors.NewSymbolsMustBeMarkedExperimental, symbol.Locations.FirstOrDefault(), symbol));
-                }
-
                 if (isMarkedObsolete)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(DiagDescriptors.ExperimentalSymbolsCantBeMarkedObsolete, symbol.Locations.FirstOrDefault(), symbol));

--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
@@ -4,11 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
-using Microsoft.Extensions.Time.Testing;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.Time.Testing;
@@ -16,7 +13,6 @@ namespace Microsoft.Extensions.Time.Testing;
 /// <summary>
 /// A synthetic time provider used to enable deterministic behavior in tests.
 /// </summary>
-[Experimental(diagnosticId: Experiments.TimeProvider, UrlFormat = Experiments.UrlFormat)]
 public class FakeTimeProvider : TimeProvider
 {
     internal readonly HashSet<Waiter> Waiters = new();

--- a/test/Analyzers/Microsoft.Analyzers.Local.Tests/ApiLifecycle/ApiLifecycleAnalyzerTest.cs
+++ b/test/Analyzers/Microsoft.Analyzers.Local.Tests/ApiLifecycle/ApiLifecycleAnalyzerTest.cs
@@ -49,11 +49,6 @@ public class ApiLifecycleAnalyzerTest
         }
     }
 
-    private const string AttributeDefinition = @"
-            namespace System.Diagnostics.CodeAnalysis;
-            internal sealed class ExperimentalAttribute : System.Attribute { }
-        ";
-
     [Theory]
     [MemberData(nameof(CodeWithMissingMembers))]
     public async Task Analyzer_Reports_Diagnostics_When_StableCode_Was_Not_Found_In_The_Compilation(int expectedDiagnostics, string fileName,
@@ -66,7 +61,6 @@ public class ApiLifecycleAnalyzerTest
                 sources: new[]
                 {
                     "[assembly: System.Runtime.Versioning.TargetFramework(\".NETCoreApp,Version=v6.0\")]",
-                    AttributeDefinition,
                     source
                 },
                 options: options,
@@ -126,7 +120,6 @@ public class ApiLifecycleAnalyzerTest
 
             "
         },
-#if false
         new object[]
         {
             1,
@@ -228,7 +221,7 @@ public class ApiLifecycleAnalyzerTest
                 using System.Collections.Generic;
                 using System.Diagnostics.CodeAnalysis;
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public class AdditionalContext2
                 {
                     protected IReadOnlyDictionary<string, object> Features { get; } = new Dictionary<string, object>();
@@ -347,7 +340,7 @@ public class ApiLifecycleAnalyzerTest
 
                 private T[] _buffer = Array.Empty<T>();
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public BufferWriter2() { }
 
                 public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, WrittenCount);
@@ -393,7 +386,6 @@ public class ApiLifecycleAnalyzerTest
             }
         "
         },
-
         new object[]
         {
             0,
@@ -474,7 +466,7 @@ public class ApiLifecycleAnalyzerTest
                     public DataClass DataClass { get; }
                 }
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public enum DataClass
                 {
 
@@ -562,10 +554,10 @@ public class ApiLifecycleAnalyzerTest
 
             using System.Diagnostics.CodeAnalysis;
 
-            [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+            [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
             public static class Test
             {
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public static void Load()
                 {
                     // Intentionally left empty.
@@ -707,7 +699,7 @@ public class ApiLifecycleAnalyzerTest
                 using System.Collections.Generic;
                 using System.Diagnostics.CodeAnalysis;
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public class WindowsCountersOptions2
                 {
                     [Required]
@@ -728,7 +720,7 @@ public class ApiLifecycleAnalyzerTest
 
                 using System.Diagnostics.CodeAnalysis;
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public sealed class BufferWriter<T>
                 {
                     internal const int MaxArrayLength = 0X7FEF_FFFF;   // Copy of the internal Array.MaxArrayLength const
@@ -751,7 +743,7 @@ public class ApiLifecycleAnalyzerTest
 
                 using System.Diagnostics.CodeAnalysis;
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public class BaseType
                 {
                     public virtual int P => 1;
@@ -774,7 +766,7 @@ public class ApiLifecycleAnalyzerTest
 
                 using System.Diagnostics.CodeAnalysis;
 
-                [Experimental(diagnosticId: "TBD", UrlFormat = "TBD")]
+                [Experimental(diagnosticId: ""TBD"", UrlFormat = ""TBD"")]
                 public class OuterType
                 {
                     public int ReadValue(string s) => new InnerType().P;
@@ -786,11 +778,40 @@ public class ApiLifecycleAnalyzerTest
                 }
             "
         }
-#endif
     };
 
     public static IEnumerable<object[]> CodeWithMissingApis => new List<object[]>
     {
+        new object[]
+        {
+            0,
+            "ApiLifecycle/Data/Microsoft.Extensions.TimeProvider.Testing.json",
+            "Microsoft.Extensions.TimeProvider.Testing",
+            DiagDescriptors.NewSymbolsMustBeMarkedExperimental,
+            @"
+                using System;
+                using System.Threading;
+
+                namespace Microsoft.Extensions.Time.Testing;
+
+                public class FakeTimeProvider : TimeProvider
+                {
+                    public FakeTimeProvider() { }
+                    public FakeTimeProvider(DateTimeOffset startDateTime) { }
+                    public DateTimeOffset Start { get; }
+                    public TimeSpan AutoAdvanceAmount { get; set; }
+                    public override DateTimeOffset GetUtcNow() => default;
+                    public void SetUtcNow(DateTimeOffset value) { }
+                    public void Advance(TimeSpan delta) { }
+                    public override long GetTimestamp() => 0;
+                    public override TimeZoneInfo LocalTimeZone => null!;
+                    public void SetLocalTimeZone(TimeZoneInfo localTimeZone) { }
+                    public override long TimestampFrequency => 0;
+                    public override string ToString() => string.Empty;
+                    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period) => null!;
+                }
+            "
+        },
         new object[]
         {
             1,

--- a/test/Analyzers/Microsoft.Analyzers.Local.Tests/ApiLifecycle/Data/Microsoft.Extensions.TimeProvider.Testing.json
+++ b/test/Analyzers/Microsoft.Analyzers.Local.Tests/ApiLifecycle/Data/Microsoft.Extensions.TimeProvider.Testing.json
@@ -3,61 +3,61 @@
   "Types": [
     {
       "Type": "class Microsoft.Extensions.Time.Testing.FakeTimeProvider : System.TimeProvider",
-      "Stage": "Stable",
+      "Stage": "Experimental",
       "Methods": [
         {
           "Member": "Microsoft.Extensions.Time.Testing.FakeTimeProvider.FakeTimeProvider();",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "Microsoft.Extensions.Time.Testing.FakeTimeProvider.FakeTimeProvider(System.DateTimeOffset startDateTime);",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.Advance(System.TimeSpan delta);",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "override System.Threading.ITimer Microsoft.Extensions.Time.Testing.FakeTimeProvider.CreateTimer(System.Threading.TimerCallback callback, object? state, System.TimeSpan dueTime, System.TimeSpan period);",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "override long Microsoft.Extensions.Time.Testing.FakeTimeProvider.GetTimestamp();",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "override System.DateTimeOffset Microsoft.Extensions.Time.Testing.FakeTimeProvider.GetUtcNow();",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.SetLocalTimeZone(System.TimeZoneInfo localTimeZone);",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "void Microsoft.Extensions.Time.Testing.FakeTimeProvider.SetUtcNow(System.DateTimeOffset value);",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "override string Microsoft.Extensions.Time.Testing.FakeTimeProvider.ToString();",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         }
       ],
       "Properties": [
         {
           "Member": "System.TimeSpan Microsoft.Extensions.Time.Testing.FakeTimeProvider.AutoAdvanceAmount { get; set; }",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "override System.TimeZoneInfo Microsoft.Extensions.Time.Testing.FakeTimeProvider.LocalTimeZone { get; }",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "System.DateTimeOffset Microsoft.Extensions.Time.Testing.FakeTimeProvider.Start { get; }",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         },
         {
           "Member": "override long Microsoft.Extensions.Time.Testing.FakeTimeProvider.TimestampFrequency { get; }",
-          "Stage": "Stable"
+          "Stage": "Experimental"
         }
       ]
     }


### PR DESCRIPTION
- Fixed a bug in the API lifecycle analyzer which complained when I removed the experimental attribute and shouldn't have.

- Reenable a bunch of analyzer tests that got turned off at some point during debugging and never turned back on.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4259)