### PR TITLE
Remove default values in IHttpClientLogEnricher

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Http.Telemetry.PerformanceTests/BenchEnricher.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Telemetry.PerformanceTests/BenchEnricher.cs
@@ -12,7 +12,7 @@ internal sealed class BenchEnricher : IHttpClientLogEnricher
     private const string Key = "Performance in .NET Extensions";
     private const string Value = "is paramount.";
 
-    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response = null, Exception? exception = null)
+    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response, Exception? exception)
     {
         if (request is not null)
         {

--- a/src/Libraries/Microsoft.Extensions.Http.Telemetry/Latency/Internal/HttpClientLatencyLogEnricher.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Telemetry/Latency/Internal/HttpClientLatencyLogEnricher.cs
@@ -31,7 +31,7 @@ internal sealed class HttpClientLatencyLogEnricher : IHttpClientLogEnricher
         _enricherInvoked = tokenIssuer.GetCheckpointToken(HttpCheckpoints.EnricherInvoked);
     }
 
-    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response = null, Exception? exception = null)
+    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response, Exception? exception)
     {
         if (response != null)
         {

--- a/src/Libraries/Microsoft.Extensions.Http.Telemetry/Logging/IHttpClientLogEnricher.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Telemetry/Logging/IHttpClientLogEnricher.cs
@@ -19,5 +19,9 @@ public interface IHttpClientLogEnricher
     /// <param name="request"><see cref="HttpRequestMessage"/> object associated with the outgoing HTTP request.</param>
     /// <param name="response"><see cref="HttpResponseMessage"/> object associated with the outgoing HTTP request.</param>
     /// <param name="exception">An optional <see cref="Exception"/> that was thrown within the outgoing HTTP request processing.</param>
-    void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response = null, Exception? exception = null);
+    /// <remarks>
+    /// Please be aware that depending on the result of the HTTP request
+    /// the <paramref name="response"/> and <paramref name="exception"/> parameters may be <see langword="null"/>.
+    /// </remarks>
+    void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response, Exception? exception);
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Telemetry/Microsoft.Extensions.Http.Telemetry.json
+++ b/src/Libraries/Microsoft.Extensions.Http.Telemetry/Microsoft.Extensions.Http.Telemetry.json
@@ -185,7 +185,7 @@
       "Stage": "Stable",
       "Methods": [
         {
-          "Member": "void Microsoft.Extensions.Http.Telemetry.Logging.IHttpClientLogEnricher.Enrich(Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentTagCollector collector, System.Net.Http.HttpRequestMessage request, System.Net.Http.HttpResponseMessage? response = null, System.Exception? exception = null);",
+          "Member": "void Microsoft.Extensions.Http.Telemetry.Logging.IHttpClientLogEnricher.Enrich(Microsoft.Extensions.Telemetry.Enrichment.IEnrichmentTagCollector collector, System.Net.Http.HttpRequestMessage request, System.Net.Http.HttpResponseMessage? response, System.Exception? exception);",
           "Stage": "Stable"
         }
       ]

--- a/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Latency/Internal/HttpClientLatencyLogEnricherTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Latency/Internal/HttpClientLatencyLogEnricherTest.cs
@@ -26,7 +26,7 @@ public class HttpClientLatencyLogEnricherTest
 
         var enricher = new HttpClientLatencyLogEnricher(context, lcti.Object);
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
-        enricher.Enrich(mockEnrichmentPropertyBag.Object, null!, null);
+        enricher.Enrich(mockEnrichmentPropertyBag.Object, null!, null, null);
         mockEnrichmentPropertyBag.Verify(m => m.Add(It.IsAny<string>(), It.IsAny<object>()), Times.Never);
     }
 
@@ -46,7 +46,7 @@ public class HttpClientLatencyLogEnricherTest
         var enricher = new HttpClientLatencyLogEnricher(context, lcti.Object);
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
 
-        enricher.Enrich(mockEnrichmentPropertyBag.Object, null!, httpResponseMessage);
+        enricher.Enrich(mockEnrichmentPropertyBag.Object, null!, httpResponseMessage, null);
         mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo")), It.Is<string>(s => s.Contains("a/b"))), Times.Once);
     }
 
@@ -68,7 +68,7 @@ public class HttpClientLatencyLogEnricherTest
         var enricher = new HttpClientLatencyLogEnricher(context, lcti.Object);
         Mock<IEnrichmentTagCollector> mockEnrichmentPropertyBag = new Mock<IEnrichmentTagCollector>();
 
-        enricher.Enrich(mockEnrichmentPropertyBag.Object, null!, httpResponseMessage);
+        enricher.Enrich(mockEnrichmentPropertyBag.Object, null!, httpResponseMessage, null);
         mockEnrichmentPropertyBag.Verify(m => m.Add(It.Is<string>(s => s.Equals("latencyInfo")), It.Is<string>(s => s.Contains("a/b") && s.Contains(serverName))), Times.Once);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/Internal/EmptyEnricher.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/Internal/EmptyEnricher.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Http.Telemetry.Logging.Test.Internal;
 
 internal class EmptyEnricher : IHttpClientLogEnricher
 {
-    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response = null, Exception? exception = null)
+    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response, Exception? exception)
     {
         // intentionally left empty.
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/Internal/EnricherWithCounter.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/Internal/EnricherWithCounter.cs
@@ -11,6 +11,6 @@ internal class EnricherWithCounter : IHttpClientLogEnricher
 {
     public int TimesCalled;
 
-    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response = null, Exception? exception = null)
+    public void Enrich(IEnrichmentTagCollector collector, HttpRequestMessage request, HttpResponseMessage? response, Exception? exception)
         => TimesCalled++;
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/Internal/TestEnricher.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Telemetry.Tests/Logging/Internal/TestEnricher.cs
@@ -26,7 +26,7 @@ internal class TestEnricher : IHttpClientLogEnricher
         _throwOnEnrich = throwOnEnrich;
     }
 
-    public void Enrich(IEnrichmentTagCollector tagCollector, HttpRequestMessage request, HttpResponseMessage? response = null, Exception? exception = null)
+    public void Enrich(IEnrichmentTagCollector tagCollector, HttpRequestMessage request, HttpResponseMessage? response, Exception? exception)
     {
         if (_throwOnEnrich)
         {


### PR DESCRIPTION
This PR removes default values of parameters in `IHttpClientLogEnricher.Enrich()` method as per Iliar's suggestion in #4224 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4323)