### PR TITLE
Upgrade to latest version of Polly

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Resilience.PerformanceTests/ResilienceEnrichmentBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Resilience.PerformanceTests/ResilienceEnrichmentBenchmark.cs
@@ -40,7 +40,7 @@ public class ResilienceEnrichmentBenchmark
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddExceptionSummarizer();
-        services.AddResiliencePipeline("my-pipeline", builder => builder.AddStrategy(context => new DummyStrategy(context.Telemetry), new DummyOptions()));
+        services.AddResiliencePipeline("my-pipeline", builder => builder.AddStrategy(context => new DummyStrategy(context.Telemetry)));
         services.AddLogging();
         configure(services);
 
@@ -65,9 +65,5 @@ public class ResilienceEnrichmentBenchmark
 
             return callback(context, state);
         }
-    }
-
-    private sealed class DummyOptions : ResilienceStrategyOptions
-    {
     }
 }

--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -37,10 +37,10 @@
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesVersion)" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="Polly" Version="8.3.0" />
-    <PackageVersion Include="Polly.Core" Version="8.3.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.3.0" />
+    <PackageVersion Include="Polly" Version="8.4.0" />
+    <PackageVersion Include="Polly.Core" Version="8.4.0" />
+    <PackageVersion Include="Polly.Extensions" Version="8.4.0" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.4.0" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/eng/packages/TestOnly.props
+++ b/eng/packages/TestOnly.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
     <PackageVersion Include="Moq.AutoMock" Version="3.1.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Polly.Testing" Version="8.3.0" />
+    <PackageVersion Include="Polly.Testing" Version="8.4.0" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/ResilienceHttpClientBuilderExtensions.Hedging.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -143,17 +142,8 @@ public static partial class ResilienceHttpClientBuilderExtensions
         return new StandardHedgingHandlerBuilder(builder.Name, builder.Services, routingBuilder);
     }
 
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-        Justification = "The EmptyResilienceStrategyOptions doesn't have any properties to validate.")]
-    private static ResiliencePipelineBuilder<HttpResponseMessage> AddStrategy(this ResiliencePipelineBuilder<HttpResponseMessage> builder, Func<StrategyBuilderContext, ResilienceStrategy> factory) =>
-        builder.AddStrategy(factory, new EmptyResilienceStrategyOptions());
-
     private sealed record StandardHedgingHandlerBuilder(
         string Name,
         IServiceCollection Services,
         IRoutingStrategyBuilder RoutingStrategyBuilder) : IStandardHedgingHandlerBuilder;
-
-    private sealed class EmptyResilienceStrategyOptions : ResilienceStrategyOptions
-    {
-    }
 }


### PR DESCRIPTION
I have also dropped workarounds for trim warnings that are no longer required with Polly 8.4.0

For context:
https://github.com/App-vNext/Polly/issues/1985

Polly 8.4.0
https://github.com/App-vNext/Polly/releases/tag/8.4.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5152)

cc @martincostello 