### PR TITLE
Expose HTTP resilience handler (#4759)

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -69,7 +69,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
             var selector = CreatePipelineSelector(serviceProvider, pipelineBuilder.PipelineName);
             var provider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<HttpKey>>();
 
-            return new ResilienceHandler(selector);
+            return new ResilienceHttpMessageHandler(selector);
         });
 
         return pipelineBuilder;

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpMessageHandler.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpMessageHandler.cs
@@ -6,18 +6,32 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Http.Diagnostics;
+using Microsoft.Extensions.Http.Resilience.Internal;
 using Polly;
 
-namespace Microsoft.Extensions.Http.Resilience.Internal;
+namespace Microsoft.Extensions.Http.Resilience;
 
 /// <summary>
-/// Base class for resilience handler, i.e. handlers that use resilience strategies  to send the requests.
+/// An HTTP message handler using resilience strategies to send requests.
 /// </summary>
-internal sealed class ResilienceHandler : DelegatingHandler
+public sealed class ResilienceHttpMessageHandler : DelegatingHandler
 {
     private readonly Func<HttpRequestMessage, ResiliencePipeline<HttpResponseMessage>> _pipelineProvider;
 
-    public ResilienceHandler(Func<HttpRequestMessage, ResiliencePipeline<HttpResponseMessage>> pipelineProvider)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResilienceHttpMessageHandler"/> class using a resilience pipeline.
+    /// </summary>
+    /// <param name="pipeline">The pipeline to use for requests.</param>
+    public ResilienceHttpMessageHandler(ResiliencePipeline<HttpResponseMessage> pipeline)
+        : this(x => pipeline)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResilienceHttpMessageHandler"/> class using a resilience pipeline delegate.
+    /// </summary>
+    /// <param name="pipelineProvider">The delegate to select a pipeline for a request.</param>
+    public ResilienceHttpMessageHandler(Func<HttpRequestMessage, ResiliencePipeline<HttpResponseMessage>> pipelineProvider)
     {
         _pipelineProvider = pipelineProvider;
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/ResilienceHandlerTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/ResilienceHandlerTest.cs
@@ -22,7 +22,7 @@ public class ResilienceHandlerTest
     [Theory]
     public async Task SendAsync_EnsureRequestMetadataFlows(bool resilienceContextSet)
     {
-        using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
+        using var handler = new ResilienceHttpMessageHandler(ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
         using var request = new HttpRequestMessage();
 
@@ -56,7 +56,7 @@ public class ResilienceHandlerTest
     [Theory]
     public async Task SendAsync_EnsureExecutionContext(bool executionContextSet)
     {
-        using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
+        using var handler = new ResilienceHttpMessageHandler(ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
         using var request = new HttpRequestMessage();
 
@@ -84,7 +84,7 @@ public class ResilienceHandlerTest
     [Theory]
     public async Task SendAsync_EnsureInvoker(bool executionContextSet)
     {
-        using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
+        using var handler = new ResilienceHttpMessageHandler(ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
         using var request = new HttpRequestMessage();
 
@@ -110,7 +110,7 @@ public class ResilienceHandlerTest
     public async Task SendAsync_EnsureCancellationTokenFlowsToResilienceContext()
     {
         using var source = new CancellationTokenSource();
-        using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
+        using var handler = new ResilienceHttpMessageHandler(ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
         using var request = new HttpRequestMessage();
 
@@ -129,7 +129,7 @@ public class ResilienceHandlerTest
     [Fact]
     public async Task SendAsync_Exception_EnsureRethrown()
     {
-        using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
+        using var handler = new ResilienceHttpMessageHandler(ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
         using var request = new HttpRequestMessage();
 


### PR DESCRIPTION
As discussed in #4759, we'd like to expose the resilience HTTP handler. I have left it sealed and given it two public constructors.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4763)