### PR TITLE
Remove unused ReleaseAnnouncement issue/PR automation

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -567,17 +567,6 @@
     },
     {
       "taskType": "trigger",
-      "capabilityId": "ReleaseAnnouncement",
-      "subCapability": "ReleaseAnnouncement",
-      "version": "1.0",
-      "config": {
-        "taskName": "Release announcement",
-        "prReply": "The fix is included in ${pkgName} ${version}.",
-        "issueReply": "Fixed in ${pkgName} ${version}."
-      }
-    },
-    {
-      "taskType": "trigger",
       "capabilityId": "InPrLabel",
       "subCapability": "InPrLabel",
       "version": "1.0",


### PR DESCRIPTION
This automation capability has been deprecated, and even though it was configured it has not been used or working.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4688)