### PR TITLE
Add missing [GeneratedCode] attribute

### DIFF
--- a/scripts/Slngen.ps1
+++ b/scripts/Slngen.ps1
@@ -70,7 +70,7 @@ param (
     [Parameter(Mandatory = $false, HelpMessage="Minimizes console output.")]
     [switch]$Quiet = $false,
     [Parameter(Mandatory = $false, HelpMessage="Output file name.")]
-    [string]$OutSln = "SDK.sln",
+    [string]$OutSln = "Extensions.sln",
     [Parameter(Mandatory = $false, HelpMessage="Parameters passed to MSBuild with slngen.")]
     [string[]]$MsBuildParams,
     [Parameter(Mandatory = $false, HelpMessage="Path to the repository.")]

--- a/scripts/Slngen.ps1
+++ b/scripts/Slngen.ps1
@@ -70,7 +70,7 @@ param (
     [Parameter(Mandatory = $false, HelpMessage="Minimizes console output.")]
     [switch]$Quiet = $false,
     [Parameter(Mandatory = $false, HelpMessage="Output file name.")]
-    [string]$OutSln = "Extensions.sln",
+    [string]$OutSln = "SDK.sln",
     [Parameter(Mandatory = $false, HelpMessage="Parameters passed to MSBuild with slngen.")]
     [string[]]$MsBuildParams,
     [Parameter(Mandatory = $false, HelpMessage="Path to the repository.")]

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -99,7 +99,7 @@ internal sealed partial class Emitter : EmitterBase
 
         var lambdaStateName = PickUniqueName("s", lm.TemplateToParameterName.Select(kvp => kvp.Key));
 
-        OutLn($"static ({lambdaStateName}, {exceptionLambdaName}) =>");
+        OutLn($"[{GeneratorUtilities.GeneratedCodeAttribute}] static ({lambdaStateName}, {exceptionLambdaName}) =>");
         OutOpenBrace();
 
         if (GenVariableAssignments(lm, lambdaStateName, numReservedUnclassifiedTags, numReservedClassifiedTags))

--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -99,7 +99,7 @@ internal sealed partial class Emitter : EmitterBase
 
         var lambdaStateName = PickUniqueName("s", lm.TemplateToParameterName.Select(kvp => kvp.Key));
 
-        OutLn($"[{GeneratorUtilities.GeneratedCodeAttribute}] static ({lambdaStateName}, {exceptionLambdaName}) =>");
+        OutLn($"[{GeneratorUtilities.GeneratedCodeAttribute}] static string ({lambdaStateName}, {exceptionLambdaName}) =>");
         OutOpenBrace();
 
         if (GenVariableAssignments(lm, lambdaStateName, numReservedUnclassifiedTags, numReservedClassifiedTags))


### PR DESCRIPTION
The logging code generator emits a static lambda. The lambda's containing function is annotated with the [GeneratedCode] attribute, but the lambda itself is not. The result is that code generators can get confused, considering the lambda as being user code.

This PR adds the [GeneratedCode] attribute to the lambda.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4802)