### PR TITLE
Clean code blocks

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -73,7 +73,7 @@ This sets up necessary environmental variables and opens the repository in VS Co
 
 Building the solution is as easy as running:
 
-```bash
+```powershell
 > build.cmd
 ```
 

--- a/eng/Tools/ApiChief/README.md
+++ b/eng/Tools/ApiChief/README.md
@@ -16,7 +16,7 @@ ApiChief is designed to help with API management activities. It provides five fe
 
 You can output a summary of the public API of an assembly with:
 
-```
+```console
 ApiChief MyAssembly.dll emit summary
 ```
 
@@ -26,7 +26,7 @@ Use the -o option to specify a file where the output should be stored.
 
 You can output a YAML file that represents a fingerprint of the public API of an assembly using:
 
-```
+```console
 ApiChief MyAssembly.dll emit baseline
 ```
 
@@ -36,7 +36,7 @@ Use the -o option to specify a file where the baseline should be stored.
 
 You can output a YAML file that captures the delta between a previously-captured fingerprint and an assembly:
 
-```
+```console
 ApiChief MyAssembly.dll delta MyPreviousBaseline.yml
 ```
 
@@ -47,7 +47,7 @@ Use the -o option to specify a file where the delta information should be stored
 You can cause the command to return a failure code (useful from scripts) whenever an assembly's API
 contains breaking changes relative to a previous API baseline fingerprint:
 
-```
+```console
 ApiChief MyAssembly.dll breaking MyPreviousBaseline.yml
 ```
 
@@ -56,6 +56,6 @@ ApiChief MyAssembly.dll breaking MyPreviousBaseline.yml
 You can output a folder containing files that capture the public API surface of an
 assembly, in a form suitable for performing API reviews.
 
-```
+```console
 ApiChief MyAssembly.dll emit review
 ```

--- a/eng/Tools/DiagConfig/README.md
+++ b/eng/Tools/DiagConfig/README.md
@@ -81,7 +81,7 @@ the tool or by a human. The `eng/Diags` folder is where all these configuration 
 
 Use the following to extract diagnostic metadata from a Roslyn analyzer assembly:
 
-```bash
+```console
 > DiagConfig <config-directory> analyzer merge <analyzers>...
 ```
 
@@ -99,7 +99,7 @@ adjust the severity level of the diagnostics.
 If you already have an `.editorconfig` file which contains analyzer settings, you can extract them and insert them into
 the config directory state.
 
-```bash
+```console
 > DiagConfig <config-directory> editorconfig merge <editor-config-file> <editor-config-family>
 ```
 
@@ -110,7 +110,7 @@ update with the settings from the config file.
 
 You use the following to produce an `.editorconfig` file:
 
-```bash
+```console
 > DiagConfig <config-directory> editorconfig save <editor-config-file> [<editor-config-attributes>...]
 ```
 
@@ -127,7 +127,7 @@ When our customers want to adopt static analysis they cannot do it all at once i
 Adding the analysis NuGet turns on all analyzers by default for given assembly.
 By creating `all of` config file they can turn on analyzers only per specific directory and adopt it gradually.
 
-```bash
+```console
 > DiagConfig <config-directory> editorconfig save --all-off <editor-config-file> [<editor-config-attributes>...]
 ```
 

--- a/src/Libraries/Microsoft.AspNetCore.AsyncState/README.md
+++ b/src/Libraries/Microsoft.AspNetCore.AsyncState/README.md
@@ -6,7 +6,7 @@ This provides the ability to store and retrieve state objects that flow with the
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.AspNetCore.AsyncState
 ```
 

--- a/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/README.md
+++ b/src/Libraries/Microsoft.AspNetCore.Diagnostics.Middleware/README.md
@@ -6,7 +6,7 @@ HTTP request diagnostics middleware for tracking latency and enriching and redac
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.AspNetCore.Diagnostics.Middleware
 ```
 

--- a/src/Libraries/Microsoft.AspNetCore.HeaderParsing/README.md
+++ b/src/Libraries/Microsoft.AspNetCore.HeaderParsing/README.md
@@ -12,7 +12,7 @@ In particular:
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.AspNetCore.HeaderParsing
 ```
 

--- a/src/Libraries/Microsoft.AspNetCore.Testing/README.md
+++ b/src/Libraries/Microsoft.AspNetCore.Testing/README.md
@@ -11,7 +11,7 @@ In particular:
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.AspNetCore.Testing
 ```
 

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.Application/README.md
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.Application/README.md
@@ -6,7 +6,7 @@ This flows runtime information for application-level ambient metadata such as th
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.AmbientMetadata.Application
 ```
 

--- a/src/Libraries/Microsoft.Extensions.AsyncState/README.md
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/README.md
@@ -6,7 +6,7 @@ This provides the ability to store and retrieve state objects that flow with the
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.AsyncState
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/README.md
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Abstractions/README.md
@@ -6,7 +6,7 @@ This package introduces data classification and data redaction features.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Compliance.Abstractions
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/README.md
@@ -6,7 +6,7 @@ A redaction engine and canonical redactors.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Compliance.Redaction
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Compliance.Testing/README.md
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Testing/README.md
@@ -6,7 +6,7 @@ This package provides test fakes for testing data classification and redaction.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Compliance.Testing
 ```
 

--- a/src/Libraries/Microsoft.Extensions.DependencyInjection.AutoActivation/README.md
+++ b/src/Libraries/Microsoft.Extensions.DependencyInjection.AutoActivation/README.md
@@ -8,7 +8,7 @@ A singleton is typically created when it is first used, which can lead to higher
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.DependencyInjection.AutoActivation
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ExceptionSummarization/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ExceptionSummarization/README.md
@@ -6,7 +6,7 @@ This provides the ability to extract essential information from well-known excep
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Diagnostics.ExceptionSummarization
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.Common/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.Common/README.md
@@ -24,7 +24,7 @@ See the [built in metrics](https://learn.microsoft.com/en-us/dotnet/core/diagnos
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Diagnostics.HealthChecks.Common
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/README.md
@@ -6,7 +6,7 @@ This provides configurable health check reporting based on the current system re
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/README.md
@@ -6,7 +6,7 @@ Answers Kubernetes liveness, startup, and readiness TCP probes based on the resu
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Diagnostics.Probes
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/README.md
@@ -6,7 +6,7 @@ Measures and reports processor and memory usage.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Diagnostics.ResourceMonitoring
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Testing/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Testing/README.md
@@ -6,7 +6,7 @@ Hand-crafted fakes to make telemetry-related testing easier.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Diagnostics.Testing
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Hosting.Testing/README.md
+++ b/src/Libraries/Microsoft.Extensions.Hosting.Testing/README.md
@@ -6,7 +6,7 @@ Tools for integration testing of apps built with Microsoft.Extensions.Hosting.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Hosting.Testing
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/README.md
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/README.md
@@ -6,7 +6,7 @@ Telemetry support for `HttpClient` that allows tracking latency and enriching an
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Http.Diagnostics
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/README.md
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/README.md
@@ -6,7 +6,7 @@ Resilience mechanisms for `HttpClient` built on the [Polly framework](https://ww
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Http.Resilience
 ```
 

--- a/src/Libraries/Microsoft.Extensions.ObjectPool.DependencyInjection/README.md
+++ b/src/Libraries/Microsoft.Extensions.ObjectPool.DependencyInjection/README.md
@@ -6,7 +6,7 @@ This provides the ability to retrieve pooled instances that can be initialized u
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.ObjectPool.DependencyInjection
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Options.Contextual/README.md
+++ b/src/Libraries/Microsoft.Extensions.Options.Contextual/README.md
@@ -6,7 +6,7 @@ APIs for dynamically configuring options based on a given context.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Options.Contextual
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Resilience/README.md
+++ b/src/Libraries/Microsoft.Extensions.Resilience/README.md
@@ -6,7 +6,7 @@ Extensions to the Polly libraries to enrich telemetry with metadata and exceptio
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Resilience
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/README.md
+++ b/src/Libraries/Microsoft.Extensions.Telemetry.Abstractions/README.md
@@ -11,7 +11,7 @@ This package contains common abstractions for high-level telemetry primitives. H
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Telemetry.Abstractions
 ```
 

--- a/src/Libraries/Microsoft.Extensions.Telemetry/README.md
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/README.md
@@ -6,7 +6,7 @@ This library provides advanced logging and telemetry enrichment capabilities for
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.Telemetry
 ```
 

--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/README.md
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/README.md
@@ -6,7 +6,7 @@ Provides a `FakeTimeProvider` for testing components that depend on `System.Time
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.TimeProvider.Testing
 ```
 

--- a/src/Packages/Microsoft.Extensions.AuditReports/README.md
+++ b/src/Packages/Microsoft.Extensions.AuditReports/README.md
@@ -6,7 +6,7 @@ Produces reports about the code being compiled which are useful during privacy a
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.AuditReports
 ```
 

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/README.md
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/README.md
@@ -6,7 +6,7 @@ A curated set of code analyzers and code analyzer settings.
 
 From the command-line:
 
-```dotnetcli
+```console
 dotnet add package Microsoft.Extensions.StaticAnalysis
 ```
 


### PR DESCRIPTION
Used `console` for portable shells (if works in bash/powershell) or `powershell`/`bash` if specific.
Remove `dotnetcli` as it seems to be only for documentation in microsoft.com sites (not NuGet, and not GitHub).

For reference, [supported syntaxes](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4693)