### PR TITLE
Introduce FakeTimeProvider.AdjustTime

### DIFF
--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/Microsoft.Extensions.TimeProvider.Testing.csproj
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/Microsoft.Extensions.TimeProvider.Testing.csproj
@@ -10,6 +10,7 @@
     <Category>Testing</Category>
     <PackageTags>$(PackageTags);Testing;TimeProvider;FakeTimeProvider</PackageTags>
     <InjectExperimentalAttributeOnLegacy>true</InjectExperimentalAttributeOnLegacy>
+    <InjectSharedDiagnosticIds>true</InjectSharedDiagnosticIds>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
@@ -158,6 +158,60 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
+    public void AdjustTimeForwardWorks()
+    {
+        var tp = new FakeTimeProvider();
+
+        var t1Tick = 0;
+        var t1 = tp.CreateTimer(_ =>
+        {
+            t1Tick++;
+        }, null, TimeSpan.FromSeconds(1), TimeSpan.Zero);
+
+        tp.AdjustTime(tp.GetUtcNow() + TimeSpan.FromMilliseconds(999));
+        Assert.Equal(0, t1Tick);
+
+        tp.AdjustTime(tp.GetUtcNow() + TimeSpan.FromMilliseconds(1));
+        Assert.Equal(0, t1Tick);
+
+        tp.AdjustTime(tp.GetUtcNow() + TimeSpan.FromSeconds(10));
+        Assert.Equal(0, t1Tick);
+
+        tp.Advance(TimeSpan.FromMilliseconds(999));
+        Assert.Equal(0, t1Tick);
+
+        tp.Advance(TimeSpan.FromMilliseconds(1));
+        Assert.Equal(1, t1Tick);
+    }
+
+    [Fact]
+    public void AdjustTimeBackwardWorks()
+    {
+        var tp = new FakeTimeProvider();
+
+        var t1Tick = 0;
+        var t1 = tp.CreateTimer(_ =>
+        {
+            t1Tick++;
+        }, null, TimeSpan.FromSeconds(1), TimeSpan.Zero);
+
+        tp.AdjustTime(tp.GetUtcNow() - TimeSpan.FromMilliseconds(999));
+        Assert.Equal(0, t1Tick);
+
+        tp.AdjustTime(tp.GetUtcNow() - TimeSpan.FromMilliseconds(1));
+        Assert.Equal(0, t1Tick);
+
+        tp.AdjustTime(tp.GetUtcNow() - TimeSpan.FromSeconds(10));
+        Assert.Equal(0, t1Tick);
+
+        tp.Advance(TimeSpan.FromMilliseconds(999));
+        Assert.Equal(0, t1Tick);
+
+        tp.Advance(TimeSpan.FromMilliseconds(1));
+        Assert.Equal(1, t1Tick);
+    }
+
+    [Fact]
     public void ToStr()
     {
         var dto = new DateTimeOffset(new DateTime(2022, 1, 2, 3, 4, 5, 6), TimeSpan.Zero);


### PR DESCRIPTION
This addresses #5072 by allowing time to be
adjusted forwards and backwards in order to simulate the system's clock being adjusted. Messing around
with the time in this way doesn't affect outstanding timers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5192)