### PR TITLE
Expose ResilienceHandlerContext.OnPipelineDisposed

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.json
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.json
@@ -346,6 +346,14 @@
         {
           "Member": "void Microsoft.Extensions.Http.Resilience.ResilienceHandlerContext.EnableReloads<TOptions>(string? name = null);",
           "Stage": "Stable"
+        },
+        {
+          "Member": "TOptions Microsoft.Extensions.Http.Resilience.ResilienceHandlerContext.GetOptions<TOptions>(string name);",
+          "Stage": "Stable"
+        },
+        {
+          "Member": "void Microsoft.Extensions.Http.Resilience.ResilienceHandlerContext.OnPipelineDisposed(System.Action callback);",
+          "Stage": "Stable"
         }
       ],
       "Properties": [

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.Http.Resilience.Internal;
+using Microsoft.Shared.Diagnostics;
 using Polly.DependencyInjection;
 
 namespace Microsoft.Extensions.Http.Resilience;
@@ -48,5 +49,20 @@ public sealed class ResilienceHandlerContext
     /// </remarks>
     public void EnableReloads<TOptions>(string? name = null) => _context.EnableReloads<TOptions>(name);
 
-    internal T GetOptions<T>(string name) => _context.GetOptions<T>(name);
+    /// <summary>
+    /// Gets the options identified by <paramref name="name"/>.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type.</typeparam>
+    /// <param name="name">The options name, if any.</param>
+    /// <returns>The options instance.</returns>
+    /// <remarks>
+    /// If <paramref name="name"/> is <see langword="null"/> then the global options are returned.
+    /// </remarks>
+    public TOptions GetOptions<TOptions>(string name) => _context.GetOptions<TOptions>(name);
+
+    /// <summary>
+    /// Registers a callback that is called when the pipeline instance being configured is disposed.
+    /// </summary>
+    /// <param name="callback">The callback delegate.</param>
+    public void OnPipelineDisposed(Action callback) => _context.OnPipelineDisposed(Throw.IfNull(callback));
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
@@ -57,6 +57,32 @@ public sealed partial class HttpClientBuilderExtensionsTests
     }
 
     [Fact]
+    public async Task AddResilienceHandler_OnPipelineDisposed_EnsureCalled()
+    {
+        var onPipelineDisposedCalled = false;
+        var services = new ServiceCollection();
+        IHttpClientBuilder? builder = services
+            .AddHttpClient("client")
+            .ConfigurePrimaryHttpMessageHandler(() => new TestHandlerStub(HttpStatusCode.OK));
+
+        builder.AddResilienceHandler("test", (builder, context) =>
+        {
+            builder.AddTimeout(TimeSpan.FromSeconds(1));
+            context.OnPipelineDisposed(() => onPipelineDisposedCalled = true);
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://dummy");
+
+        await client.GetStringAsync("https://dummy");
+        serviceProvider.Dispose();
+
+        onPipelineDisposedCalled.Should().BeTrue();
+    }
+
+    [Fact]
     public void AddResilienceHandler_EnsureServicesNotAddedTwice()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
These are Polly APIs that important when dealing with disposable pipeline resources.

Additionally, I have also exposed `GetOptions` API to have parity with Polly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4497)