### PR TITLE
AsyncState can be used across different service providers

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
@@ -14,7 +14,7 @@ internal sealed class AsyncState : IAsyncState
 {
     private static readonly AsyncLocal<AsyncStateHolder> _asyncContextCurrent = new();
     private static readonly ObjectPool<List<object?>> _featuresPool = PoolFactory.CreatePool(new FeaturesPooledPolicy());
-    private int _contextCount;
+    private static int _contextCount;
 
     public void Initialize()
     {

--- a/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
@@ -104,9 +104,9 @@ internal sealed class AsyncState : IAsyncState
         }
     }
 
-#pragma warning disable CA1822
+#pragma warning disable CA1822 // Member 'ContextCount' does not access instance data and can be marked as static.
     internal int ContextCount => Volatile.Read(ref _contextCount);
-#pragma warning restore CA1822
+#pragma warning restore CA1822 // Member 'ContextCount' does not access instance data and can be marked as static.
 
     private sealed class AsyncStateHolder
     {

--- a/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
+++ b/src/Libraries/Microsoft.Extensions.AsyncState/AsyncState.cs
@@ -104,7 +104,9 @@ internal sealed class AsyncState : IAsyncState
         }
     }
 
+#pragma warning disable CA1822
     internal int ContextCount => Volatile.Read(ref _contextCount);
+#pragma warning restore CA1822
 
     private sealed class AsyncStateHolder
     {

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AssemblyInfo.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AssemblyInfo.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncContextTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncContextTests.cs
@@ -13,12 +13,13 @@ public class AsyncContextTests
     public async Task CreateAsyncContext_BeforeInitialize()
     {
         var state = new AsyncState();
+        var initialContextCount = state.ContextCount;
         var context1 = new AsyncContext<IThing>(state);
         var context2 = new AsyncContext<IThing>(state);
         var obj1 = new Thing();
         var obj2 = new Thing();
 
-        Assert.Equal(2, state.ContextCount);
+        Assert.Equal(2, state.ContextCount - initialContextCount);
         state.Initialize();
 
         await Task.Run(() => context1.Set(obj1));
@@ -36,11 +37,12 @@ public class AsyncContextTests
     {
         var state = new AsyncState();
         state.Initialize();
+        var initialContextCount = state.ContextCount;
 
         var context1 = new AsyncContext<IThing>(state);
         var context2 = new AsyncContext<IThing>(state);
 
-        Assert.Equal(2, state.ContextCount);
+        Assert.Equal(2, state.ContextCount - initialContextCount);
 
         var obj1 = new Thing();
 
@@ -58,14 +60,14 @@ public class AsyncContextTests
     public async Task CreateAsyncContext_BeforeAndAfterInitialize()
     {
         var state = new AsyncState();
-
+        var initialContextCount = state.ContextCount;
         var context1 = new AsyncContext<IThing>(state);
         state.Initialize();
         var context2 = new AsyncContext<IThing>(state);
         var obj1 = new Thing();
         var obj2 = new Thing();
 
-        Assert.Equal(2, state.ContextCount);
+        Assert.Equal(2, state.ContextCount - initialContextCount);
 
         await Task.Run(() =>
         {
@@ -85,12 +87,13 @@ public class AsyncContextTests
     public async Task Tryget_BeforeAndAfterInitialize()
     {
         var state = new AsyncState();
+        var initialContextCount = state.ContextCount;
         var context1 = new AsyncContext<IThing>(state);
         Assert.False(context1.TryGet(out _));
         state.Initialize();
         var obj1 = new Thing();
 
-        Assert.Equal(1, state.ContextCount);
+        Assert.Equal(1, state.ContextCount - initialContextCount);
 
         await Task.Run(() =>
         {
@@ -110,12 +113,12 @@ public class AsyncContextTests
     public async Task CreateAsyncContextInAsync_AfterInitialize()
     {
         var state = new AsyncState();
-
+        var initialContextCount = state.ContextCount;
         var context1 = new AsyncContext<IThing>(state);
         var obj1 = new Thing();
 
         state.Initialize();
-        Assert.Equal(1, state.ContextCount);
+        Assert.Equal(1, state.ContextCount - initialContextCount);
 
         await Task.Run(async () =>
         {
@@ -181,6 +184,7 @@ public class AsyncContextTests
     public async Task TwoAsyncFlows_WithDiffrentAsyncStates()
     {
         var state = new AsyncState();
+        var initialContextCount = state.ContextCount;
 
         var task1 = Task.Run(async () =>
         {
@@ -215,13 +219,14 @@ public class AsyncContextTests
         });
 
         await Task.WhenAll(task1, task2);
-        Assert.Equal(2, state.ContextCount);
+        Assert.Equal(2, state.ContextCount - initialContextCount);
     }
 
     [Fact]
     public async Task IndependentAsyncFlows_WithSameAsyncState()
     {
         var state = new AsyncState();
+        var initialContextCount = state.ContextCount;
         var context = new AsyncContext<IThing>(state);
 
         Func<Task?> setAsyncState = async () =>
@@ -251,6 +256,6 @@ public class AsyncContextTests
 
         await Task.WhenAll(tasks);
 
-        Assert.Equal(1, state.ContextCount);
+        Assert.Equal(1, state.ContextCount - initialContextCount);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
@@ -196,15 +196,16 @@ public class AsyncStateTests
     public void RegisterContextCorrectly()
     {
         var asyncState = new AsyncState();
+        var initialContextCount = asyncState.ContextCount;
 
         var c1 = asyncState.RegisterAsyncContext();
-        Assert.Equal(0, c1.Index);
+        Assert.Equal(0, c1.Index - initialContextCount);
         var c2 = asyncState.RegisterAsyncContext();
-        Assert.Equal(1, c2.Index);
+        Assert.Equal(1, c2.Index - initialContextCount);
         var c3 = asyncState.RegisterAsyncContext();
-        Assert.Equal(2, c3.Index);
+        Assert.Equal(2, c3.Index - initialContextCount);
 
-        Assert.Equal(3, asyncState.ContextCount);
+        Assert.Equal(3, asyncState.ContextCount - initialContextCount);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/AsyncStateTests.cs
@@ -233,21 +233,26 @@ public class AsyncStateTests
     }
 
     [Fact]
-    public async Task AsyncStateCanBeUsedInDifferentServiceProviders()
+    public void AsyncStateCanBeUsedInDifferentServiceProviders()
     {
-        await using var spOne = PrepareAsyncState(new Tuple<double>(3.14));
-        await using var spTwo = PrepareAsyncState(new Tuple<int>(42));
+        var expectedValue1 = new Tuple<double>(3.14);
+        var expectedValue2 = new Tuple<int>(42);
+        var spOne = CreateAsyncState<Tuple<double>>();
+        var spTwo = CreateAsyncState<Tuple<int>>();
+        spOne.Set(expectedValue1);
+        spTwo.Set(expectedValue2);
+        var value1 = spOne.Get();
+        var value2 = spTwo.Get();
 
-        _ = spOne.GetRequiredService<IAsyncContext<Tuple<double>>>().Get();
-        _ = spTwo.GetRequiredService<IAsyncContext<Tuple<double>>>().Get();
+        Assert.Equal(expectedValue1, value1);
+        Assert.Equal(expectedValue2, value2);
 
-        static ServiceProvider PrepareAsyncState<T>(T value)
+        static IAsyncContext<T> CreateAsyncState<T>()
             where T : notnull
         {
             var services = new ServiceCollection().AddAsyncState().BuildServiceProvider();
             services.GetRequiredService<IAsyncState>().Initialize();
-            services.GetRequiredService<IAsyncContext<T>>().Set(value);
-            return services;
+            return services.GetRequiredService<IAsyncContext<T>>();
         }
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AsyncState.Tests/Microsoft.Extensions.AsyncState.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AsyncState.Tests/Microsoft.Extensions.AsyncState.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AsyncState\Microsoft.Extensions.AsyncState.csproj" ProjectUnderTest="true" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Current implementation of AsyncState has problems. 
This PR fixes https://github.com/dotnet/extensions/issues/4959 by making the field _contextCount static.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4966)