### PR TITLE
Fix typo in FakeTimeProvider.SetUtcNow Doc Comment

### DIFF
--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
@@ -89,7 +89,7 @@ public class FakeTimeProvider : TimeProvider
     /// Sets the date and time in the UTC time zone.
     /// </summary>
     /// <param name="value">The date and time in the UTC time zone.</param>
-    /// <exception cref="ArgumentOutOfRangeException">if the supplied time value is before the curent time.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">if the supplied time value is before the current time.</exception>
     public void SetUtcNow(DateTimeOffset value)
     {
         lock (Waiters)


### PR DESCRIPTION
`curent` -> `current`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4731)