### PR TITLE
Fix system.network.state dimension value

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsCounters.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsCounters.cs
@@ -52,7 +52,7 @@ internal sealed class WindowsCounters
 
         // IPv4:
         var snapshotV4 = _tcpTableInfo.GetIPv4CachingSnapshot();
-        measurements.Add(new Measurement<long>(snapshotV4.ClosedCount, new TagList { tcpVersionFourTag, new(NetworkStateKey, "closed") }));
+        measurements.Add(new Measurement<long>(snapshotV4.ClosedCount, new TagList { tcpVersionFourTag, new(NetworkStateKey, "close") }));
         measurements.Add(new Measurement<long>(snapshotV4.ListenCount, new TagList { tcpVersionFourTag, new(NetworkStateKey, "listen") }));
         measurements.Add(new Measurement<long>(snapshotV4.SynSentCount, new TagList { tcpVersionFourTag, new(NetworkStateKey, "syn_sent") }));
         measurements.Add(new Measurement<long>(snapshotV4.SynRcvdCount, new TagList { tcpVersionFourTag, new(NetworkStateKey, "syn_recv") }));
@@ -67,7 +67,7 @@ internal sealed class WindowsCounters
 
         // IPv6:
         var snapshotV6 = _tcpTableInfo.GetIPv6CachingSnapshot();
-        measurements.Add(new Measurement<long>(snapshotV6.ClosedCount, new TagList { tcpVersionSixTag, new(NetworkStateKey, "closed") }));
+        measurements.Add(new Measurement<long>(snapshotV6.ClosedCount, new TagList { tcpVersionSixTag, new(NetworkStateKey, "close") }));
         measurements.Add(new Measurement<long>(snapshotV6.ListenCount, new TagList { tcpVersionSixTag, new(NetworkStateKey, "listen") }));
         measurements.Add(new Measurement<long>(snapshotV6.SynSentCount, new TagList { tcpVersionSixTag, new(NetworkStateKey, "syn_sent") }));
         measurements.Add(new Measurement<long>(snapshotV6.SynRcvdCount, new TagList { tcpVersionSixTag, new(NetworkStateKey, "syn_recv") }));


### PR DESCRIPTION
According to [OTel semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/1eb70c4d74aa904a8c81c5ed10302af8bb3c1b70/docs/system/system-metrics.md#metric-systemnetworkconnections) we should use value `close` instead of `closed`.

![image](https://github.com/dotnet/extensions/assets/10431021/bf925a0b-b6ad-4a2e-9c2d-06a014f925d6)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4651)