### PR TITLE
Fix hedging for primary callbacks

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -88,6 +88,8 @@ public static partial class ResilienceHttpClientBuilderExtensions
                 }
 
                 var requestMessage = snapshot.CreateRequestMessage();
+
+                // The secondary request message should use the action resilience context
                 requestMessage.SetResilienceContext(args.ActionContext);
 
                 // replace the request message

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/HedgingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/HedgingTests.cs
@@ -207,7 +207,6 @@ public abstract class HedgingTests<TBuilder> : IDisposable
         await client.SendAsync(request, _cancellationTokenSource.Token);
 
         RequestContexts.Distinct().OfType<ResilienceContext>().Should().HaveCount(3);
-        RequestContexts.Should().NotContain(originalContext);
 
         request.GetResilienceContext().Should().Be(originalContext);
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/HedgingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/HedgingTests.cs
@@ -189,6 +189,30 @@ public abstract class HedgingTests<TBuilder> : IDisposable
     }
 
     [Fact]
+    public async Task SendAsync_EnsureContextReplacedInRequestMessage()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://to-be-replaced:1234/some-path?query");
+        var originalContext = ResilienceContextPool.Shared.Get();
+        request.SetResilienceContext(originalContext);
+
+        SetupRouting();
+        SetupRoutes(4);
+
+        AddResponse(HttpStatusCode.InternalServerError);
+        AddResponse(HttpStatusCode.InternalServerError);
+        AddResponse(HttpStatusCode.InternalServerError);
+
+        using var client = CreateClientWithHandler();
+
+        await client.SendAsync(request, _cancellationTokenSource.Token);
+
+        RequestContexts.Distinct().OfType<ResilienceContext>().Should().HaveCount(3);
+        RequestContexts.Should().NotContain(originalContext);
+
+        request.GetResilienceContext().Should().Be(originalContext);
+    }
+
+    [Fact]
     public async Task SendAsync_NoRoutesLeft_EnsureLessThanMaxHedgedAttempts()
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://to-be-replaced:1234/some-path?query");


### PR DESCRIPTION
Found this issue when working on the resilience demo. The origin of this problem comes from the fact that we are attaching `ResilienceContext` to `HttpRequestMessage`. Based on this we need to "refresh" and assign the correct instance of resilience context for each hedged action. 

For secondary hedged actions this was fixed in #4633, however, we omitted this fix for primary actions as these also get their own resilience context instance. This change makes sure that the primary hedged calls gets the correct resilience context instance.

Also switched to Polly 8.1.0 which improves the handling of resilience contexts for hedging (creates clones for primary executions too).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4686)