### PR TITLE
Add workflow for automatic SDK updates

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -1,0 +1,26 @@
+name: update-dotnet-sdk
+
+on:
+
+  # Scheduled trigger to check for .NET SDK updates at 12 UTC every Monday
+  schedule:
+    - cron:  '00 12 * * MON'
+
+  # Manual trigger to update the .NET SDK on-demand.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  update-dotnet-sdk:
+    name: Update .NET SDK
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: martincostello/update-dotnet-sdk@31f3d5a6c2c4a5a0b7eb0e0d5c30501925d6e790
+      with:
+        quality: 'daily'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow is already running in aspnetcore. See https://github.com/dotnet/aspnetcore/pull/53449 for an example PR created by the workflow. Allows us to remove manual SDK updates from build-ops duty. We'll have to add this workflow to the list of approved workflows in the repo settings in order for this to work.