### PR TITLE
Fix the automation for merged/closed PRs

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -192,11 +192,8 @@ configuration:
       description: Remove closed issues from milestones
     - if:
       - payloadType: Pull_Request
-      - or:
-        - isAction:
-            action: Null
-        - isAction:
-            action: Closed
+      - isAction:
+          action: Closed
       then:
       - removeLabel:
           label: 'work in progress :construction:'
@@ -217,4 +214,4 @@ configuration:
           label: 'waiting-author-feedback :mailbox_with_no_mail:'
       description: Remove intermediate labels from closed issue
 onFailure: 
-onSuccess: 
+onSuccess:


### PR DESCRIPTION
This is follow-up to #4898. Automation related to closed/merged PRs was not working because of an issue in the migration where there wasn't a condition for checking if a PR was merged. The 'merged' action was carried over as 'Null' in the previous PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4930)