### PR TITLE
Make AsyncState thread safe

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Shared.Diagnostics;
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.AsyncState;
 internal sealed class AsyncState : IAsyncState
 {
     private static readonly AsyncLocal<AsyncStateHolder> _asyncContextCurrent = new();
-    private static readonly ObjectPool<ConcurrentDictionary<AsyncStateToken, object?>> _featuresPool = PoolFactory.CreatePool(new FeaturesPooledPolicy());
+    private static readonly ObjectPool<Features> _featuresPool = PoolFactory.CreatePool(new FeaturesPooledPolicy());
     private int _contextCount;
 
     public void Initialize()
@@ -22,12 +22,12 @@ internal sealed class AsyncState : IAsyncState
 
         // Use an object indirection to hold the AsyncContext in the AsyncLocal,
         // so it can be cleared in all ExecutionContexts when its cleared.
-        var features = new AsyncStateHolder
+        var asyncStateHolder = new AsyncStateHolder
         {
             Features = _featuresPool.Get()
         };
 
-        _asyncContextCurrent.Value = features;
+        _asyncContextCurrent.Value = asyncStateHolder;
     }
 
     public void Reset()
@@ -60,7 +60,7 @@ internal sealed class AsyncState : IAsyncState
             return false;
         }
 
-        _ = _asyncContextCurrent.Value.Features.TryGetValue(token, out value);
+        value = _asyncContextCurrent.Value.Features.Get(token.Index);
         return true;
     }
 
@@ -84,13 +84,14 @@ internal sealed class AsyncState : IAsyncState
             Throw.InvalidOperationException("Context is not initialized");
         }
 
-        _asyncContextCurrent.Value.Features[token] = value;
+        _asyncContextCurrent.Value.Features.Set(token.Index, value);
     }
 
     internal int ContextCount => Volatile.Read(ref _contextCount);
 
     private sealed class AsyncStateHolder
     {
-        public ConcurrentDictionary<AsyncStateToken, object?>? Features { get; set; }
+        public Features? Features { get; set; }
     }
+
 }

--- a/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Shared.Diagnostics;

--- a/src/Libraries/Microsoft.Extensions.AsyncState/Features.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/Features.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.AsyncState;
+
+internal sealed class Features
+{
+    private readonly List<object?> _items = [];
+
+    public object? Get(int index)
+    {
+        return _items.Count <= index ? null : _items[index];
+    }
+
+    public void Set(int index, object? value)
+    {
+        if (_items.Count <= index)
+        {
+            lock (_items)
+            {
+                var count = index + 1;
+
+#if NET6_0_OR_GREATER
+                _items.EnsureCapacity(count);
+#endif
+
+                var difference = count - _items.Count;
+
+                for (int i = 0; i < difference; i++)
+                {
+                    _items.Add(null);
+                }
+            }
+        }
+
+        _items[index] = value;
+    }
+
+    public void Clear()
+    {
+        _items.Clear();
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AsyncState/FeaturesPooledPolicy.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/FeaturesPooledPolicy.cs
@@ -1,21 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.Extensions.AsyncState;
 
-internal sealed class FeaturesPooledPolicy : IPooledObjectPolicy<ConcurrentDictionary<AsyncStateToken, object?>>
+internal sealed class FeaturesPooledPolicy : IPooledObjectPolicy<Features>
 {
     /// <inheritdoc/>
-    public ConcurrentDictionary<AsyncStateToken, object?> Create()
+    public Features Create()
     {
-        return [];
+        return new Features();
     }
 
     /// <inheritdoc/>
-    public bool Return(ConcurrentDictionary<AsyncStateToken, object?> obj)
+    public bool Return(Features obj)
     {
         obj.Clear();
         return true;

--- a/src/Libraries/Microsoft.Extensions.AsyncState/FeaturesPooledPolicy.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/FeaturesPooledPolicy.cs
@@ -1,27 +1,24 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.Extensions.AsyncState;
 
-internal sealed class FeaturesPooledPolicy : IPooledObjectPolicy<List<object?>>
+internal sealed class FeaturesPooledPolicy : IPooledObjectPolicy<ConcurrentDictionary<AsyncStateToken, object?>>
 {
     /// <inheritdoc/>
-    public List<object?> Create()
+    public ConcurrentDictionary<AsyncStateToken, object?> Create()
     {
         return [];
     }
 
     /// <inheritdoc/>
-    public bool Return(List<object?> obj)
+    public bool Return(ConcurrentDictionary<AsyncStateToken, object?> obj)
     {
-        for (int i = 0; i < obj.Count; i++)
-        {
-            obj[i] = null;
-        }
-
+        obj.Clear();
         return true;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AsyncState/FeaturesPooledPolicy.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/FeaturesPooledPolicy.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.Extensions.AsyncState;

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
@@ -205,28 +205,4 @@ public class AsyncStateTests
 
         Assert.Equal(3, asyncState.ContextCount);
     }
-
-    [Fact]
-    public void EnsureCount_IncreasesCountCorrectly()
-    {
-        var l = new List<object?>();
-        AsyncState.EnsureCount(l, 5);
-        Assert.Equal(5, l.Count);
-    }
-
-    [Fact]
-    public void EnsureCount_WhenCountLessThanExpected()
-    {
-        var l = new List<object?>(new object?[5]);
-        AsyncState.EnsureCount(l, 2);
-        Assert.Equal(5, l.Count);
-    }
-
-    [Fact]
-    public void EnsureCount_WhenCountEqualWithExpected()
-    {
-        var l = new List<object?>(new object?[5]);
-        AsyncState.EnsureCount(l, 5);
-        Assert.Equal(5, l.Count);
-    }
 }

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/FeaturesPooledPolicyTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/FeaturesPooledPolicyTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.Extensions.AsyncState.Test;
@@ -27,6 +26,6 @@ public class FeaturesPooledPolicyTests
         dictionary[new AsyncStateToken(2)] = new object();
 
         Assert.True(policy.Return(dictionary));
-        Assert.All(dictionary, el => Assert.Null(el));
+        Assert.True(dictionary.IsEmpty);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/FeaturesPooledPolicyTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/FeaturesPooledPolicyTests.cs
@@ -12,7 +12,7 @@ public class FeaturesPooledPolicyTests
     {
         var policy = new FeaturesPooledPolicy();
 
-        Assert.True(policy.Return([]));
+        Assert.True(policy.Return(new Features()));
     }
 
     [Fact]
@@ -20,12 +20,14 @@ public class FeaturesPooledPolicyTests
     {
         var policy = new FeaturesPooledPolicy();
 
-        var dictionary = policy.Create();
-        dictionary[new AsyncStateToken(0)] = string.Empty;
-        dictionary[new AsyncStateToken(1)] = Array.Empty<int>();
-        dictionary[new AsyncStateToken(2)] = new object();
+        var features = policy.Create();
+        features.Set(0, string.Empty);
+        features.Set(1, Array.Empty<int>());
+        features.Set(2, new object());
 
-        Assert.True(policy.Return(dictionary));
-        Assert.True(dictionary.IsEmpty);
+        Assert.True(policy.Return(features));
+        Assert.Null(features.Get(0));
+        Assert.Null(features.Get(1));
+        Assert.Null(features.Get(2));
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/FeaturesPooledPolicyTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/FeaturesPooledPolicyTests.cs
@@ -21,12 +21,12 @@ public class FeaturesPooledPolicyTests
     {
         var policy = new FeaturesPooledPolicy();
 
-        var list = policy.Create();
-        list.Add(string.Empty);
-        list.Add(Array.Empty<int>());
-        list.Add(new object());
+        var dictionary = policy.Create();
+        dictionary[new AsyncStateToken(0)] = string.Empty;
+        dictionary[new AsyncStateToken(1)] = Array.Empty<int>();
+        dictionary[new AsyncStateToken(2)] = new object();
 
-        Assert.True(policy.Return(list));
-        Assert.All(list, el => Assert.Null(el));
+        Assert.True(policy.Return(dictionary));
+        Assert.All(dictionary, el => Assert.Null(el));
     }
 }


### PR DESCRIPTION
`AsyncState` uses holder object `AsyncStateHolder` that uses `List<object?>` collection. Write operations to that collection are not thread safe including `EnsureCapacity()` method. If the async flow is shared between multiple threads the `List<>` and `AsyncState` is modified in parallel the list might lose some data.

The fix replaces List<object?> with custom `Features` class that encapsulates List<object?> collection and synchronizes when its size needs to be expanded.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4833)