### PR TITLE
Add gRPC resilience tests to verify interoperability

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -143,6 +143,7 @@ getters
 github
 Golang-ci
 gRPC
+Grpc
 GuestUser
 hoc
 hotfix
@@ -355,7 +356,7 @@ versioned
 versioning
 Versioning
 Virtualization
-virtualization 
+virtualization
 VM
 WebAuth
 WebHost

--- a/eng/packages/TestOnly.props
+++ b/eng/packages/TestOnly.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.4.2" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.57.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Microsoft.Extensions.Http.Resilience.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Microsoft.Extensions.Http.Resilience.Tests.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Both" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.TimeProvider.Testing\Microsoft.Extensions.TimeProvider.Testing.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Http.Resilience\Microsoft.Extensions.Http.Resilience.csproj" ProjectUnderTest="true" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Diagnostics.Testing\Microsoft.Extensions.Diagnostics.Testing.csproj" />
@@ -28,9 +32,16 @@
     <PackageReference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
     <PackageReference Include="System.ValueTuple" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
+
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+  </ItemGroup>
+
 </Project>

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Protos/greet.proto
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "Microsoft.Extensions.Http.Resilience.Test.Grpc";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/GrpcResilienceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/GrpcResilienceTests.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NETFRAMEWORK
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Grpc.Core;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience.Test.Grpc;
+using Polly;
+using Xunit;
+
+namespace Microsoft.Extensions.Http.Resilience.Test.Resilience;
+
+public class GrpcResilienceTests
+{
+    private IWebHost _host;
+    private HttpMessageHandler _handler;
+
+    public GrpcResilienceTests()
+    {
+        _host = WebHost
+            .CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddGrpc())
+            .Configure(builder =>
+            {
+                builder.UseRouting();
+                builder.UseEndpoints(endpoints => endpoints.MapGrpcService<GreeterService>());
+            })
+            .UseTestServer()
+            .Start();
+
+        _handler = _host.GetTestServer().CreateHandler();
+    }
+
+    [Fact]
+    public async Task SayHello_NoResilience_OK()
+    {
+        var response = await CreateClient().SayHelloAsync(new HelloRequest { Name = "dummy" });
+
+        response.Message.Should().Be("HI!");
+    }
+
+    [Fact]
+    public async Task SayHello_StandardResilience_OK()
+    {
+        var response = await CreateClient(builder => builder.AddStandardResilienceHandler()).SayHelloAsync(new HelloRequest { Name = "dummy" });
+
+        response.Message.Should().Be("HI!");
+    }
+
+    [Fact]
+    public async Task SayHello_StandardHedging_OK()
+    {
+        var response = await CreateClient(builder => builder.AddStandardHedgingHandler()).SayHelloAsync(new HelloRequest { Name = "dummy" });
+
+        response.Message.Should().Be("HI!");
+    }
+
+    [Fact]
+    public async Task SayHello_CustomResilience_OK()
+    {
+        var client = CreateClient(builder => builder.AddResilienceHandler("custom", builder => builder.AddTimeout(TimeSpan.FromSeconds(1))));
+
+        var response = await client.SayHelloAsync(new HelloRequest { Name = "dummy" });
+
+        response.Message.Should().Be("HI!");
+    }
+
+    private Greeter.GreeterClient CreateClient(Action<IHttpClientBuilder>? configure = null)
+    {
+        var services = new ServiceCollection();
+        var clientBuilder = services
+            .AddGrpcClient<Greeter.GreeterClient>(options =>
+            {
+                options.Address = _host.GetTestServer().BaseAddress;
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => _handler);
+
+        configure?.Invoke(clientBuilder);
+
+        return services.BuildServiceProvider().GetRequiredService<Greeter.GreeterClient>();
+
+    }
+
+    public class GreeterService : Greeter.GreeterBase
+    {
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = "HI!" });
+        }
+    }
+}
+#endif


### PR DESCRIPTION
#4924 revealed that adding resilience makes the gRPC client unusable. Adding basic gRPC tests to ensure this won't happen again and we have at least basic interoperability working.

Contributes to #4923, #4924

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4931)