### PR TITLE
Fix inconsistent signature of `GetOptions` method

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.json
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.json
@@ -296,7 +296,7 @@
           "Stage": "Stable"
         },
         {
-          "Member": "TOptions Microsoft.Extensions.Http.Resilience.ResilienceHandlerContext.GetOptions<TOptions>(string name);",
+          "Member": "TOptions Microsoft.Extensions.Http.Resilience.ResilienceHandlerContext.GetOptions<TOptions>(string? name = null);",
           "Stage": "Stable"
         },
         {

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
@@ -44,6 +44,7 @@ public sealed class ResilienceHandlerContext
     /// <remarks>
     /// You can decide based on the <paramref name="name"/> to listen for changes in global options or named options.
     /// If <paramref name="name"/> is <see langword="null"/> then the global options are listened to.
+    /// By default, the <paramref name="name"/> parameter is <see langword="null"/>.
     /// <para>
     /// You can listen for changes only for single options. If you call this method multiple times, the preceding calls are ignored and only the last one wins.
     /// </para>
@@ -58,6 +59,7 @@ public sealed class ResilienceHandlerContext
     /// <returns>The options instance.</returns>
     /// <remarks>
     /// If <paramref name="name"/> is <see langword="null"/> then the global options are returned.
+    /// By default, the <paramref name="name"/> parameter is <see langword="null"/>.
     /// </remarks>
     public TOptions GetOptions<TOptions>(string? name = null) => _context.GetOptions<TOptions>(name);
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandlerContext.cs
@@ -59,7 +59,7 @@ public sealed class ResilienceHandlerContext
     /// <remarks>
     /// If <paramref name="name"/> is <see langword="null"/> then the global options are returned.
     /// </remarks>
-    public TOptions GetOptions<TOptions>(string name) => _context.GetOptions<TOptions>(name);
+    public TOptions GetOptions<TOptions>(string? name = null) => _context.GetOptions<TOptions>(name);
 
     /// <summary>
     /// Registers a callback that is called when the pipeline instance being configured is disposed.


### PR DESCRIPTION
Noticed this while working on samples. The new signature matches the API of Polly, has null as a default. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4647)