### PR TITLE
Separate EnableRedaction and EnableEnrichment

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Telemetry/Logging/ExtendedLoggerFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Logging/ExtendedLoggerFactory.cs
@@ -63,7 +63,7 @@ internal sealed class ExtendedLoggerFactory : ILoggerFactory
         _filterOptionsChangeTokenRegistration = filterOptions.OnChange(RefreshFilters);
         RefreshFilters(filterOptions.CurrentValue);
 
-        if (enrichmentOptions == null)
+        if (enrichmentOptions is null)
         {
             // enrichmentOptions is only present if EnableEnrichment was called, so if it's null
             // then ignore all the supplied enrichers, we're not doing enrichment


### PR DESCRIPTION
- Prior, calling EnableRedaction or EnableEnrichment would always enable both enrichment and redaction together. Now, each call only affects the specific feature it is intended.

Fixes #4683

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4838)