### PR TITLE
Handle server name header present in response within RequestLatencyTelemetry middleware

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.Telemetry.Middleware/Latency/Internal/RequestLatencyTelemetryMiddleware.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Telemetry.Middleware/Latency/Internal/RequestLatencyTelemetryMiddleware.cs
@@ -60,7 +60,10 @@ internal sealed class RequestLatencyTelemetryMiddleware : IMiddleware
             context.Response.OnStarting(ctx =>
             {
                 var httpContext = (HttpContext)ctx;
-                httpContext.Response.Headers.Append(TelemetryConstants.ServerApplicationNameHeader, _applicationName);
+
+                // Set server name header to the current one.
+                httpContext.Response.Headers[TelemetryConstants.ServerApplicationNameHeader] = _applicationName;
+
                 return Task.CompletedTask;
             }, context);
         }

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -55,7 +55,4 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Telemetry.Middleware" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Tracing.Sampling\Internal\" />
-  </ItemGroup>
 </Project>

--- a/test/Libraries/Microsoft.AspNetCore.Telemetry.Middleware.Tests/Latency/Internal/RequestLatencyTelemetryMiddlewareTest.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Telemetry.Middleware.Tests/Latency/Internal/RequestLatencyTelemetryMiddlewareTest.cs
@@ -76,6 +76,36 @@ public class RequestLatencyTelemetryMiddlewareTest
     }
 
     [Fact]
+    public async Task RequestLatency_WithServerNameHeadersSet_ReturnsLastServerName()
+    {
+        var ex1 = new TestExporter();
+        var ex2 = new TestExporter();
+        string serverName = "AppServer";
+        var m = new RequestLatencyTelemetryMiddleware(
+            Options.Create(new RequestLatencyTelemetryOptions()), new List<ILatencyDataExporter> { ex1, ex2 },
+            Options.Create(new ApplicationMetadata { ApplicationName = serverName }));
+        var lc = GetMockLatencyContext();
+        var httpContextMock = GetHttpContext(lc.Object);
+        var fakeHttpResponseFeature = new FakeHttpResponseFeature();
+        httpContextMock.Features.Set<IHttpResponseFeature>(fakeHttpResponseFeature);
+        httpContextMock.Response.Headers.Add(TelemetryConstants.ServerApplicationNameHeader, "testValue");
+        var nextInvoked = false;
+        await m.InvokeAsync(httpContextMock, (_) =>
+        {
+            nextInvoked = true;
+            return Task.CompletedTask;
+        });
+        await fakeHttpResponseFeature.StartAsync();
+        lc.Verify(c => c.Freeze());
+        var header = httpContextMock.Response.Headers[TelemetryConstants.ServerApplicationNameHeader];
+        Assert.NotEmpty(header);
+        Assert.Equal(serverName, header[0]);
+        Assert.True(nextInvoked);
+        Assert.True(ex1.Invoked == 1);
+        Assert.True(ex2.Invoked == 1);
+    }
+
+    [Fact]
     public async Task RequestLatency_NoServiceData_DoesNotAddHeader()
     {
         var ex1 = new TestExporter();

--- a/test/Libraries/Microsoft.AspNetCore.Telemetry.Middleware.Tests/Latency/Internal/RequestLatencyTelemetryMiddlewareTest.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Telemetry.Middleware.Tests/Latency/Internal/RequestLatencyTelemetryMiddlewareTest.cs
@@ -88,7 +88,7 @@ public class RequestLatencyTelemetryMiddlewareTest
         var httpContextMock = GetHttpContext(lc.Object);
         var fakeHttpResponseFeature = new FakeHttpResponseFeature();
         httpContextMock.Features.Set<IHttpResponseFeature>(fakeHttpResponseFeature);
-        httpContextMock.Response.Headers.Add(TelemetryConstants.ServerApplicationNameHeader, "testValue");
+        httpContextMock.Response.Headers.Append(TelemetryConstants.ServerApplicationNameHeader, "testValue");
         var nextInvoked = false;
         await m.InvokeAsync(httpContextMock, (_) =>
         {


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4421)