### PR TITLE
Encode query parameters for AutoClient

### DIFF
--- a/src/Generators/Microsoft.Gen.AutoClient/Emitter.cs
+++ b/src/Generators/Microsoft.Gen.AutoClient/Emitter.cs
@@ -231,17 +231,24 @@ internal sealed class Emitter : EmitterBase
         var firstQuery = true;
         foreach (var param in restApiMethod.AllParameters.Where(m => m.IsQuery))
         {
+            var escapedParamName = $"{param.Name}Escaped";
+
+            // Use interpolated string to handle any null values from any type like nullable value types or reference types.
+            OutLn($"var {escapedParamName} = {Uri}.EscapeDataString($\"{{{param.Name}}}\");");
+
             if (firstQuery)
             {
-                _ = pathSb.Append($"?{param.QueryKey}={{{param.Name}}}");
+                _ = pathSb.Append($"?{param.QueryKey}={{{escapedParamName}}}");
             }
             else
             {
-                _ = pathSb.Append($"&{param.QueryKey}={{{param.Name}}}");
+                _ = pathSb.Append($"&{param.QueryKey}={{{escapedParamName}}}");
             }
 
             firstQuery = false;
         }
+
+        OutLn();
 
         var definePath = restApiMethod.FormatParameters.Count > 0 || !firstQuery;
         var body = restApiMethod.AllParameters.FirstOrDefault(m => m.IsBody);

--- a/test/Generators/Microsoft.Gen.AutoClient/Generated/QueryTests.cs
+++ b/test/Generators/Microsoft.Gen.AutoClient/Generated/QueryTests.cs
@@ -60,6 +60,27 @@ public class QueryTests : IDisposable
     }
 
     [Fact]
+    public async Task QueryIsEscaped()
+    {
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.Is<HttpRequestMessage>(message =>
+                message.Method == HttpMethod.Get &&
+                message.RequestUri != null &&
+                message.RequestUri.PathAndQuery == "/api/users?paramQuery=http%3A%2F%2Fmicrosoft.com"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("Success!")
+            });
+
+        var response = await _sut.GetUsers("http://microsoft.com");
+
+        Assert.Equal("Success!", response);
+    }
+
+    [Fact]
     public async Task QueryFromParameterCustom()
     {
         _handlerMock


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4424)