### PR TITLE
Resilience readme, namespace

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.Resilience</RootNamespace>
-    <Description>Mechanisms to harden applications against transient failures.</Description>
+    <Description>Extensions to the Polly libraries to enrich telemetry with metadata and exception summaries.</Description>
     <Workstream>Resilience</Workstream>
   </PropertyGroup>
 

--- a/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.json
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.json
@@ -2,15 +2,15 @@
   "Name": "Microsoft.Extensions.Resilience, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
   "Types": [
     {
-      "Type": "static class Microsoft.Extensions.Resilience.ResilienceContextExtensions",
+      "Type": "static class Polly.ResilienceContextExtensions",
       "Stage": "Stable",
       "Methods": [
         {
-          "Member": "static Microsoft.Extensions.Http.Diagnostics.RequestMetadata? Microsoft.Extensions.Resilience.ResilienceContextExtensions.GetRequestMetadata(this Polly.ResilienceContext context);",
+          "Member": "static Microsoft.Extensions.Http.Diagnostics.RequestMetadata? Polly.ResilienceContextExtensions.GetRequestMetadata(this Polly.ResilienceContext context);",
           "Stage": "Stable"
         },
         {
-          "Member": "static void Microsoft.Extensions.Resilience.ResilienceContextExtensions.SetRequestMetadata(this Polly.ResilienceContext context, Microsoft.Extensions.Http.Diagnostics.RequestMetadata requestMetadata);",
+          "Member": "static void Polly.ResilienceContextExtensions.SetRequestMetadata(this Polly.ResilienceContext context, Microsoft.Extensions.Http.Diagnostics.RequestMetadata requestMetadata);",
           "Stage": "Stable"
         }
       ]

--- a/src/Libraries/Microsoft.Extensions.Resilience/README.md
+++ b/src/Libraries/Microsoft.Extensions.Resilience/README.md
@@ -1,6 +1,6 @@
 # Microsoft.Extensions.Resilience
 
-Mechanisms to harden applications against transient failures.
+Extensions to the Polly libraries to enrich telemetry with metadata and exception summaries.
 
 ## Install the package
 
@@ -18,6 +18,22 @@ Or directly in the C# project file:
 </ItemGroup>
 ```
 
+## Usage Examples
+
+The services can be registered using the following method:
+
+```csharp
+public static IServiceCollection AddResilienceEnricher(this IServiceCollection services)
+```
+
+This will optionally consume the `IExceptionSummarizer` service if it has been registered and add that data to Polly's telemetry. It will also include `RequestMetadata` that can be set or retrieved with these extensions:
+
+```csharp
+public static void SetRequestMetadata(this ResilienceContext context, RequestMetadata requestMetadata)
+public static RequestMetadata? GetRequestMetadata(this ResilienceContext context)
+```
+
+See the Polly docs for details about working with [`ResilienceContext`](https://www.pollydocs.org/advanced/resilience-context.html).
 
 ## Feedback & Contributing
 

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/ResilienceMetricsEnricher.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/Internal/ResilienceMetricsEnricher.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Diagnostics.ExceptionSummarization;
 using Microsoft.Extensions.Http.Diagnostics;
+using Polly;
 using Polly.Telemetry;
 
 namespace Microsoft.Extensions.Resilience.Internal;

--- a/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceContextExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Resilience/ResilienceContextExtensions.cs
@@ -4,9 +4,8 @@
 using System;
 using Microsoft.Extensions.Http.Diagnostics;
 using Microsoft.Shared.Diagnostics;
-using Polly;
 
-namespace Microsoft.Extensions.Resilience;
+namespace Polly;
 
 /// <summary>
 /// Extensions for <see cref="ResilienceContext"/>.


### PR DESCRIPTION
I moved the ResilienceContext extensions to match the Polly namespace.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4659)