### PR TITLE
Address a couple log generator issues.

### DIFF
--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogMethodTests.cs
@@ -231,7 +231,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal("M1 One", collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -239,7 +239,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal(string.Empty, collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -247,7 +247,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal(string.Empty, collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -255,7 +255,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal("M4 Four", collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -263,7 +263,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal("M5 Five", collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Error, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -271,7 +271,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal(string.Empty, collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -282,7 +282,7 @@ public class LogMethodTests
         Assert.Null(logRecord.Exception);
         Assert.Equal(string.Empty, logRecord.Message);
         Assert.Equal(LogLevel.Information, logRecord.Level);
-        Assert.Equal(0, logRecord.Id.Id);
+        Assert.NotEqual(0, logRecord.Id.Id);
         Assert.Equal("M7", logRecord.Id.Name);
 
         collector.Clear();
@@ -336,7 +336,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal("\"p\" -> \"q\"", collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Warning, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
 
         collector.Clear();
@@ -344,7 +344,7 @@ public class LogMethodTests
         Assert.Null(collector.LatestRecord.Exception);
         Assert.Equal("\"\n\r\\", collector.LatestRecord.Message);
         Assert.Equal(LogLevel.Debug, collector.LatestRecord.Level);
-        Assert.Equal(0, collector.LatestRecord.Id.Id);
+        Assert.NotEqual(0, collector.LatestRecord.Id.Id);
         Assert.Equal(1, collector.Count);
     }
 
@@ -575,7 +575,7 @@ public class LogMethodTests
         Assert.Null(logRecord.Exception);
         Assert.Equal(string.Empty, logRecord.Message);
         Assert.Equal(LogLevel.Warning, logRecord.Level);
-        Assert.Equal(0, logRecord.Id.Id);
+        Assert.NotEqual(0, logRecord.Id.Id);
         Assert.Equal("M1_Event", logRecord.Id.Name);
     }
 

--- a/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/LogPropertiesTests.cs
@@ -431,7 +431,7 @@ public class LogPropertiesTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Critical, latestRecord.Level);
         Assert.Equal(string.Empty, latestRecord.Message);
 
@@ -482,7 +482,7 @@ public class LogPropertiesTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Debug, latestRecord.Level);
         Assert.Empty(latestRecord.Message);
 
@@ -507,7 +507,7 @@ public class LogPropertiesTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Debug, latestRecord.Level);
         Assert.Equal($"Struct is: {recordToLog}", latestRecord.Message);
 
@@ -533,7 +533,7 @@ public class LogPropertiesTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Debug, latestRecord.Level);
         Assert.Equal($"Readonly struct is: {recordToLog}", latestRecord.Message);
 

--- a/test/Generators/Microsoft.Gen.Logging/Generated/TagProviderTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Generated/TagProviderTests.cs
@@ -80,7 +80,7 @@ public class TagProviderTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Debug, latestRecord.Level);
         Assert.Equal(string.Empty, latestRecord.Message);
 
@@ -103,7 +103,7 @@ public class TagProviderTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Trace, latestRecord.Level);
         Assert.Equal(string.Empty, latestRecord.Message);
 
@@ -124,7 +124,7 @@ public class TagProviderTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Trace, latestRecord.Level);
         Assert.Equal(string.Empty, latestRecord.Message);
         Assert.Empty(latestRecord.StructuredState!);
@@ -135,7 +135,7 @@ public class TagProviderTests
         Assert.Equal(1, _logger.Collector.Count);
         latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Trace, latestRecord.Level);
         Assert.Equal(string.Empty, latestRecord.Message);
 
@@ -185,7 +185,7 @@ public class TagProviderTests
         Assert.Equal(1, _logger.Collector.Count);
         var latestRecord = _logger.Collector.LatestRecord;
         Assert.Null(latestRecord.Exception);
-        Assert.Equal(0, latestRecord.Id.Id);
+        Assert.NotEqual(0, latestRecord.Id.Id);
         Assert.Equal(LogLevel.Error, latestRecord.Level);
         Assert.Equal(string.Empty, latestRecord.Message);
 
@@ -295,6 +295,26 @@ public class TagProviderTests
             ["param.MyIntProperty"] = interfaceToLog.MyIntProperty.ToInvariantString(),
             ["param.Custom_property_name"] = interfaceToLog.MyStringProperty,
             ["{OriginalFormat}"] = "Custom provided properties for interface."
+        };
+
+        latestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);
+    }
+
+    [Fact]
+    public void LogsWhenEnumerable()
+    {
+        var a = new[] { "Zero", "One", "Two" };
+        TagProviderExtensions.Enumerable(_logger, LogLevel.Debug, a);
+
+        Assert.Equal(1, _logger.Collector.Count);
+        var latestRecord = _logger.Collector.LatestRecord;
+        Assert.Equal(LogLevel.Debug, latestRecord.Level);
+
+        var expectedState = new Dictionary<string, string?>
+        {
+            ["things.Foo0"] = a[0],
+            ["things.Foo1"] = a[1],
+            ["things.Foo2"] = a[2],
         };
 
         latestRecord.StructuredState.Should().NotBeNull().And.Equal(expectedState);

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/TagProviderExtensions.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/TagProviderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Shared.Text;
 
@@ -49,6 +50,12 @@ namespace TestClasses
             ILogger logger,
             LogLevel level,
             [TagProvider(typeof(CustomProvider), nameof(CustomProvider.ProvideTags))] int? param);
+
+        [LoggerMessage]
+        internal static partial void Enumerable(
+            ILogger logger,
+            LogLevel level,
+            [TagProvider(typeof(CustomProvider), nameof(CustomProvider.ProvideForEnumerable))] IEnumerable<string> things);
     }
 
     internal static class CustomProvider
@@ -94,6 +101,16 @@ namespace TestClasses
         {
             list.Add(nameof(ClassToLog.MyIntProperty), param.MyIntProperty);
             list.Add("Custom_property_name", param.MyStringProperty);
+        }
+
+        public static void ProvideForEnumerable(ITagCollector list, IEnumerable<string> e)
+        {
+            int i = 0;
+            foreach (var s in e)
+            {
+                list.Add($"Foo{i}", s);
+                i++;
+            }
         }
     }
 


### PR DESCRIPTION
- Fix a bug where a tag provider attached to an enumerable parameter or property wouldn't behave as expected. Fixes #4883.

- When an event id is not specified, instead of emitting 0 for the the id, we now hash the event name and/or method name. This matches the behavior of the generator in dotnet/runtime and is generally more useful.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/extensions/pull/4894)