### PR TITLE
Cleanup Http.Resilience dependencies

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -16,7 +16,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="$(MicrosoftExtensionsDiagnosticsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />

--- a/src/Libraries/Microsoft.Extensions.AmbientMetadata.Application/Microsoft.Extensions.AmbientMetadata.Application.csproj
+++ b/src/Libraries/Microsoft.Extensions.AmbientMetadata.Application/Microsoft.Extensions.AmbientMetadata.Application.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/Microsoft.Extensions.Compliance.Redaction.csproj
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/Microsoft.Extensions.Compliance.Redaction.csproj
@@ -26,11 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
     <PackageReference Include="System.Collections.Immutable" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.IO.Hashing" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Compliance.Testing/Microsoft.Extensions.Compliance.Testing.csproj
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Testing/Microsoft.Extensions.Compliance.Testing.csproj
@@ -24,9 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.DependencyInjection.AutoActivation/Microsoft.Extensions.DependencyInjection.AutoActivation.csproj
+++ b/src/Libraries/Microsoft.Extensions.DependencyInjection.AutoActivation/Microsoft.Extensions.DependencyInjection.AutoActivation.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Testing/Microsoft.Extensions.Diagnostics.Testing.csproj
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Testing/Microsoft.Extensions.Diagnostics.Testing.csproj
@@ -25,11 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Hosting.Testing/Microsoft.Extensions.Hosting.Testing.csproj
+++ b/src/Libraries/Microsoft.Extensions.Hosting.Testing/Microsoft.Extensions.Hosting.Testing.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Extensions.Telemetry.Abstractions\Microsoft.Extensions.Telemetry.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Diagnostics.Testing\Microsoft.Extensions.Diagnostics.Testing.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Compliance.Testing\Microsoft.Extensions.Compliance.Testing.csproj" />
   </ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Microsoft.Extensions.Http.Diagnostics.csproj
+++ b/src/Libraries/Microsoft.Extensions.Http.Diagnostics/Microsoft.Extensions.Http.Diagnostics.csproj
@@ -38,12 +38,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="System.Collections.Immutable" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/Randomizer.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Internal/Randomizer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Threading;
 
 namespace Microsoft.Extensions.Http.Resilience.Internal;
 
@@ -11,9 +10,15 @@ namespace Microsoft.Extensions.Http.Resilience.Internal;
 
 internal class Randomizer
 {
-    private static readonly ThreadLocal<Random> _randomInstance = new(() => new Random());
+#if NET6_0_OR_GREATER
+    public virtual double NextDouble(double maxValue) => Random.Shared.NextDouble() * maxValue;
+
+    public virtual int NextInt(int maxValue) => Random.Shared.Next(maxValue);
+#else
+    private static readonly System.Threading.ThreadLocal<Random> _randomInstance = new(() => new Random());
 
     public virtual double NextDouble(double maxValue) => _randomInstance.Value!.NextDouble() * maxValue;
 
     public virtual int NextInt(int maxValue) => _randomInstance.Value!.Next(maxValue);
+#endif
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpClientResiliencePredicates.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpClientResiliencePredicates.cs
@@ -52,8 +52,7 @@ public static class HttpClientResiliencePredicates
 
     internal static bool IsHttpConnectionTimeout(in Outcome<HttpResponseMessage> outcome, in CancellationToken cancellationToken)
         => !cancellationToken.IsCancellationRequested
-           && outcome.Exception is OperationCanceledException { Source: "System.Private.CoreLib" }
-           && outcome.Exception.InnerException is TimeoutException;
+           && outcome.Exception is OperationCanceledException { Source: "System.Private.CoreLib", InnerException: TimeoutException };
 
     /// <summary>
     /// Determines whether a response contains a transient failure.

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpRetryStrategyOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpRetryStrategyOptions.cs
@@ -55,7 +55,7 @@ public class HttpRetryStrategyOptions : RetryStrategyOptions<HttpResponseMessage
                 DelayGenerator = args => args.Outcome.Result switch
                 {
                     HttpResponseMessage response when RetryAfterHelper.TryParse(response, TimeProvider.System, out var retryAfter) => new ValueTask<TimeSpan?>(retryAfter),
-                    _ => new ValueTask<TimeSpan?>((TimeSpan?)null)
+                    _ => default
                 };
             }
             else

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/RoutingStrategyBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/RoutingStrategyBuilderExtensions.cs
@@ -129,7 +129,7 @@ public static class RoutingStrategyBuilderExtensions
         {
             var optionsCache = new NamedOptionsCache<OrderedGroupsRoutingOptions>(builder.Name, serviceProvider.GetRequiredService<IOptionsMonitor<OrderedGroupsRoutingOptions>>());
             var factory = new OrderedGroupsRoutingStrategyFactory(serviceProvider.GetRequiredService<Randomizer>(), optionsCache);
-            return () => factory.Get();
+            return factory.Get;
         });
 
         return builder.Services.AddOptionsWithValidateOnStart<OrderedGroupsRoutingOptions, OrderedGroupsRoutingOptionsValidator>(builder.Name);
@@ -141,7 +141,7 @@ public static class RoutingStrategyBuilderExtensions
         {
             var optionsCache = new NamedOptionsCache<WeightedGroupsRoutingOptions>(builder.Name, serviceProvider.GetRequiredService<IOptionsMonitor<WeightedGroupsRoutingOptions>>());
             var factory = new WeightedGroupsRoutingStrategyFactory(serviceProvider.GetRequiredService<Randomizer>(), optionsCache);
-            return () => factory.Get();
+            return factory.Get;
         });
 
         return builder.Services.AddOptionsWithValidateOnStart<WeightedGroupsRoutingOptions, WeightedGroupsRoutingOptionsValidator>(builder.Name);

--- a/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
+++ b/src/Libraries/Microsoft.Extensions.Resilience/Microsoft.Extensions.Resilience.csproj
@@ -6,13 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <UseLoggingGenerator>true</UseLoggingGenerator>
-    <UseMetricsGenerator>true</UseMetricsGenerator>
-    <UseOptionsValidationGenerator>true</UseOptionsValidationGenerator>
-    <InjectTrimAttributesOnLegacy>true</InjectTrimAttributesOnLegacy>
     <InjectGetOrAddOnLegacy>true</InjectGetOrAddOnLegacy>
     <InjectTrimAttributesOnLegacy>true</InjectTrimAttributesOnLegacy>
-    <InjectSharedDataValidation>true</InjectSharedDataValidation>
     <InjectSharedDiagnosticIds>true</InjectSharedDiagnosticIds>
   </PropertyGroup>
 
@@ -28,12 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polly.Core" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Enrichment/ApplicationEnricherServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Enrichment/ApplicationEnricherServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public static class ApplicationEnricherServiceCollectionExtensions
 
         return services
             .AddStaticLogEnricher<ApplicationLogEnricher>()
-            .AddLogEnricherOptions(configure);
+            .Configure(configure);
     }
 
     /// <summary>
@@ -58,21 +58,6 @@ public static class ApplicationEnricherServiceCollectionExtensions
 
         return services
             .AddStaticLogEnricher<ApplicationLogEnricher>()
-            .AddLogEnricherOptions(_ => { }, section);
-    }
-
-    private static IServiceCollection AddLogEnricherOptions(
-        this IServiceCollection services,
-        Action<ApplicationLogEnricherOptions> configure,
-        IConfigurationSection? section = null)
-    {
-        _ = services.Configure(configure);
-
-        if (section is not null)
-        {
-            _ = services.Configure<ApplicationLogEnricherOptions>(section);
-        }
-
-        return services;
+            .Configure<ApplicationLogEnricherOptions>(section);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Enrichment/ProcessEnricherServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Enrichment/ProcessEnricherServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ public static class ProcessEnricherServiceCollectionExtensions
         return services
             .AddLogEnricher<ProcessLogEnricher>()
             .AddStaticLogEnricher<StaticProcessLogEnricher>()
-            .AddLogEnricherOptions(configure);
+            .Configure(configure);
     }
 
     /// <summary>
@@ -60,21 +60,6 @@ public static class ProcessEnricherServiceCollectionExtensions
         return services
             .AddLogEnricher<ProcessLogEnricher>()
             .AddStaticLogEnricher<StaticProcessLogEnricher>()
-            .AddLogEnricherOptions(_ => { }, section);
-    }
-
-    private static IServiceCollection AddLogEnricherOptions(
-        this IServiceCollection services,
-        Action<ProcessLogEnricherOptions> configure,
-        IConfigurationSection? section = null)
-    {
-        _ = services.Configure(configure);
-
-        if (section is not null)
-        {
-            _ = services.Configure<ProcessLogEnricherOptions>(section);
-        }
-
-        return services;
+            .Configure<ProcessLogEnricherOptions>(section);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
+++ b/src/Libraries/Microsoft.Extensions.Telemetry/Microsoft.Extensions.Telemetry.csproj
@@ -27,13 +27,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Extensions.DependencyInjection.AutoActivation\Microsoft.Extensions.DependencyInjection.AutoActivation.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.AmbientMetadata.Application\Microsoft.Extensions.AmbientMetadata.Application.csproj" />
-    <ProjectReference Include="..\Microsoft.Extensions.Compliance.Abstractions\Microsoft.Extensions.Compliance.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Telemetry.Abstractions\Microsoft.Extensions.Telemetry.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
     <PackageReference Include="System.Collections.Immutable" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />

--- a/src/Shared/RentedSpan/RentedSpan.cs
+++ b/src/Shared/RentedSpan/RentedSpan.cs
@@ -90,7 +90,7 @@ internal readonly ref struct RentedSpan<T>
     /// When a buffer isn't rented by this type, it's a cue to you to allocate buffer from the stack instead
     /// using stackalloc.
     /// </remarks>
-    public Span<T> Span => _rentedBuffer != null ? _rentedBuffer.AsSpan(0, _length) : Array.Empty<T>().AsSpan();
+    public Span<T> Span => _rentedBuffer != null ? _rentedBuffer.AsSpan(0, _length) : default;
 
     /// <summary>
     /// Gets a value indicating whether a buffer has been rented.


### PR DESCRIPTION
- Cleanup `Microsoft.Extensions.Http.Resilience` dependency tree.
- Cleaned up a few excessively verbose methods.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5217)