### PR TITLE
Fix standard hedging

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
@@ -87,6 +88,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
                 }
 
                 var requestMessage = snapshot.CreateRequestMessage();
+                requestMessage.SetResilienceContext(args.ActionContext);
 
                 // replace the request message
                 args.ActionContext.Properties.Set(ResilienceKeys.RequestMessage, requestMessage);


### PR DESCRIPTION
Hedging should assign the action resilience context to cloned request message, otherwise the inner handler might use incorrect context.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4633)