### PR TITLE
Update README to mention cgroups support in Microsoft.Extensions.Diagnostics.ResourceMonitoring

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/README.md
@@ -1,6 +1,9 @@
 # Microsoft.Extensions.Diagnostics.ResourceMonitoring
 
-Measures and reports processor and memory usage.
+Measures and reports processor and memory usage. This library utilizes control groups (cgroups) in Linux to monitor system resources.
+
+> [!NOTE]
+> Currently, it supports cgroups v1 but does not have support for cgroups v2.
 
 ## Install the package
 


### PR DESCRIPTION
The README file for the Microsoft.Extensions.Diagnostics.ResourceMonitoring has been updated. It has been mentioned that this library uses control groups (cgroups) in Linux to monitor system resources. A note has also been added stating that it currently supports cgroups v1, but there is no support for cgroups v2.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4884)