### PR TITLE
Update Polly to 8.1.0

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -36,9 +36,9 @@
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesVersion)" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="Polly.Core" Version="8.0.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.0.0" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.0.0" />
+    <PackageVersion Include="Polly.Core" Version="8.1.0" />
+    <PackageVersion Include="Polly.Extensions" Version="8.1.0" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.1.0" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/eng/packages/TestOnly.props
+++ b/eng/packages/TestOnly.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
     <PackageVersion Include="Moq.AutoMock" Version="3.1.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Polly.Testing" Version="8.0.0" />
+    <PackageVersion Include="Polly.Testing" Version="8.1.0" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />


### PR DESCRIPTION
Update to [Polly 8.1.0](https://github.com/App-vNext/Polly/releases/tag/8.1.0) which resolves [issues using Polly with AoT](https://github.com/App-vNext/Polly/issues/1732).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4646)