### PR TITLE
Fix "DuplicateRequestName" error message missing requestName argument

### DIFF
--- a/src/Generators/Microsoft.Gen.AutoClient/Parser.cs
+++ b/src/Generators/Microsoft.Gen.AutoClient/Parser.cs
@@ -534,7 +534,7 @@ internal sealed class Parser
 
         if (!requestNames.Add(requestName))
         {
-            Diag(DiagDescriptors.ErrorDuplicateRequestName, methodSymbol.GetLocation());
+            Diag(DiagDescriptors.ErrorDuplicateRequestName, methodSymbol.GetLocation(), requestName);
             hasErrors = true;
         }
 

--- a/test/Generators/Microsoft.Gen.AutoClient/Unit/ParserTests.cs
+++ b/test/Generators/Microsoft.Gen.AutoClient/Unit/ParserTests.cs
@@ -399,6 +399,7 @@ public class ParserTests
             }");
 
         Assert.Contains(DiagDescriptors.ErrorDuplicateRequestName.Id, ds.Select(x => x.Id));
+        Assert.Contains("GetUsers", ds.First(x => x.Id == DiagDescriptors.ErrorDuplicateRequestName.Id).GetMessage());
     }
 
     [Fact]
@@ -416,6 +417,7 @@ public class ParserTests
             }");
 
         Assert.Contains(DiagDescriptors.ErrorDuplicateRequestName.Id, ds.Select(x => x.Id));
+        Assert.Contains("GetUsers", ds.First(x => x.Id == DiagDescriptors.ErrorDuplicateRequestName.Id).GetMessage());
     }
 
     [Fact]


### PR DESCRIPTION
fixes #4354 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4357)