### PR TITLE
Adding Microsoft.Extensions.Telemetry README

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
@@ -45,10 +45,8 @@ builder.Services.AddRedaction(redactionBuilder =>
 });
 
 // Using a custom redactor provider:
-builder.Services.AddRedaction(redactionBuilder =>
-{
-    redactionBuilder.Services.AddSingleton<IRedactorProvider, MyRedactorProvider>();
-});
+builder.Services.AddSingleton<IRedactorProvider, MyRedactorProvider>();
+builder.Services.AddRedaction(redactionBuilder => { });
 ```
 
 ### Configuring the HMAC redactor

--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
@@ -31,17 +31,25 @@ public static IServiceCollection AddRedaction(this IServiceCollection services, 
 
 ### Configuring a redactor
 
-Redactors can be configured using one of these `IRedactionBuilder` extension methods:
+Redactors are fetched at runtime using an `IRedactorProvider`. You can choose to implement your own provider and register it inside the `AddRedaction` call, or alternatively you can just use the default provider. Redactors can be configured using one of these `IRedactionBuilder` extension methods:
 
 ```csharp
-// Sets the redactor to use for a set of data classes.
-IRedactionBuilder SetRedactor<T>(params DataClassificationSet[] classifications);
+// Using the default redactor provider:
+builder.Services.AddRedaction(redactionBuilder =>
+{
+    // Assigns a redactor to use for a set of data classes.
+    redactionBuilder.SetRedactor<MyRedactor>(MySensitiveDataClassification);
+    // Assigns a fallback redactor to use when processing classified data for which no specific redactor has been registered. 
+    // The `ErasingRedactor` is the default fallback redactor. If no redactor is configured for a data classification then the data will be erased.
+    redactionBuilder.SetFallbackRedactor<MyFallbackRedactor>();
+});
 
-/// Sets the redactor to use when processing classified data for which no specific redactor has been registered.
-IRedactionBuilder SetFallbackRedactor<T>();
+// Using a custom redactor provider:
+builder.Services.AddRedaction(redactionBuilder =>
+{
+    redactionBuilder.Services.AddSingleton<IRedactorProvider, MyRedactorProvider>();
+});
 ```
-
-The `ErasingRedactor` is the default fallback redactor. If no redactor is configured for a data classification then the data will be erased.
 
 ### Configuring the HMAC redactor
 

--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
@@ -61,7 +61,7 @@ public static IRedactionBuilder SetHmacRedactor(this IRedactionBuilder builder, 
 public static IRedactionBuilder SetHmacRedactor(this IRedactionBuilder builder, IConfigurationSection section, params DataClassificationSet[] classifications);
 ```
 
-The `HmacRedactorOptions` requires its `KeyId` and `Key` properties to be set.
+The `HmacRedactorOptions` requires its `KeyId` and `Key` properties to be set. The `HmacRedactor` is still in the experimental phase, which means that the above two methods will show warning `EXTEXP0002` notifying you that the `HmacRedactor` is not yet stable. In order to use it, you will need to either add `<NoWarn>$(NoWarn);EXTEXP0002</NoWarn>` to your project file or add `#pragma warning disable EXTEXP0002` around the calls to `SetHmacRedactor`.
 
 ## Feedback & Contributing
 

--- a/src/Libraries/Microsoft.Extensions.Telemetry/README.md
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/README.md
@@ -22,7 +22,7 @@ Or directly in the C# project file:
 
 ### Service Log Enrichment
 
-Enriches logs with application-specific information based on `ApplicationMetadata information. The bellow calls will add the service log enricher to the service collection.
+Enriches logs with application-specific information based on `ApplicationMetadata` information. The bellow calls will add the service log enricher to the service collection.
 
 ```csharp
 // Add service log enricher with default settings

--- a/src/Libraries/Microsoft.Extensions.Telemetry/README.md
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/README.md
@@ -1,6 +1,6 @@
 # Microsoft.Extensions.Telemetry
 
-Provides canonical implementations of telemetry abstractions.
+This library provides advanced logging and telemetry enrichment capabilities for .NET applications. It allows for detailed and configurable enrichment of log entries, along with enhanced latency monitoring and logging features. It is built for applications needing sophisticated telemetry and logging insights.
 
 ## Install the package
 
@@ -18,6 +18,65 @@ Or directly in the C# project file:
 </ItemGroup>
 ```
 
+## Usage
+
+### Service Log Enrichment
+
+Enriches logs with application-specific information based on `ApplicationMetadata information. The bellow calls will add the service log enricher to the service collection.
+
+```csharp
+// Add service log enricher with default settings
+builder.services.AddServiceLogEnricher();
+
+// Or configure with options
+builder.services.AddServiceLogEnricher(options =>
+{
+    options.ApplicationName = true;
+    options.BuildVersion = true;
+    options.DeploymentRing = true;
+    options.EnvironmentName = true;
+});
+```
+
+### Latency Monitoring
+
+Provides tools for latency data collection and export, particularly to console outputs.
+
+```csharp
+// Add latency console data exporter with configuration
+builder.services.AddConsoleLatencyDataExporter(options =>
+{
+    options.OutputCheckpoints = true;
+    options.OutputMeasures = true;
+    options.OutputTags = true;
+});
+```
+
+### Logging Enhancements
+
+Offers additional logging capabilities like stack trace capturing, exception message inclusion, and log redaction.
+
+```csharp
+// Enable log enrichment.
+builder.EnableEnrichment(options =>
+{
+    options.CaptureStackTraces = true;
+    options.IncludeExceptionMessage = true;
+    options.MaxStackTraceLength = 500;
+    options.UseFileInfoForStackTraces = true;
+});
+
+builder.Services.AddServiceLogEnricher(); // <- This call is required in order for the enricher to be added into the service collection.
+
+// Enable log redaction
+builder.EnableRedaction(options =>
+{
+    options.ApplyDiscriminator = true;
+});
+
+builder.Services.AddRedaction(); // <- This call is required in order for the redactor provider to be added into the service collection.
+
+```
 
 ## Feedback & Contributing
 


### PR DESCRIPTION
Adding README for Microsoft.Extensions.Telemetry and making one small clarification on one of the Compliance READMEs to explain how RedactorProviders should be used.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4671)