### PR TITLE
Fix [EnumStrings] source-gen bug with global namespaces

### DIFF
--- a/src/Generators/Microsoft.Gen.EnumStrings/Parser.cs
+++ b/src/Generators/Microsoft.Gen.EnumStrings/Parser.cs
@@ -211,12 +211,17 @@ internal sealed class Parser
                         members = members.Distinct(new EntryComparer());
                     }
 
+                    var resultingNamespace = nspace ??
+                        (enumType.ContainingNamespace.IsGlobalNamespace
+                            ? string.Empty
+                            : enumType.ContainingNamespace.ToString());
+
                     results.Add(new ToStringMethod(
                         enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                         members.Select(kvp => kvp.Key).ToList(),
                         members.Select(kvp => kvp.Value).ToList(),
                         flags,
-                        nspace ?? enumType.ContainingNamespace.ToString(),
+                        resultingNamespace,
                         className ?? enumType.Name + "Extensions",
                         methodName ?? "ToInvariantString",
                         classModifiers ?? "internal static",

--- a/test/Generators/Microsoft.Gen.EnumStrings/TestClasses/NoNamespace.cs
+++ b/test/Generators/Microsoft.Gen.EnumStrings/TestClasses/NoNamespace.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 
-using Microsoft.R9.Extensions.Runtime;
+using Microsoft.Extensions.EnumStrings;
 
 [EnumStrings]
 public enum NoNamespace

--- a/test/Generators/Microsoft.Gen.EnumStrings/TestClasses/NoNamespace.cs
+++ b/test/Generators/Microsoft.Gen.EnumStrings/TestClasses/NoNamespace.cs
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. All Rights Reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.EnumStrings;
 

--- a/test/Generators/Microsoft.Gen.EnumStrings/TestClasses/NoNamespace.cs
+++ b/test/Generators/Microsoft.Gen.EnumStrings/TestClasses/NoNamespace.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+using Microsoft.R9.Extensions.Runtime;
+
+[EnumStrings]
+public enum NoNamespace
+{
+    Value
+}


### PR DESCRIPTION
This PR fixes a bug when `[EnumStrings]` is applied on an enum that was placed in global namespace.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4563)