### PR TITLE
Remove unnecessary TcpListener initialization

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/Kubernetes/TcpEndpointHealthCheckService.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/Kubernetes/TcpEndpointHealthCheckService.cs
@@ -68,7 +68,6 @@ internal sealed class TcpEndpointHealthCheckService : BackgroundService
     protected async override Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await Task.Yield();
-        _listener.Start();
 
         while (!stoppingToken.IsCancellationRequested)
         {


### PR DESCRIPTION
It doesn't seem right to both start the `TcpListener` when we don't yet know that the system is healthy, and it's not using any connections limits. When the `UpdateHealthStatusAsync` method is called then it might not got call Start again, and even when it's called then the listener is active and the max pending connections value is not taken into account.

I was not able to create a unit test that would make it in a state where that it rejects connections since it's opening them in a fast paced while loop.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4315)