### PR TITLE
Fix [NoDataClassification] attribute handling in logging source-gen

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Parsing/DiagDescriptors.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/DiagDescriptors.cs
@@ -236,7 +236,8 @@ internal sealed class DiagDescriptors : DiagDescriptorsBase
         id: DiagnosticIds.LoggerMessage.LOGGEN035,
         title: Resources.RecordTypeSensitiveArgumentIsInTemplateTitle,
         messageFormat: Resources.RecordTypeSensitiveArgumentIsInTemplateMessage,
-        category: Category);
+        category: Category,
+        DiagnosticSeverity.Warning);
 
     public static DiagnosticDescriptor DefaultToString { get; } = Make(
         id: DiagnosticIds.LoggerMessage.LOGGEN036,

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/Parser.cs
@@ -494,6 +494,7 @@ internal sealed partial class Parser
             .GetAttributes()
             .Select(static attribute => attribute.AttributeClass)
             .Where(x => x is not null && symbols.DataClassificationAttribute is not null && ParserUtilities.IsBaseOrIdentity(x, symbols.DataClassificationAttribute, symbols.Compilation))
+            .Where(x => !SymbolEqualityComparer.Default.Equals(x, symbols.NoDataClassificationAttribute))
             .Select(static x => x!)
             .ToList();
 

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolHolder.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolHolder.cs
@@ -23,4 +23,5 @@ internal sealed record class SymbolHolder(
     INamedTypeSymbol EnumerableSymbol,
     INamedTypeSymbol FormatProviderSymbol,
     INamedTypeSymbol? SpanFormattableSymbol,
-    INamedTypeSymbol? DataClassificationAttribute);
+    INamedTypeSymbol? DataClassificationAttribute,
+    INamedTypeSymbol? NoDataClassificationAttribute);

--- a/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Parsing/SymbolLoader.cs
@@ -19,6 +19,7 @@ internal static class SymbolLoader
     internal const string LogLevelType = "Microsoft.Extensions.Logging.LogLevel";
     internal const string ExceptionType = "System.Exception";
     internal const string DataClassificationAttribute = "Microsoft.Extensions.Compliance.Classification.DataClassificationAttribute";
+    internal const string NoDataClassificationAttribute = "Microsoft.Extensions.Compliance.Classification.NoDataClassificationAttribute";
     internal const string IEnrichmentPropertyBag = "Microsoft.Extensions.Diagnostics.Enrichment.IEnrichmentPropertyBag";
     internal const string IFormatProviderType = "System.IFormatProvider";
     internal const string ISpanFormattableType = "System.ISpanFormattable";
@@ -60,6 +61,7 @@ internal static class SymbolLoader
         var tagCollectorSymbol = compilation.GetTypeByMetadataName(ITagCollectorType);
         var logPropertyIgnoreAttributeSymbol = compilation.GetTypeByMetadataName(LogPropertyIgnoreAttribute);
         var dataClassificationAttribute = compilation.GetTypeByMetadataName(DataClassificationAttribute);
+        var noDataClassificationAttribute = compilation.GetTypeByMetadataName(NoDataClassificationAttribute);
 
 #pragma warning disable S1067 // Expressions should not be too complex
         if (loggerSymbol == null
@@ -113,6 +115,7 @@ internal static class SymbolLoader
             enumerableSymbol,
             formatProviderSymbol,
             spanFormattableSymbol,
-            dataClassificationAttribute);
+            dataClassificationAttribute,
+            noDataClassificationAttribute);
     }
 }

--- a/test/Generators/Microsoft.Gen.Logging/TestClasses/Bug5188.cs
+++ b/test/Generators/Microsoft.Gen.Logging/TestClasses/Bug5188.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Compliance.Classification;
+using Microsoft.Extensions.Logging;
+
+public static partial class Bug5188
+{
+    internal record User()
+    {
+        public int Id { get; set; }
+
+        [NoDataClassification]
+        public string? Email { get; set; }
+    }
+
+    internal static partial class Logging
+    {
+        [LoggerMessage(6001, LogLevel.Information, "Logging User: {User}")]
+        public static partial void LogUser(ILogger logger, [LogProperties] User user);
+    }
+}

--- a/test/Generators/Microsoft.Gen.Logging/Unit/LogParserUtilitiesTests.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/LogParserUtilitiesTests.cs
@@ -65,6 +65,7 @@ public class LogParserUtilitiesTests
             null!,
             null!,
             null!,
+            null!,
             null!);
 
         var diagMock = new Mock<Action<Diagnostic>>();
@@ -112,7 +113,8 @@ public class LogParserUtilitiesTests
             null!,
             null!,
             null!,
-            Mock.Of<INamedTypeSymbol>());
+            Mock.Of<INamedTypeSymbol>(),
+            null!);
 
         var diagMock = new Mock<Action<Diagnostic>>();
         var parser = new Parser(null!, diagMock.Object, CancellationToken.None);
@@ -138,6 +140,7 @@ public class LogParserUtilitiesTests
             null!,
             null!,
             new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default),
+            null!,
             null!,
             null!,
             null!,


### PR DESCRIPTION
Fixes #5188

The logging code generator wasn't aware of the
`NoDataClassification` attribute and treated the
associated data as having in fact a data classification. This led to an incorrect warning.

In addition, what should have been a warning was
treated like an error and aborted compilation. Now, if the legit problem occurs, it will be reported
as warning and not stop compilation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5191)