### PR TITLE
Disable VS Code solution file creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bld/
 .vs/
 .build/
 .vscode
+!.vscode/settings.json
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet.automaticallyCreateSolutionInWorkspace": false
+}


### PR DESCRIPTION
Prevent C# Dev Kit from creating a solution file if the repository is opened in Visual Studio Code, as the generated file breaks the build/restore scripts.

Resolves #4488.

Supersedes #4509.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4517)