### PR TITLE
Securing the array for ResourceMonitoring's method

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/IFileSystem.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/IFileSystem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Shared.Pools;
 
@@ -22,7 +23,7 @@ internal interface IFileSystem
     /// Get directory names on the filesystem based on the provided pattern.
     /// </summary>
     /// <returns>string.</returns>
-    string[] GetDirectoryNames(string directory, string pattern);
+    IReadOnlyCollection<string> GetDirectoryNames(string directory, string pattern);
 
     /// <summary>
     /// Reads content from the file.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -230,7 +231,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
     public long GetMemoryUsageInBytesFromSlices(string pattern)
     {
         // In cgroup v2, we need to read memory usage from all slices, which are directories in /sys/fs/cgroup/*.slice.
-        string[] memoryUsageInBytesSlicesPath = _fileSystem.GetDirectoryNames("/sys/fs/cgroup/", pattern);
+        IReadOnlyCollection<string> memoryUsageInBytesSlicesPath = _fileSystem.GetDirectoryNames("/sys/fs/cgroup/", pattern);
 
         long memoryUsageInBytesTotal = 0;
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/OSFileSystem.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/OSFileSystem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -22,7 +23,7 @@ internal sealed class OSFileSystem : IFileSystem
         return fileInfo.Exists;
     }
 
-    public string[] GetDirectoryNames(string directory, string pattern)
+    public IReadOnlyCollection<string> GetDirectoryNames(string directory, string pattern)
     {
         return Directory.GetDirectories(directory, pattern)
                 .ToArray();

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/FileNamesOnlyFileSystem.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/FileNamesOnlyFileSystem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Shared.Pools;
@@ -17,7 +18,7 @@ internal sealed class FileNamesOnlyFileSystem : IFileSystem
         return fileInfo.Exists;
     }
 
-    public string[] GetDirectoryNames(string directory, string pattern)
+    public IReadOnlyCollection<string> GetDirectoryNames(string directory, string pattern)
     {
         throw new NotSupportedException();
     }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/HardcodedValueFileSystem.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/HardcodedValueFileSystem.cs
@@ -33,7 +33,7 @@ internal sealed class HardcodedValueFileSystem : IFileSystem
         return _fileContent.ContainsKey(fileInfo.FullName);
     }
 
-    public string[] GetDirectoryNames(string directory, string pattern)
+    public IReadOnlyCollection<string> GetDirectoryNames(string directory, string pattern)
     {
         return _fileContent.Keys
                 .Where(x => x.StartsWith(directory, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Changed Array to IReadOnlyCollection for GetDirectoryName method
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5111)