### PR TITLE
Fix SDK update workflow

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -20,8 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: martincostello/update-dotnet-sdk@31f3d5a6c2c4a5a0b7eb0e0d5c30501925d6e790
+      with:
+        ref: dev
+    - uses: martincostello/update-dotnet-sdk@b3d5ca8064ec275f7a1d0b9640d28a57ab94090b
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        branch-name: dev


### PR DESCRIPTION
- Checkout the dev branch so the intended behaviour happens - [docs](https://github.com/martincostello/update-dotnet-sdk/tree/v3.1.1?tab=readme-ov-file#targeting-a-specific-branch).
- Use the SHA that for the [v3.1.1 tag](https://github.com/martincostello/update-dotnet-sdk/tree/v3.1.1) ([diff](https://github.com/martincostello/update-dotnet-sdk/compare/31f3d5a6c2c4a5a0b7eb0e0d5c30501925d6e790...v3.1.1)).

https://github.com/dotnet/extensions/pull/4887#discussion_r1456984405

/cc @wtgodbe


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4890)