### PR TITLE
Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,5 +2,6 @@
 <Project>
   <PropertyGroup>
     <PublishingVersion>3</PublishingVersion>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add a boolean property named `ProducesDotNetReleaseShippingAssets` in Publishing.props for repos that produce .NET shipping packages (packages that we ship with the release infra)
Based on this property we will select which packages to ship as part of .NET on release day.

This is a infrastructure only change. It will add extra metadata to the MergedManifest.xml produced during CI build.

Issue: https://github.com/dotnet/release/issues/822