### PR TITLE
Fix the double `Resilience.Resilience` namespace

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/FailureEventMetricsOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/FailureEventMetricsOptions.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Extensions.Resilience.Resilience.Internal;
+namespace Microsoft.Extensions.Resilience.Internal;
 
 internal sealed class FailureEventMetricsOptions
 {

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/ResilienceEnricher.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/ResilienceEnricher.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Http.Telemetry;
 using Microsoft.Extensions.Options;
 using Polly.Extensions.Telemetry;
 
-namespace Microsoft.Extensions.Resilience.Resilience.Internal;
+namespace Microsoft.Extensions.Resilience.Internal;
 
 internal sealed class ResilienceEnricher
 {

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/ResilienceTagNames.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/ResilienceTagNames.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.Extensions.Resilience.Resilience.Internal;
+namespace Microsoft.Extensions.Resilience.Internal;
 
 internal static class ResilienceTagNames
 {

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceContextExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceContextExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using Polly;
 
-namespace Microsoft.Extensions.Resilience.Resilience;
+namespace Microsoft.Extensions.Resilience;
 
 /// <summary>
 /// Extensions for <see cref="ResilienceContext"/>.

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.ExceptionSummarization;
 using Microsoft.Extensions.Http.Telemetry;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Resilience.Resilience.Internal;
+using Microsoft.Extensions.Resilience.Internal;
 using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using Polly.Extensions.Telemetry;

--- a/test/Libraries/Microsoft.Extensions.Resilience.Tests/Resilience/ResilienceContextExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Resilience.Tests/Resilience/ResilienceContextExtensionsTests.cs
@@ -3,7 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.Extensions.Http.Telemetry;
-using Microsoft.Extensions.Resilience.Resilience;
+using Microsoft.Extensions.Resilience;
 using Polly;
 using Xunit;
 

--- a/test/Libraries/Microsoft.Extensions.Resilience.Tests/Resilience/ResilienceServiceCollectionExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Resilience.Tests/Resilience/ResilienceServiceCollectionExtensionsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.ExceptionSummarization;
 using Microsoft.Extensions.Http.Telemetry;
-using Microsoft.Extensions.Resilience.Resilience;
+using Microsoft.Extensions.Resilience;
 using Microsoft.Extensions.Telemetry.Testing.Metering;
 using Moq;
 using Polly;


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4293)