### PR TITLE
Suppress IL2026 with attributes

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/OrderedGroupsRoutingOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/OrderedGroupsRoutingOptions.cs
@@ -19,15 +19,14 @@ public class OrderedGroupsRoutingOptions
     /// Gets or sets the collection of ordered endpoints groups.
     /// </summary>
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
     [Required]
 #if NET8_0_OR_GREATER
     [System.ComponentModel.DataAnnotations.Length(1, int.MaxValue)]
 #else
     [Microsoft.Shared.Data.Validation.Length(1)]
 #endif
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "TODO")]
     [ValidateEnumeratedItems]
     public IList<UriEndpointGroup> Groups { get; set; } = new List<UriEndpointGroup>();
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 #pragma warning restore CA2227 // Collection properties should be read only
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/RoutingStrategyBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/RoutingStrategyBuilderExtensions.cs
@@ -15,8 +15,6 @@ using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.Http.Resilience;
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-
 /// <summary>
 /// Extensions for <see cref="IRoutingStrategyBuilder"/>.
 /// </summary>

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/UriEndpointGroup.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/UriEndpointGroup.cs
@@ -20,14 +20,13 @@ public class UriEndpointGroup
     /// At least one endpoint must be defined on each endpoint group in order to performed hedged requests.
     /// </remarks>
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 #if NET8_0_OR_GREATER
     [System.ComponentModel.DataAnnotations.Length(1, int.MaxValue)]
 #else
     [Microsoft.Shared.Data.Validation.Length(1)]
 #endif
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "TODO")]
     [ValidateEnumeratedItems]
     public IList<WeightedUriEndpoint> Endpoints { get; set; } = new List<WeightedUriEndpoint>();
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 #pragma warning restore CA2227 // Collection properties should be read only
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/WeightedGroupsRoutingOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Routing/WeightedGroupsRoutingOptions.cs
@@ -25,15 +25,14 @@ public class WeightedGroupsRoutingOptions
     /// Gets or sets the collection of weighted endpoints groups.
     /// </summary>
 #pragma warning disable CA2227 // Collection properties should be read only
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
     [Required]
 #if NET8_0_OR_GREATER
     [System.ComponentModel.DataAnnotations.Length(1, int.MaxValue)]
 #else
     [Microsoft.Shared.Data.Validation.Length(1)]
 #endif
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "TODO")]
     [ValidateEnumeratedItems]
     public IList<WeightedUriEndpointGroup> Groups { get; set; } = new List<WeightedUriEndpointGroup>();
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 #pragma warning restore CA2227 // Collection properties should be read only
 }


### PR DESCRIPTION
Use attributes to suppress IL2026 so suppressions are visible to the linker.

I originally noticed this here when trying to root the assembly for the trimmer: https://github.com/dotnet/runtime/issues/105034#issuecomment-2233608643

I couldn't find any specific justification for the four suppressions. Two came from #4410 and the rest were present when r9 was originally imported to the repo. I assume it's related to the validation source generator? I can fill in the justification as appropriate.

If these shouldn't be suppressed, then instead the properties should instead pass along some variant of the original warning on `[Length]` by adding `[RequiresUnreferencedCode]` (which is `[RequiresUnreferencedCode("Uses reflection to get the 'Count' property on types that don't implement ICollection. This 'Count' property may be trimmed. Ensure it is preserved.")]`).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5305)