### PR TITLE
Fix resource detection for unset CPU and memory limits in cgroup v2

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -218,7 +218,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 
             ReadOnlySpan<char> memoryBuffer = bufferWriter.Buffer.WrittenSpan;
 
-            if (memoryBuffer.Equals("max", StringComparison.InvariantCulture))
+            if (memoryBuffer.Equals("max\n", StringComparison.InvariantCulture))
             {
                 return GetHostAvailableMemory();
             }
@@ -503,7 +503,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             return false;
         }
 
-        if (quotaBuffer.Equals("max", StringComparison.InvariantCulture))
+        if (quotaBuffer.StartsWith("max", StringComparison.InvariantCulture))
         {
             cpuUnits = 0;
             return false;

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -217,6 +217,12 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             _fileSystem.ReadAll(_memoryLimitInBytes, bufferWriter.Buffer);
 
             ReadOnlySpan<char> memoryBuffer = bufferWriter.Buffer.WrittenSpan;
+
+            if (MemoryExtensions.Equals(memoryBuffer, "max", StringComparison.Ordinal))
+            {
+                return GetHostAvailableMemory();
+            }
+
             _ = GetNextNumber(memoryBuffer, out maybeMemory);
 
             if (maybeMemory == -1)
@@ -497,7 +503,13 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             return false;
         }
 
-        int nextQuota = GetNextNumber(quotaBuffer, out long quota);
+        if (MemoryExtensions.Equals(quotaBuffer, "max", StringComparison.Ordinal))
+        {
+            cpuUnits = 0;
+            return false;
+        }
+
+        _ = GetNextNumber(quotaBuffer, out long quota);
 
         if (quota == -1)
         {

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV2.cs
@@ -218,7 +218,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
 
             ReadOnlySpan<char> memoryBuffer = bufferWriter.Buffer.WrittenSpan;
 
-            if (MemoryExtensions.Equals(memoryBuffer, "max", StringComparison.Ordinal))
+            if (memoryBuffer.Equals("max", StringComparison.InvariantCulture))
             {
                 return GetHostAvailableMemory();
             }
@@ -503,7 +503,7 @@ internal sealed class LinuxUtilizationParserCgroupV2 : ILinuxUtilizationParser
             return false;
         }
 
-        if (MemoryExtensions.Equals(quotaBuffer, "max", StringComparison.Ordinal))
+        if (quotaBuffer.Equals("max", StringComparison.InvariantCulture))
         {
             cpuUnits = 0;
             return false;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
@@ -119,6 +119,23 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
     }
 
     [ConditionalTheory]
+    [InlineData("max", 134796910592ul)]
+    [InlineData("1000000", 1000000ul)]
+    public void When_Calling_GetAvailableMemoryInBytes_Parser_Returns_Available_Memory(string content, ulong expectedResult)
+    {
+        var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
+        {
+            { new FileInfo("/sys/fs/cgroup/memory.max"), content },
+            { new FileInfo("/proc/meminfo"), "MemTotal:       131637608 kB" }
+        });
+
+        var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
+        var result = p.GetAvailableMemoryInBytes();
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    [ConditionalTheory]
     [InlineData("Suspicious12312312")]
     [InlineData("string@")]
     [InlineData("string12312")]
@@ -255,6 +272,21 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         var cpus = p.GetCgroupLimitedCpus();
 
         Assert.Equal(result, cpus);
+    }
+
+    [ConditionalFact]
+    public void When_Cpu_Max_Is_Set_To_Max_We_Get_Available_Cpus_From_CpuSetCpus()
+    {
+        var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
+        {
+            { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0,1,2" },
+            { new FileInfo("/sys/fs/cgroup/cpu.max"), "max" },
+        });
+
+        var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));
+        var cpus = p.GetCgroupLimitedCpus();
+
+        Assert.Equal(3, cpus);
     }
 
     [ConditionalTheory]

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
@@ -119,8 +119,8 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
     }
 
     [ConditionalTheory]
-    [InlineData("max", 134796910592ul)]
-    [InlineData("1000000", 1000000ul)]
+    [InlineData("max", 134_796_910_592ul)]
+    [InlineData("1000000", 1_000_000ul)]
     public void When_Calling_GetAvailableMemoryInBytes_Parser_Returns_Available_Memory(string content, ulong expectedResult)
     {
         var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationParserCgroupV2Tests.cs
@@ -119,8 +119,8 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
     }
 
     [ConditionalTheory]
-    [InlineData("max", 134_796_910_592ul)]
-    [InlineData("1000000", 1_000_000ul)]
+    [InlineData("max\n", 134_796_910_592ul)]
+    [InlineData("1000000\n", 1_000_000ul)]
     public void When_Calling_GetAvailableMemoryInBytes_Parser_Returns_Available_Memory(string content, ulong expectedResult)
     {
         var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
@@ -280,7 +280,7 @@ public sealed class LinuxUtilizationParserCgroupV2Tests
         var f = new HardcodedValueFileSystem(new Dictionary<FileInfo, string>
         {
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0,1,2" },
-            { new FileInfo("/sys/fs/cgroup/cpu.max"), "max" },
+            { new FileInfo("/sys/fs/cgroup/cpu.max"), "max 100000" },
         });
 
         var p = new LinuxUtilizationParserCgroupV2(f, new FakeUserHz(100));


### PR DESCRIPTION
Address the issue where `/sys/fs/cgroup/cpu.max` and `/sys/fs/cgroup/memory.max` report "max", indicating unset limits in cgroup v2.

**Changes Made:**
- When `/sys/fs/cgroup/cpu.max` reads "max", the number of CPU cores is now derived from the host's `/proc/stat` file.
- Similarly, available memory is determined from the host's `/proc/meminfo` file if `/sys/fs/cgroup/memory.max` contains "max".

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5267)