### PR TITLE
Fix potential infinite loop in FakeTimeProvider when a timer callback changes the current time

### DIFF
--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
@@ -344,5 +344,21 @@ public class FakeTimeProviderTests
         timeProvider.AutoAdvanceAmount = TimeSpan.Zero;
         Assert.Equal(timeProvider.Start, timeProvider.GetUtcNow());
     }
-}
 
+    [Fact]
+    public void AdvanceTimeInCallback()
+    {
+        var oneSecond = TimeSpan.FromSeconds(1);
+        var timeProvider = new FakeTimeProvider();
+
+        var timer = timeProvider.CreateTimer(_ =>
+        {
+            // Advance the time with exactly the same amount as the period of the timer. This could lead to an
+            // infinite loop where this callback repeatedly gets invoked. A correct implementation however
+            // will adjust the timer's wake time so this won't be a problem.
+            timeProvider.Advance(oneSecond);
+        }, null, TimeSpan.Zero, oneSecond);
+
+        Assert.True(true, "Yay, we didn't enter an infinite loop!");
+    }
+}


### PR DESCRIPTION
Fixes #4275

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4277)