### PR TITLE
Bump Polly to 8.4.1

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -30,10 +30,10 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Polly" Version="8.4.0" />
-    <PackageVersion Include="Polly.Core" Version="8.4.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.4.0" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.4.0" />
+    <PackageVersion Include="Polly" Version="8.4.1" />
+    <PackageVersion Include="Polly.Core" Version="8.4.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.4.1" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.4.1" />
     <PackageVersion Include="System.Buffers" Version="4.5.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/eng/packages/TestOnly.props
+++ b/eng/packages/TestOnly.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
     <PackageVersion Include="Moq.AutoMock" Version="3.1.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Polly.Testing" Version="8.4.0" />
+    <PackageVersion Include="Polly.Testing" Version="8.4.1" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />


### PR DESCRIPTION
Bump Polly to [8.4.1](https://github.com/App-vNext/Polly/releases/tag/8.4.1) to pick up bug fixes:

- https://github.com/App-vNext/Polly/pull/2164
- https://github.com/App-vNext/Polly/pull/2166

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5258)