### PR TITLE
Log outgoing HTTP path parameters in Structured mode

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/Log.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Http.Logging.Internal;
 /// Logs <see cref="HttpRequestMessage"/>, <see cref="HttpResponseMessage"/> and the exceptions due to errors of request/response.
 /// </summary>
 [SuppressMessage("Major Code Smell", "S109:Magic numbers should not be used", Justification = "Event ID's.")]
-internal static class Log
+internal static partial class Log
 {
     internal const string OriginalFormat = "{OriginalFormat}";
     private const string NullString = "(null)";
@@ -72,6 +72,14 @@ internal static class Log
 
         state.Clear();
     }
+
+    [LoggerMessage(LogLevel.Error, RequestReadErrorMessage)]
+    public static partial void RequestReadErrorSG(
+        ILogger logger,
+        Exception exception,
+        [TagName(HttpClientLoggingTagNames.Method)] HttpMethod method,
+        [TagName(HttpClientLoggingTagNames.Host)] string? host,
+        [TagName(HttpClientLoggingTagNames.Path)] string? path);
 
     public static void ResponseReadError(ILogger logger, Exception exception, HttpMethod method, string host, string path)
     {

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LogRecord.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LogRecord.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Net.Http;
+using Microsoft.Extensions.Http.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
 
@@ -63,8 +65,24 @@ internal sealed class LogRecord : IResettable
     /// </summary>
     public LoggerMessageState? EnrichmentTags { get; set; }
 
+    /// <summary>
+    /// Gets or sets request path parameters.
+    /// </summary>
+    public HttpRouteParameter[]? PathParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets request path parameters count for <see cref="PathParameters"/>.
+    /// </summary>
+    public int PathParametersCount { get; set; }
+
     public bool TryReset()
     {
+        if (PathParameters != null)
+        {
+            ArrayPool<HttpRouteParameter>.Shared.Return(PathParameters);
+            PathParameters = null;
+        }
+
         Host = string.Empty;
         Method = null;
         Path = string.Empty;
@@ -75,6 +93,7 @@ internal sealed class LogRecord : IResettable
         EnrichmentTags = null;
         RequestHeaders = null;
         ResponseHeaders = null;
+        PathParametersCount = 0;
         return true;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggerMessageStateExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/Internal/LoggerMessageStateExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Http.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Http.Logging.Internal;
@@ -26,8 +27,7 @@ internal static class LoggerMessageStateExtensions
         {
             var key = _requestPrefixedNamesCache.GetOrAdd(
                 items[i].Key,
-                static (x, p) => p + Normalize(x),
-                HttpClientLoggingTagNames.RequestHeaderPrefix);
+                static x => HttpClientLoggingTagNames.RequestHeaderPrefix + Normalize(x));
 
             state.TagArray[index++] = new(key, items[i].Value);
         }
@@ -46,17 +46,30 @@ internal static class LoggerMessageStateExtensions
         {
             var key = _responsePrefixedNamesCache.GetOrAdd(
                 items[i].Key,
-                static (x, p) => p + Normalize(x),
-                HttpClientLoggingTagNames.ResponseHeaderPrefix);
+                static x => HttpClientLoggingTagNames.ResponseHeaderPrefix + Normalize(x));
 
             state.TagArray[index++] = new(key, items[i].Value);
+        }
+    }
+
+    /// <summary>
+    /// Adds path parameters to <see cref="LoggerMessageState"/>.
+    /// </summary>
+    /// <param name="state">A <see cref="LoggerMessageState"/> to be filled.</param>
+    /// <param name="parameters">An array with path parameters.</param>
+    /// <param name="paramsCount">A number of path parameters.</param>
+    /// <param name="index">Represents an index to be used when writing tags into <paramref name="state"/>.</param>
+    /// <remarks><paramref name="index"/> will be mutated to point to the next <paramref name="state"/> item.</remarks>
+    public static void AddPathParameters(this LoggerMessageState state, HttpRouteParameter[] parameters, int paramsCount, ref int index)
+    {
+        for (var i = 0; i < paramsCount; i++)
+        {
+            state.TagArray[index++] = new(parameters[i].Name, parameters[i].Value);
         }
     }
 
     [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase",
         Justification = "Normalization to lower case is required by OTel's semantic conventions")]
     private static string Normalize(string header)
-    {
-        return header.ToLowerInvariant();
-    }
+        => header.ToLowerInvariant();
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/LoggingOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Logging/LoggingOptions.cs
@@ -123,8 +123,9 @@ public class LoggingOptions
     /// The default value is <see cref="OutgoingPathLoggingMode.Formatted"/>.
     /// </value>
     /// <remarks>
-    /// This option is applied only when the <see cref="RequestPathLoggingMode"/> option is not set to <see cref="HttpRouteParameterRedactionMode.None"/>,
-    /// otherwise this setting is ignored and the unredacted HTTP request path is logged.
+    /// This option is applied only when the <see cref="RequestPathParameterRedactionMode"/> option is not set to
+    /// <see cref="HttpRouteParameterRedactionMode.None"/>,
+    /// otherwise this setting is ignored and the non-redacted HTTP request path is logged.
     /// </remarks>
     public OutgoingPathLoggingMode RequestPathLoggingMode { get; set; } = DefaultPathLoggingMode;
 

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Microsoft.Extensions.Http.Diagnostics.csproj
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Microsoft.Extensions.Http.Diagnostics.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Collections.Immutable" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Http/HttpRouteFormatter.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Http/HttpRouteFormatter.cs
@@ -15,7 +15,7 @@ internal sealed class HttpRouteFormatter : IHttpRouteFormatter
 {
     private const char ForwardSlashSymbol = '/';
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     private const char ForwardSlash = ForwardSlashSymbol;
 #else
 #pragma warning disable IDE1006 // Naming Styles

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Http/IHttpRouteParser.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Http/IHttpRouteParser.cs
@@ -28,12 +28,10 @@ internal interface IHttpRouteParser
     /// <param name="parametersToRedact">Dictionary of parameters with their data classification that needs to be redacted.</param>
     /// <param name="httpRouteParameters">Output array where parameters will be stored. Caller must provide the array with enough capacity to hold all parameters in route segment.</param>
     /// <returns>Returns true if parameters were extracted successfully, return false otherwise.</returns>
-#pragma warning disable CA1045 // Do not pass types by reference
     bool TryExtractParameters(
         string httpPath,
         in ParsedRouteSegments routeSegments,
         HttpRouteParameterRedactionMode redactionMode,
         IReadOnlyDictionary<string, DataClassification> parametersToRedact,
         ref HttpRouteParameter[] httpRouteParameters);
-#pragma warning restore CA1045 // Do not pass types by reference
 }

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Libraries\Microsoft.Extensions.DependencyInjection.AutoActivation\Microsoft.Extensions.DependencyInjection.AutoActivation.csproj" />
+    <ProjectReference Include="..\Microsoft.Extensions.DependencyInjection.AutoActivation\Microsoft.Extensions.DependencyInjection.AutoActivation.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.AmbientMetadata.Application\Microsoft.Extensions.AmbientMetadata.Application.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Compliance.Abstractions\Microsoft.Extensions.Compliance.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Telemetry.Abstractions\Microsoft.Extensions.Telemetry.Abstractions.csproj" />

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/Microsoft.Extensions.Diagnostics.Probes.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/Microsoft.Extensions.Diagnostics.Probes.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'" >
     <PackageReference Include="System.Net.Http" />
-    
+
     <!-- Direct dependencies as Microsoft.AspNetCore.Mvc.Testing references vulnerable versions. -->
     <PackageReference Include="Microsoft.AspNetCore.Http" />
     <PackageReference Include="System.IO.Pipelines" />

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/AcceptanceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/AcceptanceTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Diagnostics;
 using Microsoft.Extensions.Http.Logging.Test.Internal;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace Microsoft.Extensions.Http.Logging.Test;
 public class AcceptanceTests
 {
     private const string LoggingCategory = "Microsoft.Extensions.Http.Logging.HttpClientLogger";
-    private static readonly Uri _unreachableRequestUri = new("https://we.wont.hit.this.doman.anyway");
+    private static readonly Uri _unreachableRequestUri = new("https://we.wont.hit.this.domain.anyway");
 
     [Fact]
     public async Task AddHttpClientLogEnricher_WhenNullEnricherRegistered_SkipsNullEnrichers()
@@ -116,14 +115,15 @@ public class AcceptanceTests
         var logRecord = collector.GetSnapshot().Single(logRecord => logRecord.Category == LoggingCategory);
 
         Assert.Equal($"{httpRequestMessage.Method} {httpRequestMessage.RequestUri.Host}/{TelemetryConstants.Redacted}", logRecord.Message);
-        var state = logRecord.StructuredState;
         var enricher1 = sp.GetServices<IHttpClientLogEnricher>().SingleOrDefault(enn => enn is EnricherWithCounter) as EnricherWithCounter;
         var enricher2 = sp.GetServices<IHttpClientLogEnricher>().SingleOrDefault(enn => enn is TestEnricher) as TestEnricher;
 
         enricher1.Should().NotBeNull();
         enricher2.Should().NotBeNull();
-
         enricher1!.TimesCalled.Should().Be(1);
+
+        var state = logRecord.StructuredState;
+        state.Should().NotBeNull();
         state!.Single(kvp => kvp.Key == enricher2!.KvpRequest.Key).Value.Should().Be(enricher2!.KvpRequest.Value!.ToString());
     }
 
@@ -170,7 +170,7 @@ public class AcceptanceTests
         var responseString = await SendRequest(namedClient1, httpRequestMessage);
         var collector = provider.GetFakeLogCollector();
         var logRecord = collector.GetSnapshot().Single(l => l.Category == LoggingCategory);
-        var state = logRecord.State as List<KeyValuePair<string, string>>;
+        var state = logRecord.StructuredState;
         state.Should().Contain(kvp => kvp.Value == responseString);
         state.Should().Contain(kvp => kvp.Value == "Request Value");
         state.Should().Contain(kvp => kvp.Value == "Request Value 2,Request Value 3");
@@ -186,7 +186,7 @@ public class AcceptanceTests
         collector.Clear();
         responseString = await SendRequest(namedClient2, httpRequestMessage2);
         logRecord = collector.GetSnapshot().Single(l => l.Category == LoggingCategory);
-        state = logRecord.State as List<KeyValuePair<string, string>>;
+        state = logRecord.StructuredState;
         state.Should().Contain(kvp => kvp.Value == responseString);
         state.Should().Contain(kvp => kvp.Value == "Request Value");
         state.Should().Contain(kvp => kvp.Value == "Request Value 2,Request Value 3");
@@ -256,7 +256,8 @@ public class AcceptanceTests
         var responseString = Encoding.UTF8.GetString(buffer);
 
         var logRecord = collector.GetSnapshot().Single(l => l.Category == LoggingCategory);
-        var state = logRecord.State as List<KeyValuePair<string, string>>;
+        var state = logRecord.StructuredState;
+        state.Should().NotBeNull();
         state.Should().Contain(kvp => kvp.Value == responseString);
         state.Should().Contain(kvp => kvp.Value == "Request Value");
         state.Should().Contain(kvp => kvp.Value == "Request Value 2,Request Value 3");
@@ -277,7 +278,7 @@ public class AcceptanceTests
         responseString = Encoding.UTF8.GetString(buffer);
 
         logRecord = collector.GetSnapshot().Single(l => l.Category == LoggingCategory);
-        state = logRecord.State as List<KeyValuePair<string, string>>;
+        state = logRecord.StructuredState;
         state.Should().Contain(kvp => kvp.Value == responseString);
         state.Should().Contain(kvp => kvp.Value == "Request Value");
         state.Should().Contain(kvp => kvp.Value == "Request Value 2,Request Value 3");
@@ -320,8 +321,79 @@ public class AcceptanceTests
 
         var collector = sp.GetFakeLogCollector();
         var logRecord = collector.GetSnapshot().Single(logRecord => logRecord.Category == LoggingCategory);
-        var state = logRecord.State as List<KeyValuePair<string, string>>;
+        var state = logRecord.StructuredState;
+        state.Should().NotBeNull();
         state!.Single(kvp => kvp.Key == HttpClientLoggingTagNames.Path).Value.Should().Be(redactedPath);
+    }
+
+    [Theory]
+    [InlineData(HttpRouteParameterRedactionMode.Strict, "REDACTED", "<REDACTED:123>")]
+    [InlineData(HttpRouteParameterRedactionMode.Loose, "999", "<REDACTED:123>")]
+    [InlineData(HttpRouteParameterRedactionMode.None, "999", "123")]
+    public async Task AddHttpClientLogging_StructuredPathLogging_RedactsSensitiveParams(
+        HttpRouteParameterRedactionMode parameterRedactionMode,
+        string expectedUnitId,
+        string expectedUserId)
+    {
+        const string RequestPath = "https://fake.com/v1/unit/999/users/123";
+        const string RequestRoute = "/v1/unit/{unitId}/users/{userId}";
+
+        await using var sp = new ServiceCollection()
+            .AddFakeLogging()
+            .AddFakeRedaction(o => o.RedactionFormat = "<REDACTED:{0}>")
+            .AddHttpClient()
+            .AddExtendedHttpClientLogging(o =>
+            {
+                o.RouteParameterDataClasses.Add("userId", FakeTaxonomy.PrivateData);
+                o.RequestPathParameterRedactionMode = parameterRedactionMode;
+                o.RequestPathLoggingMode = OutgoingPathLoggingMode.Structured;
+            })
+            .BlockRemoteCall()
+            .BuildServiceProvider();
+
+        using var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient();
+        using var httpRequestMessage = new HttpRequestMessage
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri(RequestPath)
+        };
+
+        httpRequestMessage.SetRequestMetadata(new RequestMetadata(httpRequestMessage.Method.ToString(), RequestRoute));
+
+        using var _ = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+
+        var collector = sp.GetFakeLogCollector();
+        var logRecord = collector.GetSnapshot().Single(logRecord => logRecord.Category == LoggingCategory);
+        var state = logRecord.StructuredState;
+        var loggedPath = state.Should().NotBeNull().And
+            .ContainSingle(kvp => kvp.Key == HttpClientLoggingTagNames.Path)
+            .Subject.Value;
+
+        state.Should().ContainSingle(kvp => kvp.Key == HttpClientLoggingTagNames.Host)
+            .Which.Value.Should().Be(httpRequestMessage.RequestUri.Host);
+
+        state.Should().ContainSingle(kvp => kvp.Key == HttpClientLoggingTagNames.Method)
+            .Which.Value.Should().Be(httpRequestMessage.Method.ToString());
+
+        state.Should().ContainSingle(kvp => kvp.Key == HttpClientLoggingTagNames.StatusCode)
+            .Which.Value.Should().Be("200");
+
+        state.Should().ContainSingle(kvp => kvp.Key == HttpClientLoggingTagNames.Duration)
+            .Which.Value.Should().NotBeEmpty();
+
+        // When the redaction mode is set to "None", the RequestPathLoggingMode is ignored
+        if (parameterRedactionMode == HttpRouteParameterRedactionMode.None)
+        {
+            loggedPath.Should().Be(httpRequestMessage.RequestUri.AbsolutePath);
+            state.Should().HaveCount(5);
+        }
+        else
+        {
+            loggedPath.Should().Be(RequestRoute);
+            state.Should().ContainSingle(kvp => kvp.Key == "userId").Which.Value.Should().Be(expectedUserId);
+            state.Should().ContainSingle(kvp => kvp.Key == "unitId").Which.Value.Should().Be(expectedUnitId);
+            state.Should().HaveCount(7);
+        }
     }
 
     [Theory]
@@ -361,7 +433,8 @@ public class AcceptanceTests
 
         var collector = sp.GetFakeLogCollector();
         var logRecord = collector.GetSnapshot().Single(logRecord => logRecord.Category == LoggingCategory);
-        var state = logRecord.State as List<KeyValuePair<string, string>>;
+        var state = logRecord.StructuredState;
+        state.Should().NotBeNull();
         state!.Single(kvp => kvp.Key == HttpClientLoggingTagNames.Path).Value.Should().Be(redactedPath);
     }
 
@@ -514,7 +587,6 @@ public class AcceptanceTests
              .BlockRemoteCall()
              .BuildServiceProvider();
 
-        var options = provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
         var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, _unreachableRequestUri);
 
@@ -522,7 +594,7 @@ public class AcceptanceTests
         var collector = provider.GetFakeLogCollector();
         var logRecord = collector.GetSnapshot().Single(l => l.Category == LoggingCategory);
 
-        logRecord.Scopes.Should().HaveCount(0);
+        logRecord.Scopes.Should().BeEmpty();
     }
 
     [Fact]
@@ -563,7 +635,7 @@ public class AcceptanceTests
              .AddExtendedHttpClientLogging()
              .BlockRemoteCall()
              .BuildServiceProvider();
-        var options = provider.GetRequiredService<IOptionsMonitor<LoggingOptions>>().Get("test");
+
         var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, _unreachableRequestUri);
 

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggerTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpClientLoggerTest.cs
@@ -97,7 +97,7 @@ public class HttpClientLoggerTest
         using var handler = new TestLoggingHandler(
             new HttpClientLogger(
                 NullLogger<HttpClientLogger>.Instance,
-                new HttpRequestReader(options, GetHttpRouteFormatter(), headersReader, RequestMetadataContext),
+                new HttpRequestReader(options, GetHttpRouteFormatter(), Mock.Of<IHttpRouteParser>(), headersReader, RequestMetadataContext),
                 Enumerable.Empty<IHttpClientLogEnricher>(),
                 options),
             new TestingHandlerStub((_, _) => throw exception));
@@ -209,22 +209,23 @@ public class HttpClientLoggerTest
             BodyReadTimeout = TimeSpan.FromMinutes(5),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured,
             LogRequestStart = false,
-            LogBody = true,
-            RouteParameterDataClasses = { { "userId", FakeTaxonomy.PrivateData } },
+            LogBody = true
         };
 
         var mockHeadersRedactor = new Mock<IHttpHeadersRedactor>();
         mockHeadersRedactor.Setup(r => r.Redact(It.IsAny<IEnumerable<string>>(), It.IsAny<DataClassification>()))
             .Returns(Redacted);
+
         var headersReader = new HttpHeadersReader(options.ToOptionsMonitor(), mockHeadersRedactor.Object);
 
-        var fakeLogger = new FakeLogger<HttpClientLogger>(new FakeLogCollector(Options.Options.Create(new FakeLogCollectorOptions())));
+        var fakeLogger = new FakeLogger<HttpClientLogger>();
 
         var logger = new HttpClientLogger(
             fakeLogger,
             new HttpRequestReader(
                 options,
                 GetHttpRouteFormatter(),
+                Mock.Of<IHttpRouteParser>(),
                 headersReader, RequestMetadataContext),
             new List<IHttpClientLogEnricher> { testEnricher },
             options);
@@ -300,8 +301,7 @@ public class HttpClientLoggerTest
             BodyReadTimeout = TimeSpan.FromMinutes(5),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured,
             LogRequestStart = true,
-            LogBody = true,
-            RouteParameterDataClasses = { { "userId", FakeTaxonomy.PrivateData } },
+            LogBody = true
         };
 
         var fakeLogger = new FakeLogger<HttpClientLogger>(
@@ -321,6 +321,7 @@ public class HttpClientLoggerTest
             new HttpRequestReader(
                 options,
                 GetHttpRouteFormatter(),
+                Mock.Of<IHttpRouteParser>(),
                 headersReader, RequestMetadataContext),
             new List<IHttpClientLogEnricher> { testEnricher },
             options);
@@ -407,8 +408,7 @@ public class HttpClientLoggerTest
             BodyReadTimeout = TimeSpan.FromMinutes(5),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured,
             LogRequestStart = false,
-            LogBody = true,
-            RouteParameterDataClasses = { { "userId", FakeTaxonomy.PrivateData } },
+            LogBody = true
         };
 
         var fakeLogger = new FakeLogger<HttpClientLogger>(new FakeLogCollector(Options.Options.Create(new FakeLogCollectorOptions())));
@@ -426,6 +426,7 @@ public class HttpClientLoggerTest
                 new HttpRequestReader(
                     options,
                     GetHttpRouteFormatter(),
+                    Mock.Of<IHttpRouteParser>(),
                     headersReader, RequestMetadataContext),
                 new List<IHttpClientLogEnricher> { testEnricher },
                 options),
@@ -503,8 +504,7 @@ public class HttpClientLoggerTest
             BodyReadTimeout = TimeSpan.FromMinutes(5),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured,
             LogRequestStart = false,
-            LogBody = true,
-            RouteParameterDataClasses = { { "userId", FakeTaxonomy.PrivateData } },
+            LogBody = true
         };
 
         var fakeLogger = new FakeLogger<HttpClientLogger>(
@@ -519,7 +519,7 @@ public class HttpClientLoggerTest
 
         var exception = new InvalidOperationException("test");
 
-        var actualRequestReader = new HttpRequestReader(options, GetHttpRouteFormatter(), headersReader, RequestMetadataContext);
+        var actualRequestReader = new HttpRequestReader(options, GetHttpRouteFormatter(), Mock.Of<IHttpRouteParser>(), headersReader, RequestMetadataContext);
         var mockedRequestReader = new Mock<IHttpRequestReader>();
         mockedRequestReader
             .Setup(m =>
@@ -618,8 +618,7 @@ public class HttpClientLoggerTest
             BodyReadTimeout = TimeSpan.FromMinutes(5),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured,
             LogRequestStart = false,
-            LogBody = true,
-            RouteParameterDataClasses = { { "userId", FakeTaxonomy.PrivateData } },
+            LogBody = true
         };
 
         var fakeLogger = new FakeLogger<HttpClientLogger>(new FakeLogCollector(Options.Options.Create(new FakeLogCollectorOptions())));
@@ -635,6 +634,7 @@ public class HttpClientLoggerTest
                 new HttpRequestReader(
                     options,
                     GetHttpRouteFormatter(),
+                    Mock.Of<IHttpRouteParser>(),
                     headersReader, RequestMetadataContext),
                 new List<IHttpClientLogEnricher> { testEnricher },
                 options),
@@ -676,6 +676,7 @@ public class HttpClientLoggerTest
                 new HttpRequestReader(
                     options,
                     GetHttpRouteFormatter(),
+                    Mock.Of<IHttpRouteParser>(),
                     new HttpHeadersReader(options.ToOptionsMonitor(), mockHeadersRedactor.Object),
                     RequestMetadataContext),
                 new List<IHttpClientLogEnricher> { enricher1.Object, enricher2.Object },
@@ -718,6 +719,7 @@ public class HttpClientLoggerTest
                 new HttpRequestReader(
                     options,
                     GetHttpRouteFormatter(),
+                    Mock.Of<IHttpRouteParser>(),
                     new HttpHeadersReader(options.ToOptionsMonitor(), mockHeadersRedactor.Object),
                     RequestMetadataContext),
                 new List<IHttpClientLogEnricher> { enricher1.Object, enricher2.Object },
@@ -754,7 +756,7 @@ public class HttpClientLoggerTest
         var fakeLogger = new FakeLogger<HttpClientLogger>();
         var options = new LoggingOptions();
         var headersReader = new HttpHeadersReader(options.ToOptionsMonitor(), Mock.Of<IHttpHeadersRedactor>());
-        var requestReader = new HttpRequestReader(options, GetHttpRouteFormatter(), headersReader, RequestMetadataContext);
+        var requestReader = new HttpRequestReader(options, GetHttpRouteFormatter(), Mock.Of<IHttpRouteParser>(), headersReader, RequestMetadataContext);
         var enrichers = new List<IHttpClientLogEnricher> { enricher1.Object, enricher2.Object };
 
         using var handler = new TestLoggingHandler(
@@ -886,8 +888,7 @@ public class HttpClientLoggerTest
             BodyReadTimeout = TimeSpan.FromMinutes(5),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured,
             LogRequestStart = false,
-            LogBody = true,
-            RouteParameterDataClasses = { { "userId", FakeTaxonomy.PrivateData } },
+            LogBody = true
         };
 
         var fakeLogger = new FakeLogger<HttpClientLogger>(new FakeLogCollector(Options.Options.Create(new FakeLogCollectorOptions())));
@@ -903,6 +904,7 @@ public class HttpClientLoggerTest
                 new HttpRequestReader(
                     options,
                     GetHttpRouteFormatter(),
+                    Mock.Of<IHttpRouteParser>(),
                     headersReader, RequestMetadataContext),
                 new List<IHttpClientLogEnricher> { testEnricher },
                 options),
@@ -944,7 +946,7 @@ public class HttpClientLoggerTest
         var options = new LoggingOptions();
         var headersReader = new HttpHeadersReader(options.ToOptionsMonitor(), new Mock<IHttpHeadersRedactor>().Object);
         var requestReader = new HttpRequestReader(
-            options, GetHttpRouteFormatter(), headersReader, RequestMetadataContext);
+            options, GetHttpRouteFormatter(), Mock.Of<IHttpRouteParser>(), headersReader, RequestMetadataContext);
 
         using var handler = new TestLoggingHandler(
             new HttpClientLogger(fakeLogger, requestReader, Array.Empty<IHttpClientLogEnricher>(), options),
@@ -993,7 +995,7 @@ public class HttpClientLoggerTest
         var options = new LoggingOptions();
         var headersReader = new HttpHeadersReader(options.ToOptionsMonitor(), Mock.Of<IHttpHeadersRedactor>());
         var requestReader = new HttpRequestReader(
-            options, GetHttpRouteFormatter(), headersReader, RequestMetadataContext);
+            options, GetHttpRouteFormatter(), Mock.Of<IHttpRouteParser>(), headersReader, RequestMetadataContext);
 
         var logger = new HttpClientLogger(new FakeLogger<HttpClientLogger>(), requestReader, Array.Empty<IHttpClientLogEnricher>(), options);
         using var httpRequestMessage = new HttpRequestMessage();

--- a/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpRequestReaderTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Diagnostics.Tests/Logging/HttpRequestReaderTest.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Mime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +27,7 @@ namespace Microsoft.Extensions.Http.Logging.Test;
 public class HttpRequestReaderTest
 {
     private const string Redacted = "REDACTED";
+    private const string RequestedHost = "default-uri.com";
 
     private readonly Fixture _fixture;
 
@@ -38,14 +41,12 @@ public class HttpRequestReaderTest
     {
         var requestContent = _fixture.Create<string>();
         var responseContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
         var header3 = new KeyValuePair<string, string>("Header3", "Value3");
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = TelemetryConstants.Redacted,
             StatusCode = 200,
@@ -59,8 +60,8 @@ public class HttpRequestReaderTest
         {
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData }, { header3.Key, FakeTaxonomy.PrivateData } },
             ResponseHeadersDataClasses = new Dictionary<string, DataClassification> { { header2.Key, FakeTaxonomy.PrivateData }, { header3.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
-            ResponseBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
+            ResponseBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(100000),
             LogBody = true,
         };
@@ -74,7 +75,7 @@ public class HttpRequestReaderTest
         using var serviceProvider = GetServiceProvider(headersReader, serviceKey);
 
         var reader = new HttpRequestReader(serviceProvider, options.ToOptionsMonitor(serviceKey), serviceProvider.GetRequiredService<IHttpRouteFormatter>(),
-            RequestMetadataContext, serviceKey: serviceKey);
+            serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext, serviceKey: serviceKey);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -101,15 +102,7 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(logRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(logRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        logRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-
-        logRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        logRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        logRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
     [Fact]
@@ -144,7 +137,8 @@ public class HttpRequestReaderTest
         var headersReader = new HttpHeadersReader(options.ToOptionsMonitor(), mockHeadersRedactor.Object);
         using var serviceProvider = GetServiceProvider(headersReader);
 
-        var reader = new HttpRequestReader(serviceProvider, options.ToOptionsMonitor(), serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+        var reader = new HttpRequestReader(serviceProvider, options.ToOptionsMonitor(), serviceProvider.GetRequiredService<IHttpRouteFormatter>(),
+            serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -165,15 +159,7 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(actualRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-
-        actualRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        actualRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        actualRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
     [Fact]
@@ -181,14 +167,12 @@ public class HttpRequestReaderTest
     {
         var requestContent = _fixture.Create<string>();
         var responseContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
 
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = "foo/bar/123",
             StatusCode = 200,
@@ -202,8 +186,8 @@ public class HttpRequestReaderTest
         {
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData } },
             ResponseHeadersDataClasses = new Dictionary<string, DataClassification> { { header2.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
-            ResponseBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
+            ResponseBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(10),
             LogBody = true,
         };
@@ -217,7 +201,7 @@ public class HttpRequestReaderTest
         using var serviceProvider = GetServiceProvider(headersReader);
 
         var reader = new HttpRequestReader(serviceProvider, opts.ToOptionsMonitor(),
-            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -246,14 +230,7 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(actualRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-        actualRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        actualRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        actualRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
     [Fact]
@@ -261,14 +238,12 @@ public class HttpRequestReaderTest
     {
         var requestContent = _fixture.Create<string>();
         var responseContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
 
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = "foo/bar/{userId}",
             StatusCode = 200,
@@ -276,6 +251,7 @@ public class HttpRequestReaderTest
             ResponseHeaders = [new("Header2", Redacted)],
             RequestBody = requestContent,
             ResponseBody = responseContent,
+            PathParametersCount = 1
         };
 
         var opts = new LoggingOptions
@@ -284,8 +260,8 @@ public class HttpRequestReaderTest
             LogBody = true,
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData } },
             ResponseHeadersDataClasses = new Dictionary<string, DataClassification> { { header2.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
-            ResponseBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
+            ResponseBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(10),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured
         };
@@ -297,15 +273,15 @@ public class HttpRequestReaderTest
             .Returns(Redacted);
 
         var headersReader = new HttpHeadersReader(opts.ToOptionsMonitor(), mockHeadersRedactor.Object);
-        using var serviceProvider = GetServiceProvider(headersReader);
+        using var serviceProvider = GetServiceProvider(headersReader, configureRedaction: x => x.RedactionFormat = Redacted);
 
         var reader = new HttpRequestReader(serviceProvider, opts.ToOptionsMonitor(),
-            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
             Method = HttpMethod.Post,
-            RequestUri = new Uri("http://default-uri.com/foo/bar/123"),
+            RequestUri = new Uri($"http://{RequestedHost}/foo/bar/123"),
             Content = new StringContent(requestContent, Encoding.UTF8),
         };
 
@@ -329,28 +305,22 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(actualRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-        actualRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        actualRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        actualRecord.Should().BeEquivalentTo(expectedRecord, o => o.Excluding(x => x.PathParameters));
+
+        HttpRouteParameter[] expectedParameters = [new("userId", Redacted, true)];
+        actualRecord.PathParameters.Should().NotBeNull().And.Subject.Take(actualRecord.PathParametersCount).Should().BeEquivalentTo(expectedParameters);
     }
 
     [Fact]
     public async Task ReadAsync_RouteParameterRedactionModeNone_ReturnsLogRecordWithUnredactedRoute()
     {
         var requestContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
 
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = "/foo/bar/123",
             RequestHeaders = [new("Header1", Redacted)],
@@ -363,7 +333,7 @@ public class HttpRequestReaderTest
             LogBody = true,
             RequestPathParameterRedactionMode = HttpRouteParameterRedactionMode.None,
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(10),
             RequestPathLoggingMode = OutgoingPathLoggingMode.Structured
         };
@@ -378,7 +348,7 @@ public class HttpRequestReaderTest
         using var serviceProvider = GetServiceProvider(headersReader);
 
         var reader = new HttpRequestReader(serviceProvider, opts.ToOptionsMonitor(),
-            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -394,12 +364,7 @@ public class HttpRequestReaderTest
         var actualRecord = new LogRecord();
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
+        actualRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
     [Fact]
@@ -407,14 +372,12 @@ public class HttpRequestReaderTest
     {
         var requestContent = _fixture.Create<string>();
         var responseContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
 
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = "TestRequest",
             StatusCode = 200,
@@ -428,8 +391,8 @@ public class HttpRequestReaderTest
         {
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData } },
             ResponseHeadersDataClasses = new Dictionary<string, DataClassification> { { header2.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
-            ResponseBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
+            ResponseBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(10),
             LogBody = true,
         };
@@ -443,7 +406,7 @@ public class HttpRequestReaderTest
         using var serviceProvider = GetServiceProvider(headersReader);
 
         var reader = new HttpRequestReader(serviceProvider, opts.ToOptionsMonitor(),
-            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -472,15 +435,7 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(actualRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-
-        actualRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        actualRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        actualRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
     [Fact]
@@ -488,14 +443,12 @@ public class HttpRequestReaderTest
     {
         var requestContent = _fixture.Create<string>();
         var responseContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
 
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = TelemetryConstants.Redacted,
             StatusCode = 200,
@@ -509,8 +462,8 @@ public class HttpRequestReaderTest
         {
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData } },
             ResponseHeadersDataClasses = new Dictionary<string, DataClassification> { { header2.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
-            ResponseBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
+            ResponseBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(10),
             LogBody = true,
         };
@@ -524,7 +477,7 @@ public class HttpRequestReaderTest
         using var serviceProvider = GetServiceProvider(headersReader);
 
         var reader = new HttpRequestReader(serviceProvider, opts.ToOptionsMonitor(),
-            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -549,14 +502,7 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(actualRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-        actualRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        actualRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        actualRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
     [Fact]
@@ -564,14 +510,12 @@ public class HttpRequestReaderTest
     {
         var requestContent = _fixture.Create<string>();
         var responseContent = _fixture.Create<string>();
-        var host = "default-uri.com";
-        var plainTextMedia = "text/plain";
         var header1 = new KeyValuePair<string, string>("Header1", "Value1");
         var header2 = new KeyValuePair<string, string>("Header2", "Value2");
 
         var expectedRecord = new LogRecord
         {
-            Host = host,
+            Host = RequestedHost,
             Method = HttpMethod.Post,
             Path = TelemetryConstants.Unknown,
             StatusCode = 200,
@@ -585,8 +529,8 @@ public class HttpRequestReaderTest
         {
             RequestHeadersDataClasses = new Dictionary<string, DataClassification> { { header1.Key, FakeTaxonomy.PrivateData } },
             ResponseHeadersDataClasses = new Dictionary<string, DataClassification> { { header2.Key, FakeTaxonomy.PrivateData } },
-            RequestBodyContentTypes = new HashSet<string> { plainTextMedia },
-            ResponseBodyContentTypes = new HashSet<string> { plainTextMedia },
+            RequestBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
+            ResponseBodyContentTypes = new HashSet<string> { MediaTypeNames.Text.Plain },
             BodyReadTimeout = TimeSpan.FromSeconds(10),
             LogBody = true,
         };
@@ -600,7 +544,7 @@ public class HttpRequestReaderTest
         using var serviceProvider = GetServiceProvider(headersReader);
 
         var reader = new HttpRequestReader(serviceProvider, opts.ToOptionsMonitor(),
-            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), RequestMetadataContext);
+            serviceProvider.GetRequiredService<IHttpRouteFormatter>(), serviceProvider.GetRequiredService<IHttpRouteParser>(), RequestMetadataContext);
 
         using var httpRequestMessage = new HttpRequestMessage
         {
@@ -626,18 +570,13 @@ public class HttpRequestReaderTest
         await reader.ReadRequestAsync(actualRecord, httpRequestMessage, requestHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
         await reader.ReadResponseAsync(actualRecord, httpResponseMessage, responseHeadersBuffer, CancellationToken.None).ConfigureAwait(false);
 
-        actualRecord.Should().BeEquivalentTo(
-            expectedRecord,
-            o => o
-                .Excluding(m => m.RequestBody)
-                .Excluding(m => m.ResponseBody)
-                .ComparingByMembers<LogRecord>());
-
-        actualRecord.RequestBody.Should().BeEquivalentTo(expectedRecord.RequestBody);
-        actualRecord.ResponseBody.Should().BeEquivalentTo(expectedRecord.ResponseBody);
+        actualRecord.Should().BeEquivalentTo(expectedRecord);
     }
 
-    private static ServiceProvider GetServiceProvider(HttpHeadersReader headersReader, string? serviceKey = null)
+    private static ServiceProvider GetServiceProvider(
+        HttpHeadersReader headersReader,
+        string? serviceKey = null,
+        Action<FakeRedactorOptions>? configureRedaction = null)
     {
         var services = new ServiceCollection();
         if (serviceKey is null)
@@ -650,7 +589,7 @@ public class HttpRequestReaderTest
         }
 
         return services
-            .AddFakeRedaction()
+            .AddFakeRedaction(configureRedaction ?? (_ => { }))
             .AddHttpRouteProcessor()
             .BuildServiceProvider();
     }


### PR DESCRIPTION
Fixes #4698

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4845)