### PR TITLE
Package debug symbols as *.symbols.nupkg

### DIFF
--- a/eng/MSBuild/Packaging.props
+++ b/eng/MSBuild/Packaging.props
@@ -18,7 +18,6 @@
   <!-- packaging control -->
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <!-- packaging metadata -->


### PR DESCRIPTION
The Arcade SDK doesn't support "snupkg" format, which means the debug symbols aren't getting published.

Fixes #4406

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4417)