### PR TITLE
Simplify redaction logic a bit.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/Logging/LoggerMessageState.cs
@@ -60,25 +60,6 @@ public sealed partial class LoggerMessageState
     }
 
     /// <summary>
-    /// Allocates some room to put some redacted tags.
-    /// </summary>
-    /// <param name="count">The amount of space to allocate.</param>
-    /// <returns>The index in the <see cref="RedactedTagArray"/> where to store the tags.</returns>
-    public int ReserveRedactedTagSpace(int count)
-    {
-        int avail = _redactedTags.Length - NumRedactedTags;
-        if (count > avail)
-        {
-            var need = _redactedTags.Length + (count - avail);
-            Array.Resize(ref _redactedTags, need);
-        }
-
-        var index = NumRedactedTags;
-        NumRedactedTags += count;
-        return index;
-    }
-
-    /// <summary>
     /// Allocates some room to put some tags.
     /// </summary>
     /// <param name="count">The amount of space to allocate.</param>
@@ -90,6 +71,7 @@ public sealed partial class LoggerMessageState
         {
             var need = _classifiedTags.Length + (count - avail);
             Array.Resize(ref _classifiedTags, need);
+            Array.Resize(ref _redactedTags, need);
         }
 
         var index = NumClassifiedTags;
@@ -126,10 +108,9 @@ public sealed partial class LoggerMessageState
     public void Clear()
     {
         Array.Clear(_tags, 0, NumTags);
-        Array.Clear(_redactedTags, 0, NumRedactedTags);
         Array.Clear(_classifiedTags, 0, NumClassifiedTags);
+        Array.Clear(_redactedTags, 0, NumClassifiedTags);
         NumTags = 0;
-        NumRedactedTags = 0;
         NumClassifiedTags = 0;
         TagNamePrefix = string.Empty;
     }
@@ -138,11 +119,6 @@ public sealed partial class LoggerMessageState
     /// Gets a value indicating the number of unclassified tags currently in this instance.
     /// </summary>
     public int NumTags { get; private set; }
-
-    /// <summary>
-    /// Gets a value indicating the number of redacted tags currently in this instance.
-    /// </summary>
-    public int NumRedactedTags { get; private set; }
 
     /// <summary>
     /// Gets a value indicating the number of classified tags currently in this instance.

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/ExtendedLogger.ModernTagJoiner.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/ExtendedLogger.ModernTagJoiner.cs
@@ -49,7 +49,7 @@ internal sealed partial class ExtendedLogger
             _incomingTagsCount = value.NumTags;
 
             _redactedTags = value.RedactedTagArray;
-            _redactedTagsCount = value.NumRedactedTags;
+            _redactedTagsCount = value.NumClassifiedTags;
         }
 
         public KeyValuePair<string, object?> this[int index]

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Abstractions.Tests/Logging/LoggerMessageStateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Abstractions.Tests/Logging/LoggerMessageStateTests.cs
@@ -77,7 +77,6 @@ public static class LoggerMessageStateTests
 
         Assert.Equal(4, lms.NumTags);
         Assert.Equal(0, lms.NumClassifiedTags);
-        Assert.Equal(0, lms.NumRedactedTags);
 
         Assert.Equal("K1", lms.TagArray[0].Key);
         Assert.Equal("K2", lms.TagArray[1].Key);


### PR DESCRIPTION
- In LoggerMessageState, the redacted tag array is now grown in concert with the classified tag array. This makes it so if the new generated code is called using a legacy logger, the generated formatting function will never hit an "array out of bounds" exception.

- Remove some useless exception handling logic in the extended logger. This was a holdover from when the redaction logic was more complicated.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4317)