### PR TITLE
Rename metrics for Resource Monitoring

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
@@ -41,8 +41,6 @@ internal static class Calculator
         var utilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
         var cpuUsedPercentage = Math.Min(Hundred, utilization);
 
-        var memoryUsedPercentage = Math.Min(Hundred, (double)second.MemoryUsageInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);
-
-        return new ResourceUtilization(cpuUsedPercentage, memoryUsedPercentage, second.MemoryUsageInBytes, systemResources, second);
+        return new ResourceUtilization(cpuUtilization, second.MemoryUsageInBytes, systemResources, second);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
@@ -41,6 +41,8 @@ internal static class Calculator
         var utilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
         var cpuUtilization = Math.Min(Hundred, utilization);
 
-        return new ResourceUtilization(cpuUtilization, second.MemoryUsageInBytes, systemResources, second);
+        var memoryUsedPercentage = Math.Min(Hundred, (double)second.MemoryUsageInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);
+
+        return new ResourceUtilization(cpuUtilization, memoryUsedPercentage, second.MemoryUsageInBytes, systemResources, second);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
@@ -39,10 +39,10 @@ internal static class Calculator
         long totalUsageTickDelta = newUsageTicks - oldUsageTicks;
 
         var utilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
-        var cpuUtilization = Math.Min(Hundred, utilization);
+        var cpuUsedPercentage = Math.Min(Hundred, utilization);
 
         var memoryUsedPercentage = Math.Min(Hundred, (double)second.MemoryUsageInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);
 
-        return new ResourceUtilization(cpuUtilization, memoryUsedPercentage, second.MemoryUsageInBytes, systemResources, second);
+        return new ResourceUtilization(cpuUsedPercentage, memoryUsedPercentage, second.MemoryUsageInBytes, systemResources, second);
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
@@ -25,7 +25,7 @@ internal static class Calculator
         long runtimeTickDelta = second.TotalTimeSinceStart.Ticks - first.TotalTimeSinceStart.Ticks;
 
         // Compute the total number of ticks available on the machine during that interval
-        double totalSystemTicks = runtimeTickDelta * systemResources.GuaranteedCpuUnits;
+        double totalSystemTicks = runtimeTickDelta;
 
         // fudge to avoid divide by zero
         if (totalSystemTicks <= 0)
@@ -39,7 +39,7 @@ internal static class Calculator
         long totalUsageTickDelta = newUsageTicks - oldUsageTicks;
 
         var utilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
-        var cpuUsedPercentage = Math.Min(Hundred, utilization);
+        var cpuUtilization = Math.Min(Hundred, utilization);
 
         return new ResourceUtilization(cpuUtilization, second.MemoryUsageInBytes, systemResources, second);
     }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs
@@ -444,7 +444,7 @@ internal sealed class LinuxUtilizationParserCgroupV1 : ILinuxUtilizationParser
     /// <summary>
     /// In cgroup v1 the CPU shares is used to determine the CPU allocation.
     /// in cgroup v2 the CPU weight is used to determine the CPU allocation.
-    /// To calculete CPU request in cgroup v2 we need to read the CPU weight and convert it to CPU shares.
+    /// To calculate CPU request in cgroup v2 we need to read the CPU weight and convert it to CPU shares.
     /// But for cgroup v1 we can read the CPU shares directly from the file.
     /// 1024 equals 1 CPU core.
     /// In cgroup v1 on some systems the location of the CPU shares file is different.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -47,7 +47,6 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         _previousHostCpuTime = _parser.GetHostCpuUsageInNanoseconds();
         _previousCgroupCpuTime = _parser.GetCgroupCpuUsageInNanoseconds();
 
-        var hostMemory = _parser.GetHostAvailableMemory();
         var hostCpus = _parser.GetHostCpuCount();
         var cpuLimit = _parser.GetCgroupLimitedCpus();
         var cpuRequest = _parser.GetCgroupRequestCpu();
@@ -65,9 +64,8 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuLimit, unit: "1");
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryLimitUtilization, observeValue: MemoryUtilization, unit: "1");
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuRequestUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuRequest, unit: "1");
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryRequestUtilization, observeValue: MemoryUtilization, unit: "1");
 
-        // Obsolete metrics, kept for backward compatibility:
+        // Old metrics, obsolete for this class, but used by WindowsSnapshotProvider. Keeping them for backward compatibility:
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuLimit, unit: "1");
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryUtilization, unit: "1");
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -60,8 +60,8 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.CpuUtilization, observeValue: CpuUtilization, unit: "1");
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.MemoryUtilization, observeValue: MemoryUtilization, unit: "1");
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuUtilization, observeValue: CpuUtilization, unit: "1");
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryUtilization, observeValue: MemoryUtilization, unit: "1");
 
         // cpuGuaranteedRequest is a CPU request for pod, for host its 1 core
         // available CPUs is a CPU limit for a pod or for a host.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -53,7 +53,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         var cpuRequest = _parser.GetCgroupRequestCpu();
         _scaleRelativeToCpuLimit = hostCpus / cpuLimit;
         _scaleRelativeToCpuRequest = hostCpus / cpuRequest;
-        _scaleRelativeToCpuLimitForTrackerApi = hostCpus;
+        _scaleRelativeToCpuLimitForTrackerApi = hostCpus / cpuLimit * cpuRequest;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         // We don't dispose the meter because IMeterFactory handles that
@@ -68,7 +68,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryRequestUtilization, observeValue: MemoryUtilization, unit: "1");
 
         // Obsolete metrics, kept for backward compatibility:
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuRequest, unit: "1");
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuLimit, unit: "1");
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryUtilization, unit: "1");
 
         // cpuRequest is a CPU request (aka guaranteed number of CPU units) for pod, for host its 1 core

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -60,8 +60,12 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuUtilization, observeValue: CpuUtilization, unit: "1");
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryUtilization, observeValue: MemoryUtilization, unit: "1");
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: CpuUtilization, unit: "1");
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryLimitUtilization, observeValue: MemoryUtilization, unit: "1");
+
+        // Obsolete metrics, kept for backward compatibility:
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuUtilization, unit: "1");
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryUtilization, unit: "1");
 
         // cpuGuaranteedRequest is a CPU request for pod, for host its 1 core
         // available CPUs is a CPU limit for a pod or for a host.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -57,7 +57,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
+        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuUtilization, observeValue: CpuUtilization, unit: "1");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringServiceCollectionExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitoringServiceCollectionExtensions.cs
@@ -88,7 +88,7 @@ public static class ResourceMonitoringServiceCollectionExtensions
         builder.PickWindowsSnapshotProvider();
 
         _ = builder.Services
-            .AddActivatedSingleton<WindowsCounters>();
+            .AddActivatedSingleton<WindowsNetworkMetrics>();
 
         _ = builder.Services
             .AddActivatedSingleton<TcpTableInfo>();

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -51,10 +51,10 @@ public readonly struct ResourceUtilization
     /// <param name="systemResources">CPU and memory limits.</param>
     public ResourceUtilization(double cpuUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources)
     {
-        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / SystemResources.GuaranteedCpuUnits, 0.0);
+        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / systemResources.GuaranteedCpuUnits, 0.0);
         MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
         SystemResources = systemResources;
-        MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / SystemResources.GuaranteedMemoryInBytes * Hundred);
+        MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -61,17 +61,12 @@ public readonly struct ResourceUtilization
     /// Initializes a new instance of the <see cref="ResourceUtilization"/> struct.
     /// </summary>
     /// <param name="cpuUsedPercentage">CPU utilization.</param>
-    /// <param name="memoryUsedPercentage">Memory utilization.</param>
     /// <param name="memoryUsedInBytes">Memory used in bytes (instantaneous).</param>
     /// <param name="systemResources">CPU and memory limits.</param>
     /// <param name="snapShot">Latest ResourceUtilizationSnapshot.</param>
-    internal ResourceUtilization(double cpuUsedPercentage, double memoryUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources, Snapshot snapShot)
+    internal ResourceUtilization(double cpuUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources, Snapshot snapShot)
+        : this(cpuUsedPercentage, memoryUsedInBytes, systemResources)
     {
-        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage, 0.0);
-        MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
-
-        MemoryUsedPercentage = memoryUsedPercentage;
-        SystemResources = systemResources;
         Snapshot = snapShot;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -51,10 +51,10 @@ public readonly struct ResourceUtilization
     /// <param name="systemResources">CPU and memory limits.</param>
     public ResourceUtilization(double cpuUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources)
     {
-        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / systemResources.GuaranteedCpuUnits, 0.0);
+        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / SystemResources.GuaranteedCpuUnits, 0.0);
         MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
         SystemResources = systemResources;
-        MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);
+        MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / SystemResources.GuaranteedMemoryInBytes * Hundred);
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -51,10 +51,10 @@ public readonly struct ResourceUtilization
     /// <param name="systemResources">CPU and memory limits.</param>
     public ResourceUtilization(double cpuUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources)
     {
-        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage, 0.0);
+        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / systemResources.GuaranteedCpuUnits, 0.0);
         MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
         SystemResources = systemResources;
-        MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / SystemResources.GuaranteedMemoryInBytes * Hundred);
+        MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);
     }
 
     /// <summary>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -51,7 +51,13 @@ public readonly struct ResourceUtilization
     /// <param name="systemResources">CPU and memory limits.</param>
     public ResourceUtilization(double cpuUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources)
     {
-        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / systemResources.GuaranteedCpuUnits, 0.0);
+        var guaranteedCpuUnits = systemResources.GuaranteedCpuUnits;
+        if (guaranteedCpuUnits <= 0)
+        {
+            guaranteedCpuUnits = 1;
+        }
+
+        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / guaranteedCpuUnits, 0.0);
         MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
         SystemResources = systemResources;
         MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -61,12 +61,17 @@ public readonly struct ResourceUtilization
     /// Initializes a new instance of the <see cref="ResourceUtilization"/> struct.
     /// </summary>
     /// <param name="cpuUsedPercentage">CPU utilization.</param>
+    /// <param name="memoryUsedPercentage">Memory utilization.</param>
     /// <param name="memoryUsedInBytes">Memory used in bytes (instantaneous).</param>
     /// <param name="systemResources">CPU and memory limits.</param>
     /// <param name="snapShot">Latest ResourceUtilizationSnapshot.</param>
-    internal ResourceUtilization(double cpuUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources, Snapshot snapShot)
-        : this(cpuUsedPercentage, memoryUsedInBytes, systemResources)
+    internal ResourceUtilization(double cpuUsedPercentage, double memoryUsedPercentage, ulong memoryUsedInBytes, SystemResources systemResources, Snapshot snapShot)
     {
+        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage, 0.0);
+        MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
+
+        MemoryUsedPercentage = memoryUsedPercentage;
+        SystemResources = systemResources;
         Snapshot = snapShot;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 
 /// <summary>
@@ -26,21 +28,37 @@ internal static class ResourceUtilizationInstruments
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
     /// </remarks>
-    public const string ProcessMemoryUtilization = "process.memory.utilization";
+    public const string ProcessMemoryUtilization = "dotnet.process.memory.virtual.utilization";
 
     /// <summary>
-    /// Gets the CPU consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// Gets the CPU limit consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
     /// </remarks>
-    public const string ContainerCpuUtilization = "container.cpu.utilization";
+    public const string ContainerCpuLimitUtilization = "container.cpu.limit.utilization";
 
     /// <summary>
-    /// Gets the memory consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// Gets the CPU request consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
     /// </remarks>
-    public const string ContainerMemoryUtilization = "container.memory.utilization";
+    public const string ContainerCpuRequestUtilization = "container.cpu.request.utilization";
+
+    /// <summary>
+    /// Gets the memory limit consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// </remarks>
+    public const string ContainerMemoryLimitUtilization = "container.memory.limit.utilization";
+
+    /// <summary>
+    /// Gets the memory limit consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// </remarks>
+    public const string ContainerMemoryRequestUtilization = "container.memory.request.utilization";
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
@@ -21,20 +21,20 @@ internal static class ResourceUtilizationInstruments
     public const string ProcessCpuUtilization = "process.cpu.utilization";
 
     /// <summary>
-    /// Gets the CPU consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
-    /// </summary>
-    /// <remarks>
-    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
-    /// </remarks>
-    public const string ContainerCpuUtilization = "container.cpu.utilization";
-
-    /// <summary>
     /// Gets the memory consumption of the running process in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
     /// </remarks>
     public const string ProcessMemoryUtilization = "process.memory.utilization";
+
+    /// <summary>
+    /// Gets the CPU consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// </remarks>
+    public const string ContainerCpuUtilization = "container.cpu.utilization";
 
     /// <summary>
     /// Gets the memory consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
@@ -13,18 +13,34 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 internal static class ResourceUtilizationInstruments
 {
     /// <summary>
-    /// Gets the CPU consumption of the running application in range <c>[0, 1]</c>.
+    /// Gets the CPU consumption of the running process in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
     /// </remarks>
-    public const string CpuUtilization = "process.cpu.utilization";
+    public const string ProcessCpuUtilization = "process.cpu.utilization";
 
     /// <summary>
-    /// Gets the memory consumption of the running application in range <c>[0, 1]</c>.
+    /// Gets the CPU consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
     /// </remarks>
-    public const string MemoryUtilization = "dotnet.process.memory.virtual.utilization";
+    public const string ContainerCpuUtilization = "container.cpu.utilization";
+
+    /// <summary>
+    /// Gets the memory consumption of the running process in range <c>[0, 1]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// </remarks>
+    public const string ProcessMemoryUtilization = "process.memory.utilization";
+
+    /// <summary>
+    /// Gets the memory consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
+    /// </remarks>
+    public const string ContainerMemoryUtilization = "container.memory.utilization";
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 internal static class ResourceUtilizationInstruments
 {
     /// <summary>
-    /// Gets the CPU consumption of the running process in range <c>[0, 1]</c>.
+    /// Gets the CPU consumption share of the running process in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.
@@ -23,7 +23,7 @@ internal static class ResourceUtilizationInstruments
     public const string ProcessCpuUtilization = "process.cpu.utilization";
 
     /// <summary>
-    /// Gets the memory consumption of the running process in range <c>[0, 1]</c>.
+    /// Gets the memory consumption share of the running process in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>
     /// The type of an instrument is <see cref="System.Diagnostics.Metrics.ObservableGauge{T}"/>.

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -105,7 +105,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: CpuPercentage);
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryLimitUtilization, observeValue: MemoryPercentage);
 
-        // Obsolete metrics, keeping it for backward compatibility:
+        // Old metrics, obsolete for this class, but used by WindowsSnapshotProvider. Keeping them for backward compatibility:
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuPercentage);
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryPercentage);
     }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -101,8 +101,8 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.CpuUtilization, observeValue: CpuPercentage);
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.MemoryUtilization, observeValue: MemoryPercentage);
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuUtilization, observeValue: CpuPercentage);
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryUtilization, observeValue: MemoryPercentage);
     }
 
     public Snapshot GetSnapshot()

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -98,7 +98,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
+        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuUtilization, observeValue: CpuPercentage);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -82,8 +82,8 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         _cpuUnits = GetMaximumCpuUnits(jobHandle, systemInfo);
         var memory = GetMemoryLimits(jobHandle);
 
-        // CPU request is not supported on Windows, so we set it to the same value as CPU limit.
-        // Memory request is not supported on Windows, so we set it to the same value as memory limit.
+        // CPU request (aka guaranteed CPU units) is not supported on Windows, so we set it to the same value as CPU limit (aka maximum CPU units).
+        // Memory request (aka guaranteed memory) is not supported on Windows, so we set it to the same value as memory limit (aka maximum memory).
         Resources = new SystemResources(_cpuUnits, _cpuUnits, memory, memory);
 
         _totalMemory = memory;
@@ -105,7 +105,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: CpuPercentage);
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerMemoryLimitUtilization, observeValue: MemoryPercentage);
 
-        // Obsolete metrics, kept for backward compatibility:
+        // Obsolete metrics, keeping it for backward compatibility:
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuPercentage);
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryPercentage);
     }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -79,8 +79,8 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
 
         using var jobHandle = _createJobHandleObject();
 
-        _cpuUnits = GetMaximumCpuUnits(jobHandle, systemInfo);
-        var memory = GetMemoryLimits(jobHandle);
+        _cpuUnits = GetCpuLimit(jobHandle, systemInfo);
+        var memory = GetMemoryLimit(jobHandle);
 
         // CPU request (aka guaranteed CPU units) is not supported on Windows, so we set it to the same value as CPU limit (aka maximum CPU units).
         // Memory request (aka guaranteed memory) is not supported on Windows, so we set it to the same value as memory limit (aka maximum memory).
@@ -124,7 +124,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
             GetMemoryUsage());
     }
 
-    private static double GetMaximumCpuUnits(IJobHandle jobHandle, ISystemInfo systemInfo)
+    private static double GetCpuLimit(IJobHandle jobHandle, ISystemInfo systemInfo)
     {
         // Note: This function convert the CpuRate from CPU cycles to CPU units, also it scales
         // the CPU units with the number of processors (cores) available in the system.
@@ -154,7 +154,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
     /// Gets memory limit of the system.
     /// </summary>
     /// <returns>Memory limit allocated to the system in bytes.</returns>
-    private ulong GetMemoryLimits(IJobHandle jobHandle)
+    private ulong GetMemoryLimit(IJobHandle jobHandle)
     {
         var memoryLimitInBytes = jobHandle.GetExtendedLimitInfo().JobMemoryLimit.ToUInt64();
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsNetworkMetrics.cs
@@ -8,11 +8,11 @@ using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Network;
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 
-internal sealed class WindowsCounters
+internal sealed class WindowsNetworkMetrics
 {
     private readonly TcpTableInfo _tcpTableInfo;
 
-    public WindowsCounters(IMeterFactory meterFactory, TcpTableInfo tcpTableInfo)
+    public WindowsNetworkMetrics(IMeterFactory meterFactory, TcpTableInfo tcpTableInfo)
     {
         _tcpTableInfo = tcpTableInfo;
 
@@ -20,7 +20,7 @@ internal sealed class WindowsCounters
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
+        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         var tcpTag = new KeyValuePair<string, object?>("network.transport", "tcp");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -55,8 +55,9 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
         _cpuUnits = getCpuUnitsFunc();
         var totalMemory = getTotalMemoryInBytesFunc();
 
-        // We are not running in a job object (e.g. container), so we don't have any resource requests or limits,
-        // therefore using physical values such as number of CPUs and physical memory:
+        // We are not running in a job object (e.g. container), so we don't have
+        // any resource requests or resource limits, therefore using physical values
+        // such as number of CPUs and physical memory and using it for both requests and limits (aka 'guaranteed' and 'max'):
         Resources = new SystemResources(_cpuUnits, _cpuUnits, totalMemory, totalMemory);
 
         _timeProvider = timeProvider;

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -75,8 +75,8 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
         var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.CpuUtilization, observeValue: CpuPercentage);
-        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.MemoryUtilization, observeValue: MemoryPercentage);
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuPercentage);
+        _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: MemoryPercentage);
     }
 
     public Snapshot GetSnapshot()

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -54,6 +54,9 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
 
         _cpuUnits = getCpuUnitsFunc();
         var totalMemory = getTotalMemoryInBytesFunc();
+
+        // We are not running in a job object (e.g. container), so we don't have any resource requests or limits,
+        // therefore using physical values such as number of CPUs and physical memory:
         Resources = new SystemResources(_cpuUnits, _cpuUnits, totalMemory, totalMemory);
 
         _timeProvider = timeProvider;

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -72,7 +72,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create("Microsoft.Extensions.Diagnostics.ResourceMonitoring");
+        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuPercentage);

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -200,7 +200,7 @@ public sealed class AcceptanceTest
                 { new FileInfo("/sys/fs/cgroup/cpuacct/cpuacct.usage"), "102312"},
                 { new FileInfo("/proc/meminfo"), "MemTotal: 102312 kB"},
                 { new FileInfo("/sys/fs/cgroup/cpuset/cpuset.cpus"), "0-19"},
-                { new FileInfo("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"), "24"},
+                { new FileInfo("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"), "12"},
                 { new FileInfo("/sys/fs/cgroup/cpu/cpu.cfs_period_us"), "6"},
                 { new FileInfo("/sys/fs/cgroup/cpu/cpu.shares"), "2048"},
                 { new FileInfo("/sys/fs/cgroup/memory/memory.stat"), "total_inactive_file 100"},
@@ -293,7 +293,7 @@ public sealed class AcceptanceTest
 
         Assert.Equal(1, utilization.CpuUsedPercentage);
         Assert.Equal(utilization.CpuUsedPercentage, cpuFromGauge * 100);
-        Assert.Equal(0.5, cpuLimitFromGauge * 100);
+        Assert.Equal(utilization.CpuUsedPercentage, cpuLimitFromGauge * 100);
         Assert.Equal(utilization.CpuUsedPercentage, cpuRequestFromGauge * 100);
         Assert.Equal(50, utilization.MemoryUsedPercentage);
         Assert.Equal(utilization.MemoryUsedPercentage, memoryFromGauge * 100);

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -219,8 +219,8 @@ public sealed class AcceptanceTest
                 return;
             }
 
-            if (instrument.Name == ResourceUtilizationInstruments.CpuUtilization ||
-                instrument.Name == ResourceUtilizationInstruments.MemoryUtilization)
+            if (instrument.Name == ResourceUtilizationInstruments.ContainerCpuUtilization ||
+                instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization)
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }
@@ -228,11 +228,11 @@ public sealed class AcceptanceTest
 
         listener.SetMeasurementEventCallback<double>((m, f, _, _) =>
         {
-            if (m.Name == ResourceUtilizationInstruments.CpuUtilization)
+            if (m.Name == ResourceUtilizationInstruments.ContainerCpuUtilization)
             {
                 cpuFromGauge = f;
             }
-            else if (m.Name == ResourceUtilizationInstruments.MemoryUtilization)
+            else if (m.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization)
             {
                 memoryFromGauge = f;
             }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -200,7 +200,7 @@ public sealed class AcceptanceTest
             { new FileInfo("/sys/fs/cgroup/cpuacct/cpuacct.usage"), "102312"},
             { new FileInfo("/proc/meminfo"), "MemTotal: 102312 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset/cpuset.cpus"), "0-19"},
-            { new FileInfo("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"), "12"},
+            { new FileInfo("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"), "24"},
             { new FileInfo("/sys/fs/cgroup/cpu/cpu.cfs_period_us"), "6"},
             { new FileInfo("/sys/fs/cgroup/cpu/cpu.shares"), "2048"},
             { new FileInfo("/sys/fs/cgroup/memory/memory.stat"), "total_inactive_file 100"},
@@ -291,10 +291,10 @@ public sealed class AcceptanceTest
 
         utilization = tracker.GetUtilization(TimeSpan.FromSeconds(5));
 
-        Assert.Equal(1, utilization.CpuUsedPercentage);
+        Assert.Equal(0.5, utilization.CpuUsedPercentage);
         Assert.Equal(utilization.CpuUsedPercentage, cpuFromGauge * 100);
         Assert.Equal(utilization.CpuUsedPercentage, cpuLimitFromGauge * 100);
-        Assert.Equal(utilization.CpuUsedPercentage, cpuRequestFromGauge * 100);
+        Assert.Equal(1, cpuRequestFromGauge * 100);
         Assert.Equal(50, utilization.MemoryUsedPercentage);
         Assert.Equal(utilization.MemoryUsedPercentage, memoryFromGauge * 100);
 
@@ -314,7 +314,7 @@ public sealed class AcceptanceTest
             { new FileInfo("/sys/fs/cgroup/memory.max"), "1048576" },
             { new FileInfo("/proc/meminfo"), "MemTotal: 1024 kB"},
             { new FileInfo("/sys/fs/cgroup/cpuset.cpus.effective"), "0-19"},
-            { new FileInfo("/sys/fs/cgroup/cpu.max"), "20000 10000"},
+            { new FileInfo("/sys/fs/cgroup/cpu.max"), "40000 10000"},
             { new FileInfo("/sys/fs/cgroup/cpu.weight"), "79"}, // equals to 2046,9 CPU shares (cgroups v1) which is ~2 CPU units (2 * 1024), so have to use Math.Round() in Assertions down below.
         });
 
@@ -405,11 +405,11 @@ public sealed class AcceptanceTest
 
         utilization = tracker.GetUtilization(TimeSpan.FromSeconds(5));
 
-        var roundedCpuUsedPercentage = Math.Round(utilization.CpuUsedPercentage);
-        Assert.Equal(1, roundedCpuUsedPercentage);
+        var roundedCpuUsedPercentage = Math.Round(utilization.CpuUsedPercentage, 1);
+        Assert.Equal(0.5, roundedCpuUsedPercentage);
         Assert.Equal(roundedCpuUsedPercentage, cpuFromGauge * 100);
         Assert.Equal(roundedCpuUsedPercentage, cpuLimitFromGauge * 100);
-        Assert.Equal(roundedCpuUsedPercentage, Math.Round(cpuRequestFromGauge * 100));
+        Assert.Equal(1, Math.Round(cpuRequestFromGauge * 100));
         Assert.Equal(50, utilization.MemoryUsedPercentage);
         Assert.Equal(utilization.MemoryUsedPercentage, memoryFromGauge * 100);
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -220,8 +220,8 @@ public sealed class AcceptanceTest
                 return;
             }
 
-            if (instrument.Name == ResourceUtilizationInstruments.ContainerCpuUtilization ||
-                instrument.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization)
+            if (instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization ||
+                instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization)
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }
@@ -229,11 +229,11 @@ public sealed class AcceptanceTest
 
         listener.SetMeasurementEventCallback<double>((m, f, _, _) =>
         {
-            if (m.Name == ResourceUtilizationInstruments.ContainerCpuUtilization)
+            if (m.Name == ResourceUtilizationInstruments.ProcessCpuUtilization)
             {
                 cpuFromGauge = f;
             }
-            else if (m.Name == ResourceUtilizationInstruments.ContainerMemoryUtilization)
+            else if (m.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization)
             {
                 memoryFromGauge = f;
             }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
@@ -65,9 +65,9 @@ public sealed class LinuxCountersTests
         listener.RecordObservableInstruments();
 
         Assert.Equal(2, samples.Count);
-        Assert.Equal(ResourceUtilizationInstruments.CpuUtilization, samples[0].instrument.Name);
+        Assert.Equal(ResourceUtilizationInstruments.ContainerCpuUtilization, samples[0].instrument.Name);
         Assert.Equal(double.NaN, samples[0].value);
-        Assert.Equal(ResourceUtilizationInstruments.MemoryUtilization, samples[1].instrument.Name);
+        Assert.Equal(ResourceUtilizationInstruments.ContainerMemoryUtilization, samples[1].instrument.Name);
         Assert.Equal(0.5, samples[1].value);
     }
 
@@ -121,9 +121,9 @@ public sealed class LinuxCountersTests
         listener.RecordObservableInstruments();
 
         Assert.Equal(2, samples.Count);
-        Assert.Equal(ResourceUtilizationInstruments.CpuUtilization, samples[0].instrument.Name);
+        Assert.Equal(ResourceUtilizationInstruments.ContainerCpuUtilization, samples[0].instrument.Name);
         Assert.Equal(double.NaN, samples[0].value);
-        Assert.Equal(ResourceUtilizationInstruments.MemoryUtilization, samples[1].instrument.Name);
+        Assert.Equal(ResourceUtilizationInstruments.ContainerMemoryUtilization, samples[1].instrument.Name);
         Assert.Equal(1, samples[1].value);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.IO;
+using System.Linq;
 using Microsoft.TestUtilities;
 using Moq;
 using Xunit;
@@ -64,11 +65,13 @@ public sealed class LinuxCountersTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(2, samples.Count);
-        Assert.Equal(ResourceUtilizationInstruments.ContainerCpuUtilization, samples[0].instrument.Name);
-        Assert.Equal(double.NaN, samples[0].value);
-        Assert.Equal(ResourceUtilizationInstruments.ContainerMemoryUtilization, samples[1].instrument.Name);
-        Assert.Equal(0.5, samples[1].value);
+        Assert.Equal(4, samples.Count);
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
+        Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization);
+        Assert.Equal(0.5, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization).value);
     }
 
     [ConditionalFact]
@@ -120,10 +123,12 @@ public sealed class LinuxCountersTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(2, samples.Count);
-        Assert.Equal(ResourceUtilizationInstruments.ContainerCpuUtilization, samples[0].instrument.Name);
-        Assert.Equal(double.NaN, samples[0].value);
-        Assert.Equal(ResourceUtilizationInstruments.ContainerMemoryUtilization, samples[1].instrument.Name);
-        Assert.Equal(1, samples[1].value);
+        Assert.Equal(4, samples.Count);
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
+        Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));
+
+        Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization);
+        Assert.Equal(1, samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessMemoryUtilization).value);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
@@ -65,7 +65,7 @@ public sealed class LinuxCountersTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(4, samples.Count);
+        Assert.Equal(6, samples.Count);
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
         Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));
@@ -123,7 +123,7 @@ public sealed class LinuxCountersTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(4, samples.Count);
+        Assert.Equal(6, samples.Count);
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
         Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
@@ -65,7 +65,7 @@ public sealed class LinuxCountersTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(6, samples.Count);
+        Assert.Equal(5, samples.Count);
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
         Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));
@@ -123,7 +123,7 @@ public sealed class LinuxCountersTests
         listener.Start();
         listener.RecordObservableInstruments();
 
-        Assert.Equal(6, samples.Count);
+        Assert.Equal(5, samples.Count);
 
         Assert.Contains(samples, x => x.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization);
         Assert.True(double.IsNaN(samples.Single(i => i.instrument.Name == ResourceUtilizationInstruments.ProcessCpuUtilization).value));

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
@@ -205,7 +205,7 @@ public sealed class WindowsContainerSnapshotProviderTests
         var meterFactoryMock = new Mock<IMeterFactory>();
         meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))
             .Returns(meter);
-        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ContainerCpuUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ProcessCpuUtilization, fakeClock);
 
         var options = new ResourceMonitoringOptions { CpuConsumptionRefreshInterval = TimeSpan.FromMilliseconds(2) };
 
@@ -261,7 +261,7 @@ public sealed class WindowsContainerSnapshotProviderTests
         var meterFactoryMock = new Mock<IMeterFactory>();
         meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))
             .Returns(meter);
-        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ContainerMemoryUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ProcessMemoryUtilization, fakeClock);
 
         var options = new ResourceMonitoringOptions { MemoryConsumptionRefreshInterval = TimeSpan.FromMilliseconds(2) };
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
@@ -205,7 +205,7 @@ public sealed class WindowsContainerSnapshotProviderTests
         var meterFactoryMock = new Mock<IMeterFactory>();
         meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))
             .Returns(meter);
-        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.CpuUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ContainerCpuUtilization, fakeClock);
 
         var options = new ResourceMonitoringOptions { CpuConsumptionRefreshInterval = TimeSpan.FromMilliseconds(2) };
 
@@ -261,7 +261,7 @@ public sealed class WindowsContainerSnapshotProviderTests
         var meterFactoryMock = new Mock<IMeterFactory>();
         meterFactoryMock.Setup(x => x.Create(It.IsAny<MeterOptions>()))
             .Returns(meter);
-        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.MemoryUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ContainerMemoryUtilization, fakeClock);
 
         var options = new ResourceMonitoringOptions { MemoryConsumptionRefreshInterval = TimeSpan.FromMilliseconds(2) };
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsCountersTests.cs
@@ -35,7 +35,7 @@ public sealed class WindowsCountersTests
         var tcpTableInfo = new TcpTableInfo(Options.Options.Create(options));
         tcpTableInfo.SetGetTcpTableDelegate(TcpTableInfoTests.FakeGetTcpTableWithFakeInformation);
         tcpTableInfo.SetGetTcp6TableDelegate(Tcp6TableInfoTests.FakeGetTcp6TableWithFakeInformation);
-        var windowsCounters = new WindowsCounters(meterFactoryMock.Object, tcpTableInfo);
+        var windowsCounters = new WindowsNetworkMetrics(meterFactoryMock.Object, tcpTableInfo);
         using var listener = new MeterListener
         {
             InstrumentPublished = (instrument, listener) =>
@@ -77,7 +77,7 @@ public sealed class WindowsCountersTests
         var tcpTableInfo = new TcpTableInfo(Options.Options.Create(options));
         tcpTableInfo.SetGetTcpTableDelegate(TcpTableInfoTests.FakeGetTcpTableWithUnsuccessfulStatusAllTheTime);
         tcpTableInfo.SetGetTcp6TableDelegate(Tcp6TableInfoTests.FakeGetTcp6TableWithUnsuccessfulStatusAllTheTime);
-        var windowsCounters = new WindowsCounters(meterFactoryMock.Object, tcpTableInfo);
+        var windowsCounters = new WindowsNetworkMetrics(meterFactoryMock.Object, tcpTableInfo);
         using var listener = new MeterListener
         {
             InstrumentPublished = (instrument, listener) =>

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
@@ -77,7 +77,7 @@ public sealed class WindowsSnapshotProviderTests
 
         cpuTicks = 1_500L;
 
-        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.CpuUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ProcessCpuUtilization, fakeClock);
 
         // Step #0 - state in the beginning:
         metricCollector.RecordObservableInstruments();
@@ -110,7 +110,7 @@ public sealed class WindowsSnapshotProviderTests
 
         var snapshotProvider = new WindowsSnapshotProvider(_fakeLogger, meterFactoryMock.Object, options, fakeClock, static () => 1, static () => 0, () => memoryUsed, static () => 3000UL);
 
-        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.MemoryUtilization, fakeClock);
+        using var metricCollector = new MetricCollector<double>(meter, ResourceUtilizationInstruments.ProcessMemoryUtilization, fakeClock);
 
         // Step #0 - state in the beginning:
         metricCollector.RecordObservableInstruments();


### PR DESCRIPTION
Fixes #5113 

1. Renamed metrics
2. Introduced more specific metrics for container related measurements to distinguish process vs. container (cgroup).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5309)