### PR TITLE
Remove IMiddleware

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/CapturePipelineEntryMiddleware.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/CapturePipelineEntryMiddleware.cs
@@ -5,25 +5,27 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Latency;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.AspNetCore.Diagnostics.Latency;
 
 /// <summary>
 /// Middleware that should be put at the beginning of the middleware pipeline to capture time.
 /// </summary>
-internal sealed class CapturePipelineEntryMiddleware : IMiddleware
+internal sealed class CapturePipelineEntryMiddleware
 {
     private readonly CheckpointToken _elapsedTillEntry;
+    private readonly RequestDelegate _next;
 
-    public CapturePipelineEntryMiddleware(ILatencyContextTokenIssuer tokenIssuer)
+    public CapturePipelineEntryMiddleware(RequestDelegate next, ILatencyContextTokenIssuer tokenIssuer)
     {
         _elapsedTillEntry = tokenIssuer.GetCheckpointToken(RequestCheckpointConstants.ElapsedTillEntryMiddleware);
+        _next = Throw.IfNull(next);
     }
 
-    /// <inheritdoc/>
-    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    public async Task InvokeAsync(HttpContext context)
     {
-        await next(context).ConfigureAwait(false);
+        await _next(context).ConfigureAwait(false);
 
         var latencyContext = context.RequestServices.GetRequiredService<ILatencyContext>();
         latencyContext.AddCheckpoint(_elapsedTillEntry);

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/CapturePipelineEntryStartupFilter.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/CapturePipelineEntryStartupFilter.cs
@@ -22,7 +22,7 @@ internal sealed class CapturePipelineEntryStartupFilter : IStartupFilter
     {
         return builder =>
         {
-            _ = builder.UseMiddleware<CapturePipelineEntryMiddleware>(Array.Empty<object>());
+            _ = builder.UseMiddleware<CapturePipelineEntryMiddleware>();
             next(builder);
         };
     }

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/CapturePipelineExitMiddleware.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/CapturePipelineExitMiddleware.cs
@@ -5,31 +5,33 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Latency;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.AspNetCore.Diagnostics.Latency;
 
 /// <summary>
 /// Middleware that should be put at the end of the pipeline to capture time.
 /// </summary>
-internal sealed class CapturePipelineExitMiddleware : IMiddleware
+internal sealed class CapturePipelineExitMiddleware
 {
     private readonly CheckpointToken _elapsedTillPipelineExit;
 
     private readonly CheckpointToken _elapsedResponseProcessed;
+    private readonly RequestDelegate _next;
 
-    public CapturePipelineExitMiddleware(ILatencyContextTokenIssuer tokenIssuer)
+    public CapturePipelineExitMiddleware(RequestDelegate next, ILatencyContextTokenIssuer tokenIssuer)
     {
         _elapsedTillPipelineExit = tokenIssuer.GetCheckpointToken(RequestCheckpointConstants.ElapsedTillPipelineExitMiddleware);
         _elapsedResponseProcessed = tokenIssuer.GetCheckpointToken(RequestCheckpointConstants.ElapsedResponseProcessed);
+        _next = Throw.IfNull(next);
     }
 
-    /// <inheritdoc/>
-    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    public async Task InvokeAsync(HttpContext context)
     {
         var latencyContext = context.RequestServices.GetRequiredService<ILatencyContext>();
         latencyContext.AddCheckpoint(_elapsedTillPipelineExit);
 
-        await next(context).ConfigureAwait(false);
+        await _next(context).ConfigureAwait(false);
 
         latencyContext.AddCheckpoint(_elapsedResponseProcessed);
     }

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/RequestLatencyTelemetryApplicationBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/RequestLatencyTelemetryApplicationBuilderExtensions.cs
@@ -20,9 +20,9 @@ public static class RequestLatencyTelemetryApplicationBuilderExtensions
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static IApplicationBuilder UseRequestCheckpoint(this IApplicationBuilder builder)
         => Throw.IfNull(builder)
-            .UseMiddleware<AddServerTimingHeaderMiddleware>([])
-            .UseMiddleware<CaptureResponseTimeMiddleware>([])
-            .UseMiddleware<CapturePipelineExitMiddleware>([]);
+            .UseMiddleware<AddServerTimingHeaderMiddleware>()
+            .UseMiddleware<CaptureResponseTimeMiddleware>()
+            .UseMiddleware<CapturePipelineExitMiddleware>();
 
     /// <summary>
     /// Adds the request latency telemetry middleware to <see cref="IApplicationBuilder"/> request execution pipeline.
@@ -32,5 +32,5 @@ public static class RequestLatencyTelemetryApplicationBuilderExtensions
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null" />.</exception>
     public static IApplicationBuilder UseRequestLatencyTelemetry(this IApplicationBuilder builder)
         => Throw.IfNull(builder)
-        .UseMiddleware<RequestLatencyTelemetryMiddleware>([]);
+        .UseMiddleware<RequestLatencyTelemetryMiddleware>();
 }

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/RequestLatencyTelemetryServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/Latency/RequestLatencyTelemetryServiceCollectionExtensions.cs
@@ -25,11 +25,7 @@ public static class RequestLatencyTelemetryServiceCollectionExtensions
     /// <exception cref="ArgumentNullException"><paramref name="services"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddRequestCheckpoint(this IServiceCollection services)
         => Throw.IfNull(services)
-        .AddSingleton<CaptureResponseTimeMiddleware>()
-        .AddSingleton<AddServerTimingHeaderMiddleware>()
-        .AddSingleton<CapturePipelineEntryMiddleware>()
         .AddPipelineEntryCheckpoint()
-        .AddSingleton<CapturePipelineExitMiddleware>()
         .RegisterCheckpointNames(RequestCheckpointConstants.RequestCheckpointNames);
 
     /// <summary>
@@ -43,7 +39,6 @@ public static class RequestLatencyTelemetryServiceCollectionExtensions
         _ = Throw.IfNull(services);
 
         services.TryAddScoped(p => p.GetRequiredService<ILatencyContextProvider>().CreateContext());
-        services.TryAddSingleton<RequestLatencyTelemetryMiddleware>();
 
         _ = services.AddOptionsWithValidateOnStart<RequestLatencyTelemetryOptions, RequestLatencyTelemetryOptionsValidator>();
 

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/AddServerTimingHeaderMiddlewareTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/AddServerTimingHeaderMiddlewareTests.cs
@@ -38,8 +38,8 @@ public class AddServerTimingHeaderMiddlewareTests
         var fakeHttpResponseFeature = new FakeHttpResponseFeature();
         context.Features.Set<IHttpResponseFeature>(fakeHttpResponseFeature);
 
-        var middleware = new AddServerTimingHeaderMiddleware();
-        await middleware.InvokeAsync(context, _stubRequestDelegate);
+        var middleware = new AddServerTimingHeaderMiddleware(_stubRequestDelegate);
+        await middleware.InvokeAsync(context);
         await fakeHttpResponseFeature.StartAsync();
 
         var header = context.Response.Headers[AddServerTimingHeaderMiddleware.ServerTimingHeaderName];

--- a/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/RequestLatencyTelemetryExtensionsTests.cs
+++ b/test/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware.Tests/Latency/RequestLatencyTelemetryExtensionsTests.cs
@@ -28,17 +28,6 @@ public class RequestLatencyTelemetryExtensionsTests
     }
 
     [Fact]
-    public void RequestLatencyExtensions_AddRequestLatency_AddsMiddleware()
-    {
-        using var serviceProvider = new ServiceCollection()
-            .AddLatencyContext()
-            .AddRequestLatencyTelemetry()
-            .BuildServiceProvider();
-
-        Assert.NotNull(serviceProvider.GetService<RequestLatencyTelemetryMiddleware>());
-    }
-
-    [Fact]
     public void RequestLatencyExtensions_AddRequestLatency_AddsLatencyContext()
     {
         using var serviceProvider = new ServiceCollection()
@@ -55,19 +44,6 @@ public class RequestLatencyTelemetryExtensionsTests
             scope1.ServiceProvider.GetService<ILatencyContext>());
         Assert.NotEqual(scope1.ServiceProvider.GetService<ILatencyContext>(),
             scope2.ServiceProvider.GetService<ILatencyContext>());
-    }
-
-    [Fact]
-    public void RequestLatencyExtensions_AddRequestLatency_InvokesConfig()
-    {
-        bool invoked = false;
-        using var serviceProvider = new ServiceCollection()
-            .AddLatencyContext()
-            .AddRequestLatencyTelemetry(a => { invoked = true; })
-            .BuildServiceProvider();
-
-        Assert.NotNull(serviceProvider.GetService<RequestLatencyTelemetryMiddleware>());
-        Assert.True(invoked);
     }
 
     [Fact]


### PR DESCRIPTION
There are two main patterns for implementing AspNetCore middleware, IMiddleware or convention based. The IMiddleware API is only recommended for specific scenarios and is less efficient per-request.
https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/extensibility?view=aspnetcore-7.0

I've converted the middleware to the convention approach that we use throughout aspnetcore.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4521)