### PR TITLE
Fix incorrect diagnostic value.

### DIFF
--- a/bench/.editorconfig
+++ b/bench/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:45Z
+# Generated : 2024-03-07 23:40:38Z
 # Max Tier  : 2147483647
 # Attributes: general, performance
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6361,7 +6361,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/eng/Diags/Microsoft.VisualStudio.Threading.Analyzers.yml
+++ b/eng/Diags/Microsoft.VisualStudio.Threading.Analyzers.yml
@@ -80,4 +80,4 @@ Diagnostics:
     Tier: 1
     Attributes:
       general:
-        Severity: Warning
+        Severity: Error

--- a/eng/Tools/.editorconfig
+++ b/eng/Tools/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:45Z
+# Generated : 2024-03-07 23:40:38Z
 # Max Tier  : 2147483647
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6353,7 +6353,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Analyzers/.editorconfig
+++ b/src/Analyzers/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:43Z
+# Generated : 2024-03-07 23:40:36Z
 # Max Tier  : 2147483647
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6364,7 +6364,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Generators/.editorconfig
+++ b/src/Generators/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:43Z
+# Generated : 2024-03-07 23:40:36Z
 # Max Tier  : 2147483647
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6364,7 +6364,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/LegacySupport/.editorconfig
+++ b/src/LegacySupport/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:44Z
+# Generated : 2024-03-07 23:40:37Z
 # Max Tier  : 2147483647
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6364,7 +6364,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Libraries/.editorconfig
+++ b/src/Libraries/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:44Z
+# Generated : 2024-03-07 23:40:36Z
 # Max Tier  : 2147483647
 # Attributes: api, general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6390,7 +6390,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:49Z
+# Generated : 2024-03-07 23:40:41Z
 # Max Tier  : 1
 # Attributes: general, performance
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:52Z
+# Generated : 2024-03-07 23:40:44Z
 # Max Tier  : 2
 # Attributes: general, performance
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4512,7 +4512,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Benchmark.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:55Z
+# Generated : 2024-03-07 23:40:48Z
 # Max Tier  : 3
 # Attributes: general, performance
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4543,7 +4543,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:46Z
+# Generated : 2024-03-07 23:40:39Z
 # Max Tier  : 1
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:50Z
+# Generated : 2024-03-07 23:40:42Z
 # Max Tier  : 2
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4506,7 +4506,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/General.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:53Z
+# Generated : 2024-03-07 23:40:45Z
 # Max Tier  : 3
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4535,7 +4535,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:48Z
+# Generated : 2024-03-07 23:40:41Z
 # Max Tier  : 1
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:51Z
+# Generated : 2024-03-07 23:40:44Z
 # Max Tier  : 2
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4506,7 +4506,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdExe.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:54Z
+# Generated : 2024-03-07 23:40:47Z
 # Max Tier  : 3
 # Attributes: general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4535,7 +4535,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:48Z
+# Generated : 2024-03-07 23:40:41Z
 # Max Tier  : 1
 # Attributes: api, general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:52Z
+# Generated : 2024-03-07 23:40:44Z
 # Max Tier  : 2
 # Attributes: api, general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4516,7 +4516,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/NonProdLib.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:55Z
+# Generated : 2024-03-07 23:40:47Z
 # Max Tier  : 3
 # Attributes: api, general
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4564,7 +4564,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:47Z
+# Generated : 2024-03-07 23:40:40Z
 # Max Tier  : 1
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:50Z
+# Generated : 2024-03-07 23:40:43Z
 # Max Tier  : 2
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4513,7 +4513,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdExe.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:53Z
+# Generated : 2024-03-07 23:40:46Z
 # Max Tier  : 3
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4545,7 +4545,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:47Z
+# Generated : 2024-03-07 23:40:40Z
 # Max Tier  : 1
 # Attributes: api, general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:51Z
+# Generated : 2024-03-07 23:40:43Z
 # Max Tier  : 2
 # Attributes: api, general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4522,7 +4522,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/ProdLib.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:54Z
+# Generated : 2024-03-07 23:40:46Z
 # Max Tier  : 3
 # Attributes: api, general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp
@@ -4571,7 +4571,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier1.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier1.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:49Z
+# Generated : 2024-03-07 23:40:42Z
 # Max Tier  : 1
 # Attributes: general, test
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, xunit.analyzers
@@ -4462,7 +4462,7 @@ dotnet_diagnostic.VSTHRD113.severity = none
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier2.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test-Tier2.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:52Z
+# Generated : 2024-03-07 23:40:45Z
 # Max Tier  : 2
 # Attributes: general, test
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, xunit.analyzers
@@ -4506,7 +4506,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test.globalconfig
+++ b/src/Packages/Microsoft.Extensions.StaticAnalysis/build/config/Test.globalconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:56Z
+# Generated : 2024-03-07 23:40:48Z
 # Max Tier  : 3
 # Attributes: general, test
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, xunit.analyzers
@@ -4535,7 +4535,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/src/Shared/.editorconfig
+++ b/src/Shared/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:45Z
+# Generated : 2024-03-07 23:40:37Z
 # Max Tier  : 2147483647
 # Attributes: general, performance, production
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers
@@ -6364,7 +6364,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,5 +1,5 @@
 # Created by DiagConfig, the diagnostic config generator
-# Generated : 2024-01-25 20:57:46Z
+# Generated : 2024-03-07 23:40:39Z
 # Max Tier  : 2147483647
 # Attributes: general, test
 # Analyzers : ILLink.RoslynAnalyzer, Microsoft.Analyzers.Extra, Microsoft.Analyzers.Local, Microsoft.AspNetCore.App.Analyzers, Microsoft.AspNetCore.Components.Analyzers, Microsoft.CodeAnalysis.CodeStyle, Microsoft.CodeAnalysis.CSharp.CodeStyle, Microsoft.CodeAnalysis.CSharp.NetAnalyzers, Microsoft.CodeAnalysis.NetAnalyzers, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.VisualStudio.Threading.Analyzers.CSharp, SonarAnalyzer.CSharp, StyleCop.Analyzers, xunit.analyzers
@@ -6353,7 +6353,7 @@ dotnet_diagnostic.VSTHRD113.severity = suggestion
 # Title    : Avoid returning a null Task
 # Category : Usage
 # Help Link: https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD114.md
-dotnet_diagnostic.VSTHRD114.severity = warning
+dotnet_diagnostic.VSTHRD114.severity = error
 
 # Title    : Avoid returning a null Task
 # Category : Usage


### PR DESCRIPTION
- VSTHRD114 appears in two different assemblies, and so shows up twice in the diagnostics yaml
files. Both uses should be configured consistently. The only manual change here is in the .yml file,
everything else is generated by
scripts/MakeEditorConfigs.ps1

Fixed #4991
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/4994)