### PR TITLE
Skip TcpEndpointProbesServiceTests.ExecuteAsync_CheckListenerOpenAndC…

### DIFF
--- a/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/TcpEndpointProbesServiceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/TcpEndpointProbesServiceTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Diagnostics.Probes.Test;
 [CollectionDefinition(nameof(TcpEndpointProbesServiceTests), DisableParallelization = true)]
 public class TcpEndpointProbesServiceTests
 {
-    [Fact]
+    [Fact(Skip = "Flaky test, see https://github.com/dotnet/extensions/issues/5006")]
     public async Task ExecuteAsync_CheckListenerOpenAndCloseAfterHealthStatusEvents()
     {
         var port = GetFreeTcpPort();


### PR DESCRIPTION
…loseAfterHealthStatusEvents

For #5006
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5008)