### PR TITLE
Improve support for [TagName]

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethod.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethod.cs
@@ -33,7 +33,7 @@ internal sealed class LoggingMethod
     {
         foreach (var p in Parameters)
         {
-            if (templateName.Equals(p.ParameterName, StringComparison.OrdinalIgnoreCase))
+            if (templateName.Equals(p.TagName, StringComparison.OrdinalIgnoreCase))
             {
                 return p;
             }
@@ -43,19 +43,29 @@ internal sealed class LoggingMethod
     }
 
     public List<string> GetTemplatesForParameter(LoggingMethodParameter lp)
-        => GetTemplatesForParameter(lp.ParameterName);
-
-    public List<string> GetTemplatesForParameter(string parameterName)
     {
         HashSet<string> templates = [];
         foreach (var t in Templates)
         {
-            if (parameterName.Equals(t, StringComparison.OrdinalIgnoreCase))
+            if (lp.TagName.Equals(t, StringComparison.OrdinalIgnoreCase))
             {
                 _ = templates.Add(t);
             }
         }
 
         return templates.ToList();
+    }
+
+    public List<string> GetTemplatesForParameter(string parameterName)
+    {
+        foreach (var p in Parameters)
+        {
+            if (parameterName == p.ParameterName)
+            {
+                return GetTemplatesForParameter(p);
+            }
+        }
+
+        return [];
     }
 }

--- a/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Model/LoggingMethodParameter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Gen.Logging.Model;
 /// <summary>
 /// A single parameter to a logger method.
 /// </summary>
-[DebuggerDisplay("{Name}")]
+[DebuggerDisplay("{ParameterName}")]
 internal sealed class LoggingMethodParameter
 {
     public string ParameterName = string.Empty;
@@ -35,7 +35,7 @@ internal sealed class LoggingMethodParameter
     public List<LoggingProperty> Properties = [];
     public TagProvider? TagProvider;
 
-    public string ParameterNameWithAt => NeedsAtSign ? "@" + ParameterName : ParameterName;
+    public string ParameterNameWithAtIfNeeded => NeedsAtSign ? "@" + ParameterName : ParameterName;
 
     public string PotentiallyNullableType
         => (IsReference && !IsNullable)

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
@@ -152,7 +152,7 @@ internal sealed partial class Parser
                         bool parameterInTemplate = false;
                         foreach (var t in lm.Templates)
                         {
-                            if (lp.ParameterName.Equals(t, StringComparison.OrdinalIgnoreCase))
+                            if (lp.TagName.Equals(t, StringComparison.OrdinalIgnoreCase))
                             {
                                 parameterInTemplate = true;
                                 break;
@@ -273,9 +273,10 @@ internal sealed partial class Parser
                             bool found = false;
                             foreach (var p in lm.Parameters)
                             {
-                                if (t.Equals(p.ParameterName, StringComparison.OrdinalIgnoreCase))
+                                if (t.Equals(p.TagName, StringComparison.OrdinalIgnoreCase))
                                 {
                                     found = true;
+                                    p.TagName = t;
                                     break;
                                 }
                             }
@@ -398,7 +399,7 @@ internal sealed partial class Parser
                 keepMethod = false;
             }
 
-            TemplateExtractor.ExtractTemplates(message, lm.Templates);
+            TemplateProcessor.ExtractTemplates(message, lm.Templates);
 
 #pragma warning disable EA0003 // Use the character-based overloads of 'String.StartsWith' or 'String.EndsWith'
             var templatesWithAtSymbol = lm.Templates.Where(x => x.StartsWith("@", StringComparison.Ordinal)).ToArray();
@@ -522,12 +523,9 @@ internal sealed partial class Parser
                     }
                 });
             }
-            else
+            else if (!names.Add(parameter.TagName))
             {
-                if (!names.Add(parameter.TagName))
-                {
-                    Diag(DiagDescriptors.TagNameCollision, parameterSymbols[parameter].GetLocation(), parameter.ParameterName, parameter.TagName, lm.Name);
-                }
+                Diag(DiagDescriptors.TagNameCollision, parameterSymbols[parameter].GetLocation(), parameter.ParameterName, parameter.TagName, lm.Name);
             }
         }
     }

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
@@ -756,6 +756,11 @@ public class LogMethodTests
         collector.Clear();
         AtSymbolsTestExtensions.M5(logger, LogLevel.Debug, o);
         Assert.Equal("42", collector.LatestRecord.StructuredState!.GetValue("class"));
+
+        collector.Clear();
+        AtSymbolsTestExtensions.M6(logger, "42");
+        Assert.Equal("42", collector.LatestRecord.StructuredState!.GetValue("class"));
+        Assert.Equal("M6 class 42", collector.LatestRecord.Message);
     }
 
     [Fact]

--- a/test/Generators/Microsoft.Gen.Logging/Generated/TagNameTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/TagNameTests.cs
@@ -17,12 +17,19 @@ public class TagNameTests
         var logger = new FakeLogger();
 
         TagNameExtensions.M0(logger, 0);
-
-        var expectedState = new Dictionary<string, string?>
+        logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(new Dictionary<string, string?>
         {
             ["TN1"] = "0",
-        };
+        });
 
-        logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+        logger.Collector.Clear();
+        TagNameExtensions.M1(logger, 0);
+        logger.Collector.LatestRecord.StructuredState.Should().NotBeNull().And.Equal(new Dictionary<string, string?>
+        {
+            ["foo.bar"] = "0",
+            ["{OriginalFormat}"] = "{foo.bar}",
+        });
+
+        Assert.Equal("0", logger.Collector.LatestRecord.Message);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/AtSymbolsTestExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/AtSymbolsTestExtensions.cs
@@ -32,5 +32,8 @@ namespace TestClasses
 
         [LoggerMessage("M5")]
         internal static partial void M5(ILogger logger, LogLevel level, [LogProperties(OmitReferenceName = true)] SpecialNames @event);
+
+        [LoggerMessage(LogLevel.Information, "M6 class {class}")]
+        internal static partial void M6(ILogger logger, string @class);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/TagNameExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/TagNameExtensions.cs
@@ -9,5 +9,8 @@ namespace TestClasses
     {
         [LoggerMessage(LogLevel.Warning)]
         internal static partial void M0(ILogger logger, [TagName("TN1")] int p0);
+
+        [LoggerMessage(LogLevel.Warning, Message = "{foo.bar}")]
+        internal static partial void M1(ILogger logger, [TagName("foo.bar")] int p0);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/Unit/LoggingMethodParameterTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/LoggingMethodParameterTests.cs
@@ -61,9 +61,9 @@ public class LoggingMethodParameterTests
             NeedsAtSign = false,
         };
 
-        Assert.Equal(lp.ParameterName, lp.ParameterNameWithAt);
+        Assert.Equal(lp.ParameterName, lp.ParameterNameWithAtIfNeeded);
         lp.NeedsAtSign = true;
-        Assert.Equal("@" + lp.ParameterName, lp.ParameterNameWithAt);
+        Assert.Equal("@" + lp.ParameterName, lp.ParameterNameWithAtIfNeeded);
 
         lp.Type = "Foo";
         lp.IsReference = false;

--- a/test/Generators/Microsoft.Gen.Logging/Unit/TemplatesExtractorTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/TemplatesExtractorTests.cs
@@ -17,7 +17,7 @@ public class TemplatesExtractorTests
     [InlineData("NewLine \n Test", 8)]
     public void Should_FindIndexOfAny_Correctly(string message, int expectedResult)
     {
-        var result = TemplateExtractor.FindIndexOfAny(message, new[] { '\n', 'a', 'b', 'z' }, 0, message.Length);
+        var result = TemplateProcessor.FindIndexOfAny(message, new[] { '\n', 'a', 'b', 'z' }, 0, message.Length);
         Assert.Equal(expectedResult, result);
     }
 }


### PR DESCRIPTION
- When using [TagName] to control the name of a logging tag, the expectation is that the logging message (if present) should be using the tag name instead of the parameter name. SO:

```
[LoggerMessage(1, LogLevel.Information, "My message {foo.bar}")]
public static partial void Log(this ILogger logger, [TagName("foo.bar") string msg);
```

Fixes #4848

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4851)