### PR TITLE
 Bump update-dotnet-sdk action

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: dev
-    - uses: martincostello/update-dotnet-sdk@65c5f402b15326dd12d7b1dac63abdbb53ed695c # v3.1.2
+    - uses: martincostello/update-dotnet-sdk@67d6e2b14939c06978a7f80444157296c3defe14 # v3.2.3
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump the [martincostello/update-dotnet-sdk](https://github.com/martincostello/update-dotnet-sdk) action to [v3.2.3](https://github.com/martincostello/update-dotnet-sdk/releases/tag/v3.2.3) to handle upcoming changes from the merging of the installer and sdk repos.

See https://github.com/dotnet/sdk/pull/41316.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5195)