### PR TITLE
Fix CA1859 warning

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringServiceCollectionExtensions.cs
@@ -110,7 +110,7 @@ public static class ResourceMonitoringServiceCollectionExtensions
     }
 
 #if !NETFRAMEWORK
-    private static ResourceMonitorBuilder AddLinuxProvider(this IResourceMonitorBuilder builder)
+    private static ResourceMonitorBuilder AddLinuxProvider(this ResourceMonitorBuilder builder)
     {
         _ = Throw.IfNull(builder);
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringServiceCollectionExtensions.cs
@@ -110,7 +110,7 @@ public static class ResourceMonitoringServiceCollectionExtensions
     }
 
 #if !NETFRAMEWORK
-    private static IResourceMonitorBuilder AddLinuxProvider(this IResourceMonitorBuilder builder)
+    private static ResourceMonitorBuilder AddLinuxProvider(this IResourceMonitorBuilder builder)
     {
         _ = Throw.IfNull(builder);
 


### PR DESCRIPTION
As mentioned [here](https://github.com/dotnet/extensions/pull/4903#issuecomment-1912505506) this is to prevent a warning from blocking an SDK update in dev. It's better to do it in main and sync with dev.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4908)