### PR TITLE
Disable HttpClient's timeout for Standard Resilience and Hedging

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
@@ -138,6 +139,9 @@ public static partial class ResilienceHttpClientBuilderExtensions
                     .AddTimeout(options.Endpoint.Timeout);
             })
             .SelectPipelineByAuthority();
+
+        // Disable the HttpClient timeout to allow the timeout strategies to control the timeout.
+        _ = builder.ConfigureHttpClient(client => client.Timeout = Timeout.InfiniteTimeSpan);
 
         return new StandardHedgingHandlerBuilder(builder.Name, builder.Services, routingBuilder);
     }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.StandardResilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.StandardResilience.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
@@ -85,6 +86,9 @@ public static partial class ResilienceHttpClientBuilderExtensions
                 .AddCircuitBreaker(options.CircuitBreaker)
                 .AddTimeout(options.AttemptTimeout);
         });
+
+        // Disable the HttpClient timeout to allow the timeout strategies to control the timeout.
+        _ = builder.ConfigureHttpClient(client => client.Timeout = Timeout.InfiniteTimeSpan);
 
         return new HttpStandardResiliencePipelineBuilder(optionsName, builder.Services);
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/StandardHedgingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/StandardHedgingTests.cs
@@ -247,6 +247,14 @@ public sealed class StandardHedgingTests : HedgingTests<IStandardHedgingHandlerB
     }
 
     [Fact]
+    public void AddStandardResilienceHandler_EnsureHttpClientTimeoutDisabled()
+    {
+        var client = CreateClientWithHandler();
+
+        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
+    [Fact]
     public async Task NoRouting_Ok()
     {
         // arrange

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -232,6 +234,16 @@ public sealed partial class HttpClientBuilderExtensionsTests : IDisposable
 
         await client.GetAsync("https://dummy");
         requests.Should().HaveCount(11);
+    }
+
+    [Fact]
+    public void AddStandardResilienceHandler_EnsureHttpClientTimeoutDisabled()
+    {
+        var builder = new ServiceCollection().AddLogging().AddMetrics().AddHttpClient("test").AddStandardHedgingHandler();
+
+        using var client = builder.Services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("test");
+
+        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
     }
 
     private static void AddStandardResilienceHandler(


### PR DESCRIPTION
Closes #4770 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4862)