### PR TITLE
Fix missing readme entry in NuSpecs

### DIFF
--- a/eng/MSBuild/Packaging.targets
+++ b/eng/MSBuild/Packaging.targets
@@ -22,6 +22,14 @@
                                        ($(TargetFrameworks.Contains('$(MinimumSupportedTfmForPackaging)')) and $(TargetFrameworks.Contains('$(ConditionalNet462)')))" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(IsPackable)' == 'true' and '$(IsShipping)' == 'true' ">
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Condition=" '$(IsPackable)' == 'true' and '$(IsShipping)' == 'true' " Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <!-- Verify that the minimum supported TFM is actually used. -->
   <Target Name="_VerifyMinimumSupportedTfmForPackagingIsUsed"
           Condition="'$(IsPackable)' == 'true' and '$(DisableNETStandardCompatErrors)' != 'true'">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,14 +9,6 @@
     <ErrorLog>$(MSBuildProjectFullPath).$([System.Guid]::NewGuid().ToString().Substring(0,8)).sarif</ErrorLog>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsPackable)' == 'true' and '$(IsShipping)' == 'true' ">
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Condition=" '$(IsPackable)' == 'true' and '$(IsShipping)' == 'true' " Include="README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(RunRoslynSdlAnalyzers)' == 'True'">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Resolves #4722

`$(IsShipping)` is being set in one of the *.targets, which requires the readme setting to be done in a *.targets as well.

While at it, move the definitions to Packaging.targets which is the better suited location.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4776)