### PR TITLE
Ensure calling ToString when auto advance is enable does not advance time

### DIFF
--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
@@ -161,7 +161,7 @@ public class FakeTimeProvider : TimeProvider
     /// Returns a string representation this provider's idea of current time.
     /// </summary>
     /// <returns>A string representing the provider's current time.</returns>
-    public override string ToString() => GetUtcNow().ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
+    public override string ToString() => _now.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
 
     /// <inheritdoc />
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)

--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
@@ -334,7 +334,7 @@ public class FakeTimeProviderTests
     [Fact]
     public void ToString_AutoAdvance_on()
     {
-        var timeProvider = new FakeTimeProvider()
+        var timeProvider = new FakeTimeProvider
         {
             AutoAdvanceAmount = TimeSpan.FromSeconds(1)
         };

--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
@@ -320,5 +320,29 @@ public class FakeTimeProviderTests
         Assert.Equal(timeProvider.Start + TimeSpan.FromSeconds(1), second);
         Assert.Equal(timeProvider.Start + TimeSpan.FromSeconds(2), third);
     }
+
+    [Fact]
+    public void ToString_AutoAdvance_off()
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        _ = timeProvider.ToString();
+
+        Assert.Equal(timeProvider.Start, timeProvider.GetUtcNow());
+    }
+
+    [Fact]
+    public void ToString_AutoAdvance_on()
+    {
+        var timeProvider = new FakeTimeProvider()
+        {
+            AutoAdvanceAmount = TimeSpan.FromSeconds(1)
+        };
+
+        _ = timeProvider.ToString();
+
+        timeProvider.AutoAdvanceAmount = TimeSpan.Zero;
+        Assert.Equal(timeProvider.Start, timeProvider.GetUtcNow());
+    }
 }
 


### PR DESCRIPTION
Fixes #4268.

Ps. I was unable to get the build to run locally on my machine, so I hope CI on GitHub can verify my changes for me.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4269)