### PR TITLE
try dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+registries:
+  public-nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    registries:
+      - public-nuget
+    schedule:
+      interval: daily
+      time: "07:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 15
+    ignore:
+      # handled by Darc/Maestro flows
+      - dependency-name: "Microsoft.DotNet.Arcade.Sdk"
+      - dependency-name: "Microsoft.DotNet.Helix.Sdk"
+      - dependency-name: "Microsoft.DotNet.SharedFramework.Sdk"
+      - dependency-name: "Microsoft.Build.NoTargets"
+    groups:
+      AspNetCore:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.Extensions.Features"
+      MicrosoftCodeAnalysis:
+        patterns:
+          - "Microsoft.CodeAnalysis.*"
+      MicrosoftExtensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      OpenTelemetry:
+        patterns:
+          - "OpenTelemetry.*"
+      MicrosoftDotNet:
+        patterns:
+          - "Microsoft.DotNet.*"
+      AutoFixture:
+        patterns:
+          - "AutoFixture.*"
+      FluentAssertions:
+        patterns:
+          - "FluentAssertions.*"
+      BenchmarkDotNet:
+        patterns:
+          - "BenchmarkDotNet.*"
+      Moq:
+        patterns:
+          - "Moq.*"
+      Grpc:
+        patterns:
+          - "Grpc.*"
+      Polly:
+        patterns:
+          - "Polly.*"
+      Xunit:
+        patterns:
+          - "Xunit.*"
+    labels:
+      - "area-codeflow"


### PR DESCRIPTION
This doesn't work in my fork -- "Dependabot requires a .(cs|vb|fs)proj to evaluate your .NET dependencies. It had expected to find one at the path: /<anything>.(cs|vb|fs)proj." .. which is a new one.

I cannot figure out why it's doing that, as it's essentially the same as the one in dotnet/aspire. I wonder whether we should just merge it in here anyway and see if it works here...
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4978)