### PR TITLE
Fix incorrect TCP port used by default for k8s probes

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/KubernetesProbesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/KubernetesProbesExtensions.cs
@@ -52,8 +52,11 @@ public static class KubernetesProbesExtensions
         return services
             .AddTcpEndpointProbe(ProbeTags.Liveness, options =>
             {
+                options.TcpPort = wrapperOptions.LivenessProbe.TcpPort;
                 wrapperOptions.LivenessProbe = options;
+
                 configure(wrapperOptions);
+
                 var originalPredicate = options.FilterChecks;
                 if (originalPredicate == null)
                 {
@@ -66,8 +69,11 @@ public static class KubernetesProbesExtensions
             })
             .AddTcpEndpointProbe(ProbeTags.Startup, options =>
             {
+                options.TcpPort = wrapperOptions.StartupProbe.TcpPort;
                 wrapperOptions.StartupProbe = options;
+
                 configure(wrapperOptions);
+
                 var originalPredicate = options.FilterChecks;
                 if (originalPredicate == null)
                 {
@@ -80,8 +86,11 @@ public static class KubernetesProbesExtensions
             })
             .AddTcpEndpointProbe(ProbeTags.Readiness, (options) =>
             {
+                options.TcpPort = wrapperOptions.ReadinessProbe.TcpPort;
                 wrapperOptions.ReadinessProbe = options;
+
                 configure(wrapperOptions);
+
                 var originalPredicate = options.FilterChecks;
                 if (originalPredicate == null)
                 {

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesExtensionsTests.cs
@@ -49,16 +49,19 @@ public class KubernetesProbesExtensionsTests
         Assert.True(livenessConfig.FilterChecks!(livenessRegistration));
         Assert.False(livenessConfig.FilterChecks(startupRegistration));
         Assert.False(livenessConfig.FilterChecks(readinessRegistration));
+        Assert.Equal(2305, livenessConfig.TcpPort);
 
         var startupConfig = config.Get(ProbeTags.Startup);
         Assert.False(startupConfig.FilterChecks!(livenessRegistration));
         Assert.True(startupConfig.FilterChecks(startupRegistration));
         Assert.False(startupConfig.FilterChecks(readinessRegistration));
+        Assert.Equal(2306, startupConfig.TcpPort);
 
         var readinessConfig = config.Get(ProbeTags.Readiness);
         Assert.False(readinessConfig.FilterChecks!(livenessRegistration));
         Assert.False(readinessConfig.FilterChecks(startupRegistration));
         Assert.True(readinessConfig.FilterChecks(readinessRegistration));
+        Assert.Equal(2307, readinessConfig.TcpPort);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #5082 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5085)