### PR TITLE
Improved DownstreamDependencyMetadataManager to handle trailing slash…

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -55,7 +55,4 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Telemetry.Middleware" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Tracing.Sampling\Internal\" />
-  </ItemGroup>
 </Project>

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Telemetry/DownstreamDependencyMetadataManager.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Telemetry/DownstreamDependencyMetadataManager.cs
@@ -350,9 +350,8 @@ internal sealed class DownstreamDependencyMetadataManager : IDownstreamDependenc
             return hostMetadata.RequestMetadata;
         }
 
-
         ReadOnlySpan<char> requestRouteAsSpan;
-        if (requestPath[requestPath.Length -1] == '/')
+        if (requestPath[requestPath.Length - 1] == '/')
         {
             requestRouteAsSpan = requestPath.AsSpan(0, requestPath.Length - 1);
         }

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Telemetry/BackslashDownstreamDependencyMetadata.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Telemetry/BackslashDownstreamDependencyMetadata.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Http.Telemetry;
+
+namespace Microsoft.Extensions.Telemetry.Telemetry;
+
+internal sealed class BackslashDownstreamDependencyMetadata : IDownstreamDependencyMetadata
+{
+    private static readonly ISet<string> _uniqueHostNameSuffixes = new HashSet<string>
+    {
+        "anotherservice.net",
+    };
+
+    private static readonly ISet<RequestMetadata> _requestMetadataSet = new HashSet<RequestMetadata>
+    {
+        new ("DELETE", "/singlebackslash", "StartingSingleBackslash"),
+        new ("POST", "//doublebackslash", "StartingDoublebackslash"),
+        new ("PUT", "/singlethensingle/", "StartingSingleBackslashEndingSingleBackslash"),
+        new ("GET", "//doublethensingle/", "StartingDoublebackslashEndingSingleBackslash"),
+    };
+
+    public string DependencyName => "BackslashService";
+
+    public ISet<string> UniqueHostNameSuffixes => _uniqueHostNameSuffixes;
+
+    public ISet<RequestMetadata> RequestMetadata => _requestMetadataSet;
+}

--- a/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Telemetry/DownstreamDependencyMetadataManagerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Telemetry.Tests/Telemetry/DownstreamDependencyMetadataManagerTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Telemetry.Internal;
+using Xunit;
+
+namespace Microsoft.Extensions.Telemetry.Telemetry;
+
+public class DownstreamDependencyMetadataManagerTests : IDisposable
+{
+    private readonly IDownstreamDependencyMetadataManager _depMetadataManager;
+    private readonly ServiceProvider _sp;
+
+    public DownstreamDependencyMetadataManagerTests()
+    {
+        _sp = new ServiceCollection()
+            .AddDownstreamDependencyMetadata(new BackslashDownstreamDependencyMetadata())
+            .BuildServiceProvider();
+        _depMetadataManager = _sp.GetRequiredService<IDownstreamDependencyMetadataManager>();
+    }
+
+    [Theory]
+    [InlineData("DELETE", "https://anotherservice.net/singlebackslash", "StartingSingleBackslash", "/singlebackslash")]
+    [InlineData("POST", "https://anotherservice.net/doublebackslash", "StartingDoublebackslash", "//doublebackslash")]
+    [InlineData("PUT", "https://anotherservice.net/singlethensingle", "StartingSingleBackslashEndingSingleBackslash", "/singlethensingle/")]
+    [InlineData("GET", "https://anotherservice.net/doublethensingle", "StartingDoublebackslashEndingSingleBackslash", "//doublethensingle/")]
+
+    [InlineData("DELETE", "https://anotherservice.net//singlebackslash", "StartingSingleBackslash", "/singlebackslash")]
+    [InlineData("POST", "https://anotherservice.net//doublebackslash", "StartingDoublebackslash", "//doublebackslash")]
+    [InlineData("PUT", "https://anotherservice.net//singlethensingle", "StartingSingleBackslashEndingSingleBackslash", "/singlethensingle/")]
+    [InlineData("GET", "https://anotherservice.net//doublethensingle", "StartingDoublebackslashEndingSingleBackslash", "//doublethensingle/")]
+
+    [InlineData("DELETE", "https://anotherservice.net/singlebackslash/", "StartingSingleBackslash", "/singlebackslash")]
+    [InlineData("POST", "https://anotherservice.net/doublebackslash/", "StartingDoublebackslash", "//doublebackslash")]
+    [InlineData("PUT", "https://anotherservice.net/singlethensingle/", "StartingSingleBackslashEndingSingleBackslash", "/singlethensingle/")]
+    [InlineData("GET", "https://anotherservice.net/doublethensingle/", "StartingDoublebackslashEndingSingleBackslash", "//doublethensingle/")]
+
+    [InlineData("DELETE", "https://anotherservice.net//singlebackslash/", "StartingSingleBackslash", "/singlebackslash")]
+    [InlineData("POST", "https://anotherservice.net//doublebackslash/", "StartingDoublebackslash", "//doublebackslash")]
+    [InlineData("PUT", "https://anotherservice.net//singlethensingle/", "StartingSingleBackslashEndingSingleBackslash", "/singlethensingle/")]
+    [InlineData("GET", "https://anotherservice.net//doublethensingle/", "StartingDoublebackslashEndingSingleBackslash", "//doublethensingle/")]
+    public void GetRequestMetadata_RoutesRegisteredWithBackslashes_ShouldReturnHostMetadata(string httpMethod, string urlString, string expectedRequestName, string expectedRequestRoute)
+    {
+        using var requestMessage = new HttpRequestMessage
+        {
+            Method = new HttpMethod(method: httpMethod),
+            RequestUri = new Uri(uriString: urlString)
+        };
+
+        var requestMetadata = _depMetadataManager.GetRequestMetadata(requestMessage);
+        Assert.NotNull(requestMetadata);
+        Assert.Equal(new BackslashDownstreamDependencyMetadata().DependencyName, requestMetadata.DependencyName);
+        Assert.Equal(expectedRequestName, requestMetadata.RequestName);
+        Assert.Equal(expectedRequestRoute, requestMetadata.RequestRoute);
+        Assert.Equal(httpMethod, requestMetadata.MethodType);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _sp.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
… in HTTP routes

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4422)