### PR TITLE
Ignore statics in metric source-gen

### DIFF
--- a/test/Generators/Microsoft.Gen.Metrics/TestClasses/CounterDimensions.cs
+++ b/test/Generators/Microsoft.Gen.Metrics/TestClasses/CounterDimensions.cs
@@ -8,6 +8,11 @@ namespace TestClasses
 #pragma warning disable SA1402 // File may only contain a single type
     public class CounterDimensions : CounterParentDimensions
     {
+        // The generator should ignore these statics:
+        public const string Const = "Constant Value";
+
+        public static string Static = "Static Value";
+
         public string? Dim1;
 
         public CounterOperations OperationsEnum { get; set; }

--- a/test/Generators/Microsoft.Gen.Metrics/TestClasses/HistogramTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Metrics/TestClasses/HistogramTestExtensions.cs
@@ -107,7 +107,13 @@ namespace TestClasses
 #pragma warning disable SA1402 // File may only contain a single type
     public class HistogramDimensionsTest : HistogramParentDimensions
     {
+        // The generator should ignore these statics:
+        public const string Const = "Constant Value";
+
+        public static string Static = "Static Value";
+
         public string? Dim1;
+
         public HistogramOperations OperationsEnum { get; set; }
 
         [TagName("Enum2")]
@@ -156,6 +162,11 @@ namespace TestClasses
 
     public struct HistogramStruct
     {
+        // The generator should ignore these statics:
+        public const string Const = "Constant Value";
+
+        public static string Static = "Static Value";
+
         public string? Dim1 { get; set; }
 
         [TagName("DimInField")]

--- a/test/Generators/Microsoft.Gen.Metrics/Unit/ParserTests.Diagnostics.cs
+++ b/test/Generators/Microsoft.Gen.Metrics/Unit/ParserTests.Diagnostics.cs
@@ -97,27 +97,6 @@ public partial class ParserTests
     }
 
     [Fact]
-    public async Task StrongTypeCounter_CyclicReference_Guid()
-    {
-        var d = await RunGenerator(@"
-            public class TypeA
-            {
-                public System.Guid TestA { get; set; }
-            }
-
-            public static partial class MetricClass
-            {
-                [Counter(typeof(TypeA), Name=""CyclicTest"")]
-                public static partial CyclicTest CreateCyclicTestCounter(Meter meter);
-            }");
-
-        Assert.NotNull(d);
-        var diag = Assert.Single(d);
-        Assert.Equal(DiagDescriptors.ErrorTagTypeCycleDetected.Id, diag.Id);
-        Assert.Contains("System.Guid ⇆ System.Guid", diag.GetMessage());
-    }
-
-    [Fact]
     public async Task StructTypeGauge()
     {
         var d = await RunGenerator(@"


### PR DESCRIPTION
Fixes #4787

This PR also enables and aligns all metering tests for generated code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4843)