### PR TITLE
Add support for processing requests with StreamContent to AddStandardHedgingHandler()

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -90,11 +90,12 @@ public static partial class ResilienceHttpClientBuilderExtensions
                     Throw.InvalidOperationException("Request message snapshot is not attached to the resilience context.");
                 }
 
-                // if a routing strategy has been configured but it does not return the next route, then no more routes
-                // are availabe, stop hedging
+                // if a routing strategy has been configured, get the next route from the routing strategy
                 Uri? route;
                 if (args.PrimaryContext.Properties.TryGetValue(ResilienceKeys.RoutingStrategy, out var routingPipeline))
                 {
+                    // if a routing strategy has been configured but it does not return the next route, then no more routes
+                    // are availabe, stop hedging
                     if (!routingPipeline.TryGetNextRoute(out route))
                     {
                         return null;
@@ -121,7 +122,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
 
                         if (route != null)
                         {
-                            // replace the RequestUri of the request per the routing strategy
+                            // replace the Host on the RequestUri of the request per the routing strategy
                             requestMessage.RequestUri = requestMessage.RequestUri!.ReplaceHost(route);
                         }
                     }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -120,7 +120,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
                         // replace the request message
                         args.ActionContext.Properties.Set(ResilienceKeys.RequestMessage, requestMessage);
 
-                        if (route != null)
+                        if (route is not null)
                         {
                             // replace the Host on the RequestUri of the request per the routing strategy
                             requestMessage.RequestUri = requestMessage.RequestUri!.ReplaceHost(route);

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -111,7 +111,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
 
                     try
                     {
-                        var requestMessage = await snapshot.CreateRequestMessageAsync().ConfigureAwait(false);
+                        var requestMessage = await snapshot.CreateRequestMessageAsync().ConfigureAwait(args.ActionContext.ContinueOnCapturedContext);
 
                         // The secondary request message should use the action resilience context
                         requestMessage.SetResilienceContext(args.ActionContext);

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/RequestMessageSnapshot.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/RequestMessageSnapshot.cs
@@ -25,7 +25,7 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
     private HttpContent? _content;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "Past the point of no cancellation.")]
-    public static async Task<RequestMessageSnapshot> CreateAsync(HttpRequestMessage request)
+    public static async ValueTask<RequestMessageSnapshot> CreateAsync(HttpRequestMessage request)
     {
         _ = Throw.IfNull(request);
 
@@ -35,7 +35,7 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "Past the point of no cancellation.")]
-    public async Task<HttpRequestMessage> CreateRequestMessageAsync()
+    public async ValueTask<HttpRequestMessage> CreateRequestMessageAsync()
     {
         if (!IsInitialized())
         {
@@ -101,7 +101,7 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
     void IDisposable.Dispose() => _snapshots.Return(this);
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "Past the point of no cancellation.")]
-    private static async Task<(HttpContent? content, HttpContent? clonedContent)> CloneContentAsync(HttpContent? content)
+    private static async ValueTask<(HttpContent? content, HttpContent? clonedContent)> CloneContentAsync(HttpContent? content)
     {
         HttpContent? clonedContent = null;
         if (content is not null)

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/RequestMessageSnapshot.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/RequestMessageSnapshot.cs
@@ -104,7 +104,7 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
     private static async Task<(HttpContent? content, HttpContent? clonedContent)> CloneContentAsync(HttpContent? content)
     {
         HttpContent? clonedContent = null;
-        if (content != null)
+        if (content is not null)
         {
             HttpContent originalContent = content;
             Stream originalRequestBody = await content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -137,7 +137,7 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
 
     private bool IsInitialized()
     {
-        return _method != null;
+        return _method is not null;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "Past the point of no cancellation.")]

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/RequestMessageSnapshot.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/RequestMessageSnapshot.cs
@@ -37,12 +37,12 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "Past the point of no cancellation.")]
     public async Task<HttpRequestMessage> CreateRequestMessageAsync()
     {
-        if (IsReset())
+        if (!IsInitialized())
         {
-            throw new InvalidOperationException($"{nameof(CreateRequestMessageAsync)}() cannot be called on a snapshot object that has been reset and has not been initialized");
+            throw new InvalidOperationException($"{nameof(CreateRequestMessageAsync)}() cannot be called on a snapshot object that has been reset and/or has not been initialized");
         }
 
-        var clone = new HttpRequestMessage(_method!, _requestUri)
+        var clone = new HttpRequestMessage(_method!, _requestUri?.OriginalString)
         {
             Version = _version!
         };
@@ -135,9 +135,9 @@ internal sealed class RequestMessageSnapshot : IResettable, IDisposable
         return (content, clonedContent);
     }
 
-    private bool IsReset()
+    private bool IsInitialized()
     {
-        return _method == null;
+        return _method != null;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "Past the point of no cancellation.")]

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/StandardHedgingTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Hedging/StandardHedgingTests.cs
@@ -103,7 +103,7 @@ public sealed class StandardHedgingTests : HedgingTests<IStandardHedgingHandlerB
     }
 
     [Fact]
-    public void ActionGenerator_Ok()
+    public async Task ActionGenerator_Ok()
     {
         var options = Builder.Services.BuildServiceProvider().GetRequiredService<IOptionsMonitor<HttpStandardHedgingResilienceOptions>>().Get(Builder.Name);
         var generator = options.Hedging.ActionGenerator;
@@ -115,7 +115,7 @@ public sealed class StandardHedgingTests : HedgingTests<IStandardHedgingHandlerB
         generator.Invoking(g => g(args)).Should().Throw<InvalidOperationException>().WithMessage("Request message snapshot is not attached to the resilience context.");
 
         using var request = new HttpRequestMessage();
-        using var snapshot = RequestMessageSnapshot.Create(request);
+        using var snapshot = await RequestMessageSnapshot.CreateAsync(request).ConfigureAwait(false);
         primary.Properties.Set(ResilienceKeys.RequestSnapshot, snapshot);
         generator.Invoking(g => g(args)).Should().NotThrow();
     }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RequestMessageSnapshotStrategyTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RequestMessageSnapshotStrategyTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Net.Http;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Http.Resilience.Internal;
@@ -39,5 +42,38 @@ public class RequestMessageSnapshotStrategyTests
         strategy.Invoking(s => s.Execute(() => { })).Should().Throw<InvalidOperationException>();
     }
 
+    [Fact]
+    public async Task ExecuteCoreAsync_IOExceptionThrownWhenCreatingSnapshot_ReturnsExceptionOutcome()
+    {
+        var strategy = Create();
+        var context = ResilienceContextPool.Shared.Get();
+        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri("https://www.example.com/some-resource"));
+        using var stream = new StreamTestHelper("some stream content");
+        request.Content = new StreamContent(stream);
+        context.Properties.Set(ResilienceKeys.RequestMessage, request);
+
+        _ = await Assert.ThrowsAsync<IOException>(async () => await strategy.ExecuteAsync(context => default, context));
+    }
+
     private static ResiliencePipeline Create() => new ResiliencePipelineBuilder().AddStrategy(_ => new RequestMessageSnapshotStrategy(), Mock.Of<ResilienceStrategyOptions>()).Build();
+
+    private class StreamTestHelper : MemoryStream
+    {
+        public StreamTestHelper(string str)
+            : base(Encoding.UTF8.GetBytes(str))
+        {
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => throw new IOException();
+
+#if NET5_0_OR_GREATER
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => throw new IOException();
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new IOException();
+#else
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new IOException();
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new IOException();
+#endif
+    }
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RequestMessageSnapshotStrategyTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RequestMessageSnapshotStrategyTests.cs
@@ -32,7 +32,7 @@ public class RequestMessageSnapshotStrategyTests
     }
 
     [Fact]
-    public void ExecuteAsync_requestMessageNotFound_Throws()
+    public void ExecuteAsync_RequestMessageNotFound_Throws()
     {
         var strategy = Create();
 

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/RequestMessageSnapshotTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/RequestMessageSnapshotTests.cs
@@ -2,99 +2,222 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Http.Resilience.Internal;
 using Xunit;
 
 namespace Microsoft.Extensions.Http.Resilience.Test.Resilience;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
-
-public class RequestMessageSnapshotTests
+public class RequestMessageSnapshotTests : IDisposable
 {
-    [Fact]
-    public void CreateSnapshot_StreamContent_ShouldThrow()
-    {
-        var initialRequest = new HttpRequestMessage
-        {
-            RequestUri = new Uri("https://dummy-uri.com?query=param"),
-            Method = HttpMethod.Get,
-            Content = new StreamContent(new MemoryStream())
-        };
+    private readonly Uri _requestUri = new Uri("https://www.example.com/some-resource");
+    private bool _disposedValue;
+    private HttpRequestMessage? _requestMessage;
 
-        var exception = Assert.Throws<InvalidOperationException>(() => RequestMessageSnapshot.Create(initialRequest));
-        Assert.Equal("StreamContent content cannot by cloned.", exception.Message);
-        initialRequest.Dispose();
+    public RequestMessageSnapshotTests()
+    {
+        _requestMessage = new HttpRequestMessage(HttpMethod.Post, _requestUri);
     }
 
     [Fact]
-    public void CreateSnapshot_CreatesClone()
+    public async Task CreateSnapshotAsync_RequestMessageContainsStringContent_Success()
     {
-        using var request = CreateRequest();
-        using var snapshot = RequestMessageSnapshot.Create(request);
-        var cloned = snapshot.CreateRequestMessage();
-        AssertClonedMessage(request, cloned);
+        _requestMessage!.Content = new StringContent("some string content");
+        AddRequestHeaders(_requestMessage);
+        AddRequestOptions(_requestMessage);
+        AddContentHeaders(_requestMessage!.Content);
+        using RequestMessageSnapshot snapshot = await RequestMessageSnapshot.CreateAsync(_requestMessage).ConfigureAwait(false);
+        using HttpRequestMessage clonedRequestMessage = await snapshot.CreateRequestMessageAsync().ConfigureAwait(false);
+        await AssertRequestMessagesAreEqual(_requestMessage, clonedRequestMessage).ConfigureAwait(false);
     }
 
     [Fact]
-    public void CreateSnapshot_OriginalMessageChanged_SnapshotReturnsOriginalData()
+    public async Task CreateSnapshotAsync_RequestMessageContainsStreamContent_Success()
     {
-        using var request = CreateRequest();
-        using var snapshot = RequestMessageSnapshot.Create(request);
-
-        request.Properties["some-new-prop"] = "ABC";
-        var cloned = snapshot.CreateRequestMessage();
-        cloned.Properties.Should().NotContainKey("some-new-prop");
+        using var stream = new MemoryStream();
+        using var streamWriter = new StreamWriter(stream);
+        await streamWriter.WriteAsync("some stream content").ConfigureAwait(false);
+        await streamWriter.FlushAsync().ConfigureAwait(false);
+        stream.Position = 0;
+        _requestMessage!.Content = new StreamContent(stream);
+        AddRequestHeaders(_requestMessage);
+        AddRequestOptions(_requestMessage);
+        AddContentHeaders(_requestMessage!.Content);
+        using RequestMessageSnapshot snapshot = await RequestMessageSnapshot.CreateAsync(_requestMessage).ConfigureAwait(false);
+        using HttpRequestMessage clonedRequestMessage = await snapshot.CreateRequestMessageAsync().ConfigureAwait(false);
+        await AssertRequestMessagesAreEqual(_requestMessage, clonedRequestMessage).ConfigureAwait(false);
     }
 
-    private static HttpRequestMessage CreateRequest()
+    [Fact]
+    public async Task CreateSnapshotAsync_RequestMessageContainsNonSeekableStreamContent_Success()
     {
-        var initialRequest = new HttpRequestMessage
-        {
-            RequestUri = new Uri("https://dummy-uri.com?query=param"),
-            Method = HttpMethod.Get,
-            Version = new Version(1, 1),
-            Content = new StringContent("{\"name\":\"John Doe\",\"age\":33}", Encoding.UTF8, "application/json")
-        };
+        using var stream = new NonSeekableStream("some stream content");
+        _requestMessage!.Content = new StreamContent(stream);
+        AddRequestHeaders(_requestMessage);
+        AddRequestOptions(_requestMessage);
+        AddContentHeaders(_requestMessage!.Content);
+        using RequestMessageSnapshot snapshot = await RequestMessageSnapshot.CreateAsync(_requestMessage).ConfigureAwait(false);
+        using HttpRequestMessage clonedRequestMessage = await snapshot.CreateRequestMessageAsync().ConfigureAwait(false);
+        await AssertRequestMessagesAreEqual(_requestMessage, clonedRequestMessage).ConfigureAwait(false);
+    }
 
-        initialRequest.Headers.Add("Authorization", "Bearer token");
-        initialRequest.Properties.Add("A", "A");
-        initialRequest.Properties.Add("B", "B");
+    [Fact]
+    public async Task CreateSnapshotAsync_RequestMessageHasNoContent_Success()
+    {
+        _requestMessage!.Method = HttpMethod.Get;
+        Assert.Null(_requestMessage!.Content);
+        AddRequestHeaders(_requestMessage);
+        AddRequestOptions(_requestMessage);
+        using RequestMessageSnapshot snapshot = await RequestMessageSnapshot.CreateAsync(_requestMessage).ConfigureAwait(false);
+        using HttpRequestMessage clonedRequestMessage = await snapshot.CreateRequestMessageAsync().ConfigureAwait(false);
+        await AssertRequestMessagesAreEqual(_requestMessage, clonedRequestMessage).ConfigureAwait(false);
+    }
 
-#if NET8_0_OR_GREATER
-        // Whilst these API are marked as NET5_0_OR_GREATER we don't build .NET 5.0,
-        // and as such the API is available in .NET 8 onwards.
-        initialRequest.Options.Set(new HttpRequestOptionsKey<string>("C"), "C");
-        initialRequest.Options.Set(new HttpRequestOptionsKey<string>("D"), "D");
+    [Fact]
+    public async Task CreateSnapshotAsync_RequestMessageIsNull_ThrowsException()
+    {
+        HttpRequestMessage? requestMessage = null;
+#pragma warning disable CS8604 // Possible null reference argument.
+        _ = await Assert.ThrowsAsync<ArgumentNullException>(async () => await RequestMessageSnapshot.CreateAsync(requestMessage).ConfigureAwait(false)).ConfigureAwait(false);
+#pragma warning restore CS8604 // Possible null reference argument.
+    }
+
+    [Fact]
+    public async Task CreateSnapshotAsync_OriginalMessageChanged_SnapshotReturnsOriginalData()
+    {
+        using var snapshot = await RequestMessageSnapshot.CreateAsync(_requestMessage!).ConfigureAwait(false);
+
+#if NET5_0_OR_GREATER
+        _requestMessage!.Options.Set(new HttpRequestOptionsKey<object?>("Some.New.Request.Option"), "some new request option value");
+#else
+        _requestMessage!.Properties["Some.New.Request.Property"] = "some new request property value";
 #endif
-        return initialRequest;
+
+        var cloned = await snapshot.CreateRequestMessageAsync().ConfigureAwait(false);
+
+#if NET5_0_OR_GREATER
+        cloned.Options.Should().NotContainKey("Some.New.Request.Option");
+#else
+        cloned.Properties.Should().NotContainKey("Some.New.Request.Property");
+#endif
     }
 
-    private static void AssertClonedMessage(HttpRequestMessage initialRequest, HttpRequestMessage cloned)
+    public void Dispose()
     {
-        Assert.NotNull(cloned);
-        Assert.Equal(initialRequest.Method, cloned.Method);
-        Assert.Equal(initialRequest.RequestUri, cloned.RequestUri);
-        Assert.Equal(initialRequest.Content, cloned.Content);
-        Assert.Equal(initialRequest.Version, cloned.Version);
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
 
-        Assert.NotNull(cloned.Headers.Authorization);
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _requestMessage!.Dispose();
+                _requestMessage = null;
+            }
 
-        cloned.Properties["A"].Should().Be("A");
-        cloned.Properties["B"].Should().Be("B");
+            _disposedValue = true;
+        }
+    }
 
-#if NET8_0_OR_GREATER
-        // Whilst these API are marked as NET5_0_OR_GREATER we don't build .NET 5.0,
-        // and as such the API is available in .NET 8 onwards.
-        initialRequest.Options.TryGetValue(new HttpRequestOptionsKey<string>("C"), out var val).Should().BeTrue();
-        val.Should().Be("C");
+    private static void AddContentHeaders(HttpContent content)
+    {
+        content.Headers.TryAddWithoutValidation("Some-Content-Header", "some content header value");
+        content.Headers.TryAddWithoutValidation("Some-Other-Content-Header", "some other content header value");
+    }
 
-        initialRequest.Options.TryGetValue(new HttpRequestOptionsKey<string>("D"), out val).Should().BeTrue();
-        val.Should().Be("D");
+    private static void AddRequestHeaders(HttpRequestMessage requestMessage)
+    {
+        requestMessage.Headers.TryAddWithoutValidation("Some-Header", "some header value");
+        requestMessage.Headers.TryAddWithoutValidation("Some-Other-Header", "some other header value");
+    }
+
+    private static void AddRequestOptions(HttpRequestMessage requestMessage)
+    {
+#if NET5_0_OR_GREATER
+        requestMessage.Options.TryAdd("Some.Request.Option", "some request option value");
+        requestMessage.Options.TryAdd("Some.Other.Request.Option", "some other request option value");
+#else
+        requestMessage.Properties["Some.Request.Property"] = "some request property value";
+        requestMessage.Properties["Some.Other.Request.Property"] = "some other request property value";
 #endif
+    }
+
+    private static async Task AssertRequestMessagesAreEqual(HttpRequestMessage requestMessageA, HttpRequestMessage requestMessageB)
+    {
+        Assert.NotNull(requestMessageA);
+        Assert.NotNull(requestMessageB);
+        Assert.NotSame(requestMessageA, requestMessageB); // assert no shallow copy
+        Assert.Equal(requestMessageA.Method, requestMessageB.Method);
+        Assert.Equal(requestMessageA.RequestUri?.AbsoluteUri, requestMessageB.RequestUri?.AbsoluteUri);
+        Assert.Equal(requestMessageA.Version, requestMessageB.Version);
+        if (requestMessageA.Content == null)
+        {
+            Assert.Null(requestMessageB.Content);
+        }
+        else if (requestMessageB.Content == null)
+        {
+            Assert.Null(requestMessageA.Content);
+        }
+        else
+        {
+            if (requestMessageA.Content is StreamContent)
+            {
+                Assert.NotSame(requestMessageA.Content, requestMessageB.Content); // assert no shallow copy
+            }
+            else
+            {
+                Assert.Same(requestMessageA.Content, requestMessageB.Content); // assert shallow copy
+            }
+
+            Assert.Equal(
+                await requestMessageA.Content.ReadAsStringAsync().ConfigureAwait(false),
+                await requestMessageB.Content.ReadAsStringAsync().ConfigureAwait(false));
+
+            foreach (KeyValuePair<string, IEnumerable<string>> header in requestMessageA.Content.Headers)
+            {
+                Assert.Contains(requestMessageB.Content.Headers, (x) => x.Key == header.Key && x.Value.Any((y) => header.Value.Any((z) => z == y)));
+            }
+        }
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header in requestMessageA.Headers)
+        {
+            Assert.NotSame(requestMessageA.Headers, requestMessageB.Headers); // assert no shallow copy
+            Assert.Contains(requestMessageB.Headers, (x) => x.Key == header.Key
+                && x.Value.Any((y) => header.Value.Any((z) => z == y))
+                && x.Value != header.Value); // assert no shallow copy
+        }
+
+#if NET5_0_OR_GREATER
+        foreach (KeyValuePair<string, object?> option in requestMessageA.Options)
+        {
+            Assert.NotSame(requestMessageA.Options, requestMessageB.Options); // assert no shallow copy
+            Assert.Contains(requestMessageB.Options, (x) => x.Key == option.Key && x.Value == option.Value);
+        }
+#else
+        foreach (KeyValuePair<string, object?> property in requestMessageA.Properties)
+        {
+            Assert.NotSame(requestMessageA.Properties, requestMessageB.Properties); // assert no shallow copy
+            Assert.Contains(requestMessageB.Properties, (x) => x.Key == property.Key && x.Value == property.Value);
+        }
+#endif
+    }
+
+    private class NonSeekableStream : MemoryStream
+    {
+        public NonSeekableStream(string str)
+            : base(Encoding.UTF8.GetBytes(str), writable: false)
+        {
+        }
+
+        public override bool CanSeek => false;
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/RequestMessageSnapshotTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/RequestMessageSnapshotTests.cs
@@ -123,7 +123,7 @@ public class RequestMessageSnapshotTests : IDisposable
         AddContentHeaders(_requestMessage!.Content);
         using RequestMessageSnapshot snapshot = await RequestMessageSnapshot.CreateAsync(_requestMessage).ConfigureAwait(false);
         ((IResettable)snapshot).TryReset();
-        _ = await Assert.ThrowsAsync<InvalidOperationException>(snapshot.CreateRequestMessageAsync);
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(async () => await snapshot.CreateRequestMessageAsync().ConfigureAwait(false));
     }
 
     public void Dispose()


### PR DESCRIPTION
Fixes #5105 

Add support for processing HttpRequestMessage objects containing StreamContent to the AddStandardHedgingHandler() resilience API.

This change does not update any public API contracts. It updates internal and private API contracts only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5112)