### PR TITLE
Enhance path validation logic

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.AutoClient/AutoClientUtilities.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.AutoClient/AutoClientUtilities.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+
+namespace Microsoft.Extensions.Http.AutoClient;
+
+/// <summary>
+/// Utilities for AutoClient feature.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class AutoClientUtilities
+{
+    private static readonly char[] _slashes = { '/', '\\' };
+    private static readonly char[] _slashesOrDot = { '/', '\\', '.' };
+
+    /// <summary>
+    /// Returns whether a value is a valid path argument.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <returns>Whether the value is a valid path argument.</returns>
+    public static bool IsPathParameterValid(string value)
+    {
+        var trimmed = value.AsSpan().Trim();
+
+        if (trimmed.Length == 0)
+        {
+            return false;
+        }
+
+        // Fast path for most common cases
+        var index = trimmed.IndexOfAny(_slashesOrDot);
+        if (index == -1)
+        {
+            return true;
+        }
+
+        // Slashes can't be used
+        if (trimmed.Slice(index).IndexOfAny(_slashes) >= 0)
+        {
+            return false;
+        }
+
+        // The trimmed string can't be made of dots only
+
+#if NET7_0_OR_GREATER
+
+        if (trimmed.IndexOfAnyExcept('.') >= 0)
+        {
+            return true;
+        }
+
+#else
+
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            if (trimmed[i] != '.')
+            {
+                return true;
+            }
+        }
+
+#endif
+
+        return false;
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.Http.AutoClient/Microsoft.Extensions.Http.AutoClient.json
+++ b/src/Libraries/Microsoft.Extensions.Http.AutoClient/Microsoft.Extensions.Http.AutoClient.json
@@ -116,6 +116,16 @@
       ]
     },
     {
+      "Type": "static class Microsoft.Extensions.Http.AutoClient.AutoClientUtilities",
+      "Stage": "Stable",
+      "Methods": [
+        {
+          "Member": "static bool IsPathParameterValid(string value);",
+          "Stage": "Stable"
+        }
+      ]
+    },
+    {
       "Type": "sealed class Microsoft.Extensions.Http.AutoClient.BodyAttribute : System.Attribute",
       "Stage": "Stable",
       "Methods": [

--- a/src/Libraries/Microsoft.Extensions.Http.AutoClient/Microsoft.Extensions.Http.AutoClient.json
+++ b/src/Libraries/Microsoft.Extensions.Http.AutoClient/Microsoft.Extensions.Http.AutoClient.json
@@ -120,7 +120,7 @@
       "Stage": "Stable",
       "Methods": [
         {
-          "Member": "static bool IsPathParameterValid(string value);",
+          "Member": "static bool Microsoft.Extensions.Http.AutoClient.AutoClientUtilities.IsPathParameterValid(string value);",
           "Stage": "Stable"
         }
       ]


### PR DESCRIPTION
Adding query arguments tests for the chars `?`, `/`, `%`, `#`, ` `

Adding these rules for path segment arguments:

- If the string contains '/' or '\' anywhere, fail.
- If after calling string.Trim():
  - The string is empty, fail.
  - The string contains only '.' characters, fail.
  
This is because we don't think it's legitimate for users to be able to use these as valid path arguments since it could be provided by user data (tenant name, username, ...) and escaping could be tricky as servers might un-encode them.

I am not sure `ArgumentException` is the best here so please send suggestions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4495)