### PR TITLE
Improve HTTP benchmarks

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/EmptyHandler.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/EmptyHandler.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Extensions.Http.Resilience.Bench;
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
 
 internal sealed class EmptyHandler : DelegatingHandler
 {

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HedgingBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HedgingBenchmark.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.Http.Resilience.Bench;
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
 
 public class HedgingBenchmark
 {

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpClientFactory.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpClientFactory.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 #pragma warning disable EA0006 // Replace uses of 'Enum.GetName' and 'Enum.ToString' with the '[EnumStrings]' code generator for improved performance
 
-namespace Microsoft.Extensions.Http.Resilience.Bench;
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
 
 [Flags]
 [SuppressMessage("Performance", "EA0004:Make types declared in an executable internal", Justification = "Needs to be public for BenchmarkDotNet consumption")]

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/HttpResilienceBenchmark.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.Http.Resilience.Bench;
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
 
 public class HttpResilienceBenchmark
 {

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Microsoft.Extensions.Http.Resilience.PerformanceTests.csproj
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Microsoft.Extensions.Http.Resilience.PerformanceTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RootNamespace>Microsoft.Extensions.Http.Resilience.FaultInjection.PerformanceTests</RootNamespace>
+    <RootNamespace>Microsoft.Extensions.Http.Resilience.PerformanceTests</RootNamespace>
     <Description>Benchmarks for Microsoft.Extensions.Http.Resilience.</Description>
   </PropertyGroup>
 
@@ -10,4 +10,10 @@
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Testing\Microsoft.Extensions.Compliance.Testing.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Compliance.Redaction\Microsoft.Extensions.Compliance.Redaction.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Polly" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
+  </ItemGroup>
+  
 </Project>

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/NoRemoteCallHandler.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/NoRemoteCallHandler.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Extensions.Http.Resilience.Bench;
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
 
 internal sealed class NoRemoteCallHandler : DelegatingHandler
 {

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Program.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/Program.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
-namespace Microsoft.Extensions.Http.Resilience.FaultInjection.Benchmark
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests
 {
     internal static class Program
     {

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/RetryBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/RetryBenchmark.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Polly;
+using Polly.Timeout;
+
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
+
+public class RetryBenchmark
+{
+    private static readonly Uri _uri = new(HttpClientFactory.PrimaryEndpoint);
+
+    private HttpClient _v7 = null!;
+    private HttpClient _v8 = null!;
+    private CancellationToken _cancellationToken;
+
+    private static HttpRequestMessage Request => new(HttpMethod.Post, _uri);
+
+    [GlobalSetup]
+    public void Prepare()
+    {
+        _cancellationToken = new CancellationTokenSource().Token;
+
+        var services = new ServiceCollection();
+
+        // The ResiliencePipelineBuilder added by Polly includes telemetry, which affects the results.
+        // Since Polly v7 does not include telemetry either, let's disable the telemetry for v8 for fair results.
+        services.TryAddTransient<ResiliencePipelineBuilder>();
+
+        services
+            .AddHttpClient("v8")
+            .ConfigurePrimaryHttpMessageHandler(() => new NoRemoteCallHandler())
+            .AddResilienceHandler("my-retries", builder => builder.AddRetry(new HttpRetryStrategyOptions
+            {
+                BackoffType = DelayBackoffType.Constant,
+                Delay = TimeSpan.FromSeconds(1),
+                MaxRetryAttempts = 3
+            }));
+
+        var builder = Policy.Handle<HttpRequestException>().Or<TimeoutRejectedException>().OrResult<HttpResponseMessage>(r =>
+        {
+            var statusCode = (int)r.StatusCode;
+
+            return statusCode >= 500 ||
+                r.StatusCode == HttpStatusCode.RequestTimeout ||
+                statusCode == 429;
+        });
+
+        services
+            .AddHttpClient("v7")
+            .ConfigurePrimaryHttpMessageHandler(() => new NoRemoteCallHandler())
+            .AddPolicyHandler(builder.WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(1)));
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+
+        _v7 = factory.CreateClient("v7");
+        _v8 = factory.CreateClient("v8");
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<HttpResponseMessage> Retry_Polly_V7()
+    {
+        return _v7!.SendAsync(Request, _cancellationToken);
+    }
+
+    [Benchmark]
+    public Task<HttpResponseMessage> Retry_Polly_V8()
+    {
+        return _v8!.SendAsync(Request, _cancellationToken);
+    }
+}

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/StandardResilienceBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/StandardResilienceBenchmark.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Polly;
+using Polly.Timeout;
+
+namespace Microsoft.Extensions.Http.Resilience.PerformanceTests;
+
+public class StandardResilienceBenchmark
+{
+    private static readonly Uri _uri = new(HttpClientFactory.PrimaryEndpoint);
+
+    private HttpClient _v7 = null!;
+    private HttpClient _v8 = null!;
+    private CancellationToken _cancellationToken;
+
+    private static HttpRequestMessage Request => new(HttpMethod.Post, _uri);
+
+    [GlobalSetup]
+    public void Prepare()
+    {
+        _cancellationToken = new CancellationTokenSource().Token;
+
+        var services = new ServiceCollection();
+
+        // The ResiliencePipelineBuilder added by Polly includes telemetry, which affects the results.
+        // Since Polly v7 does not include telemetry either, let's disable the telemetry for v8 for fair results.
+        services.TryAddTransient<ResiliencePipelineBuilder>();
+
+        services
+            .AddHttpClient("v8")
+            .ConfigurePrimaryHttpMessageHandler(() => new NoRemoteCallHandler())
+            .AddStandardResilienceHandler();
+
+        var builder = Policy.Handle<HttpRequestException>().Or<TimeoutRejectedException>().OrResult<HttpResponseMessage>(r =>
+        {
+            var statusCode = (int)r.StatusCode;
+
+            return statusCode >= 500 ||
+                r.StatusCode == HttpStatusCode.RequestTimeout ||
+                statusCode == 429;
+        });
+
+        var policy = Policy.WrapAsync(
+            Policy.TimeoutAsync<HttpResponseMessage>(3),
+            builder.AdvancedCircuitBreakerAsync(0.1, TimeSpan.FromSeconds(30), 100, TimeSpan.FromSeconds(5)),
+            builder.WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(1)),
+            Policy.BulkheadAsync<HttpResponseMessage>(1000, 100),
+            Policy.TimeoutAsync<HttpResponseMessage>(30));
+
+        services
+            .AddHttpClient("v7")
+            .ConfigurePrimaryHttpMessageHandler(() => new NoRemoteCallHandler())
+            .AddPolicyHandler(_ => policy);
+
+        var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+
+        _v7 = factory.CreateClient("v7");
+        _v8 = factory.CreateClient("v8");
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<HttpResponseMessage> StandardPipeline_Polly_V7()
+    {
+        return _v7!.SendAsync(Request, _cancellationToken);
+    }
+
+    [Benchmark]
+    public Task<HttpResponseMessage> StandardPipeline_Polly_V8()
+    {
+        return _v8!.SendAsync(Request, _cancellationToken);
+    }
+}

--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.Features" Version="$(MicrosoftExtensionsFeaturesVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftExtensionsHttpPollyVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsLoggingConfigurationVersion)" />
@@ -36,6 +37,7 @@
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesVersion)" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Polly" Version="8.0.0" />
     <PackageVersion Include="Polly.Core" Version="8.0.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.0.0" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.0.0" />


### PR DESCRIPTION
- Cleanup namespaces
- Add new benchmarks for standard pipeline and retries


**Standard Pipeline**

|                    Method |     Mean |     Error |    StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
|-------------------------- |---------:|----------:|----------:|------:|-------:|----------:|------------:|
| StandardPipeline_Polly_V7 | 3.236 us | 0.0130 us | 0.0187 us |  1.00 | 0.1488 |    3816 B |        1.00 |
| StandardPipeline_Polly_V8 | 3.104 us | 0.0237 us | 0.0317 us |  0.96 | 0.0381 |    1008 B |        0.26 |

**Retries**

|         Method |     Mean |     Error |    StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
|--------------- |---------:|----------:|----------:|------:|-------:|----------:|------------:|
| Retry_Polly_V7 | 1.094 us | 0.0073 us | 0.0107 us |  1.00 | 0.0534 |    1384 B |        1.00 |
| Retry_Polly_V8 | 1.354 us | 0.0038 us | 0.0057 us |  1.24 | 0.0324 |     824 B |        0.60 |

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4612)