### PR TITLE
Revert "Disable HttpClient's timeout for Standard Resilience and Hedging"

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net.Http;
-using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
@@ -139,9 +138,6 @@ public static partial class ResilienceHttpClientBuilderExtensions
                     .AddTimeout(options.Endpoint.Timeout);
             })
             .SelectPipelineByAuthority();
-
-        // Disable the HttpClient timeout to allow the timeout strategies to control the timeout.
-        _ = builder.ConfigureHttpClient(client => client.Timeout = Timeout.InfiniteTimeSpan);
 
         return new StandardHedgingHandlerBuilder(builder.Name, builder.Services, routingBuilder);
     }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.StandardResilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.StandardResilience.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
@@ -86,9 +85,6 @@ public static partial class ResilienceHttpClientBuilderExtensions
                 .AddCircuitBreaker(options.CircuitBreaker)
                 .AddTimeout(options.AttemptTimeout);
         });
-
-        // Disable the HttpClient timeout to allow the timeout strategies to control the timeout.
-        _ = builder.ConfigureHttpClient(client => client.Timeout = Timeout.InfiniteTimeSpan);
 
         return new HttpStandardResiliencePipelineBuilder(optionsName, builder.Services);
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/StandardHedgingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/StandardHedgingTests.cs
@@ -247,14 +247,6 @@ public sealed class StandardHedgingTests : HedgingTests<IStandardHedgingHandlerB
     }
 
     [Fact]
-    public void AddStandardResilienceHandler_EnsureHttpClientTimeoutDisabled()
-    {
-        var client = CreateClientWithHandler();
-
-        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
-    }
-
-    [Fact]
     public async Task NoRouting_Ok()
     {
         // arrange

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -233,16 +232,6 @@ public sealed partial class HttpClientBuilderExtensionsTests : IDisposable
 
         await client.GetAsync("https://dummy");
         requests.Should().HaveCount(11);
-    }
-
-    [Fact]
-    public void AddStandardResilienceHandler_EnsureHttpClientTimeoutDisabled()
-    {
-        var builder = new ServiceCollection().AddLogging().AddMetrics().AddHttpClient("test").AddStandardHedgingHandler();
-
-        using var client = builder.Services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("test");
-
-        client.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
     }
 
     private static void AddStandardResilienceHandler(


### PR DESCRIPTION
Reverts dotnet/extensions#4862

See https://github.com/dotnet/extensions/issues/4924 for more details.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4925)