### PR TITLE
Leverage an existing Roslyn API instead of rolling my own inferior version

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
@@ -658,7 +658,7 @@ internal sealed partial class Parser
                     {
                         if (ParserUtilities.IsBaseOrIdentity(gm.ReturnType, symbol, _compilation))
                         {
-                            if (!originType.CanAccess(gm))
+                            if (!sm.Compilation.IsSymbolAccessibleWithin(gm, originType, type))
                             {
                                 continue;
                             }
@@ -679,7 +679,7 @@ internal sealed partial class Parser
                 {
                     if (f.AssociatedSymbol == null && ParserUtilities.IsBaseOrIdentity(f.Type, symbol, _compilation))
                     {
-                        if (!originType.CanAccess(f))
+                        if (!sm.Compilation.IsSymbolAccessibleWithin(f, originType, type))
                         {
                             continue;
                         }

--- a/src/Generators/Shared/SymbolHelpers.cs
+++ b/src/Generators/Shared/SymbolHelpers.cs
@@ -16,40 +16,4 @@ internal static class SymbolHelpers
     {
         return symbol.ContainingNamespace.IsGlobalNamespace ? string.Empty : symbol.ContainingNamespace.ToString();
     }
-
-    /// <summary>
-    /// Can code in a given type access a given member?
-    /// </summary>
-    /// <remarks>
-    /// Note that this implementation assumes that the target member is within the origin type
-    /// or a base class of the origin type.
-    /// </remarks>
-    public static bool CanAccess(this INamedTypeSymbol originType, ISymbol targetMember)
-    {
-        if (SymbolEqualityComparer.Default.Equals(originType, targetMember.ContainingType))
-        {
-            // target member is from the origin type, we're good
-            return true;
-        }
-
-        if (targetMember.DeclaredAccessibility == Accessibility.Private)
-        {
-            // can't access a private member from a different type
-            return false;
-        }
-
-        if (SymbolEqualityComparer.Default.Equals(originType.ContainingAssembly, targetMember.ContainingAssembly))
-        {
-            // target member is in the same assembly as the origin type, so we're good
-            return true;
-        }
-
-        if (targetMember.DeclaredAccessibility is Accessibility.Internal or Accessibility.ProtectedAndInternal)
-        {
-            // can't access internal members of other assemblies (sorry, we don't support IVT right now)
-            return false;
-        }
-
-        return true;
-    }
 }


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4850)