### PR TITLE
[Http.Resilience] Add support of the HTTP resilience for synchronous HttpClient requests

### DIFF
--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/RetryBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/RetryBenchmark.cs
@@ -76,4 +76,10 @@ public class RetryBenchmark
     {
         return _v8!.SendAsync(Request, _cancellationToken);
     }
+
+    [Benchmark]
+    public HttpResponseMessage Retry_Polly_V8_Sync()
+    {
+        return _v8!.Send(Request, _cancellationToken);
+    }
 }

--- a/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/StandardResilienceBenchmark.cs
+++ b/bench/Libraries/Microsoft.Extensions.Http.Resilience.PerformanceTests/StandardResilienceBenchmark.cs
@@ -78,4 +78,10 @@ public class StandardResilienceBenchmark
     {
         return _v8!.SendAsync(Request, _cancellationToken);
     }
+
+    [Benchmark]
+    public HttpResponseMessage StandardPipeline_Polly_V8_Sync()
+    {
+        return _v8!.Send(Request, _cancellationToken);
+    }
 }

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandler.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHandler.cs
@@ -55,27 +55,17 @@ public class ResilienceHandler : DelegatingHandler
         _ = Throw.IfNull(request);
 
         var pipeline = _pipelineProvider(request);
-        var created = false;
-        if (request.GetResilienceContext() is not ResilienceContext context)
-        {
-            context = ResilienceContextPool.Shared.Get(cancellationToken);
-            created = true;
-            request.SetResilienceContext(context);
-        }
 
-        if (request.GetRequestMetadata() is RequestMetadata requestMetadata)
-        {
-            context.Properties.Set(ResilienceKeys.RequestMetadata, requestMetadata);
-        }
-
-        context.Properties.Set(ResilienceKeys.RequestMessage, request);
+        var context = GetOrSetResilienceContext(request, cancellationToken, out var created);
+        TrySetRequestMetadata(context, request);
+        SetRequestMessage(context, request);
 
         try
         {
             var outcome = await pipeline.ExecuteOutcomeAsync(
                 static async (context, state) =>
                 {
-                    var request = context.Properties.GetValue(ResilienceKeys.RequestMessage, state.request);
+                    var request = GetRequestMessage(context, state.request);
 
                     // Always re-assign the context to this request message before execution.
                     // This is because for primary actions the context is also cloned and we need to re-assign it
@@ -104,19 +94,99 @@ public class ResilienceHandler : DelegatingHandler
         }
         finally
         {
-            if (created)
-            {
-                ResilienceContextPool.Shared.Return(context);
-                request.SetResilienceContext(null);
-            }
-            else
-            {
-                // Restore the original context
-                request.SetResilienceContext(context);
-            }
+            RestoreResilienceContext(context, request, created);
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Sends an HTTP request to the inner handler to send to the server as a synchronous operation.
+    /// </summary>
+    /// <param name="request">The HTTP request message to send to the server.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
+    /// <returns>An HTTP response received from the server.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="request"/> is <see langword="null"/>.</exception>
+    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        _ = Throw.IfNull(request);
+
+        var pipeline = _pipelineProvider(request);
+
+        var context = GetOrSetResilienceContext(request, cancellationToken, out var created);
+        TrySetRequestMetadata(context, request);
+        SetRequestMessage(context, request);
+
+        try
+        {
+            return pipeline.Execute(
+                static (context, state) =>
+                {
+                    var request = GetRequestMessage(context, state.request);
+
+                    // Always re-assign the context to this request message before execution.
+                    // This is because for primary actions the context is also cloned and we need to re-assign it
+                    // here because Polly doesn't have any other events that we can hook into.
+                    request.SetResilienceContext(context);
+
+                    return state.instance.SendCore(request, context.CancellationToken);
+                },
+                context,
+                (instance: this, request));
+        }
+        finally
+        {
+            RestoreResilienceContext(context, request, created);
+        }
+    }
+#endif
+
+    private static ResilienceContext GetOrSetResilienceContext(HttpRequestMessage request, CancellationToken cancellationToken, out bool created)
+    {
+        created = false;
+
+        if (request.GetResilienceContext() is not ResilienceContext context)
+        {
+            context = ResilienceContextPool.Shared.Get(cancellationToken);
+            created = true;
+            request.SetResilienceContext(context);
+        }
+
+        return context;
+    }
+
+    private static void TrySetRequestMetadata(ResilienceContext context, HttpRequestMessage request)
+    {
+        if (request.GetRequestMetadata() is RequestMetadata requestMetadata)
+        {
+            context.Properties.Set(ResilienceKeys.RequestMetadata, requestMetadata);
+        }
+    }
+
+    private static void SetRequestMessage(ResilienceContext context, HttpRequestMessage request)
+        => context.Properties.Set(ResilienceKeys.RequestMessage, request);
+
+    private static HttpRequestMessage GetRequestMessage(ResilienceContext context, HttpRequestMessage request)
+        => context.Properties.GetValue(ResilienceKeys.RequestMessage, request);
+
+    private static void RestoreResilienceContext(ResilienceContext context, HttpRequestMessage request, bool created)
+    {
+        if (created)
+        {
+            ResilienceContextPool.Shared.Return(context);
+            request.SetResilienceContext(null);
+        }
+        else
+        {
+            // Restore the original context
+            request.SetResilienceContext(context);
         }
     }
 
     private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
         => base.SendAsync(requestMessage, cancellationToken);
+
+#if NET6_0_OR_GREATER
+    private HttpResponseMessage SendCore(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
+        => base.Send(requestMessage, cancellationToken);
+#endif
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Helpers/TestHandlerStub.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Helpers/TestHandlerStub.cs
@@ -27,4 +27,13 @@ public class TestHandlerStub : DelegatingHandler
     {
         return _handlerFunc(request, cancellationToken);
     }
+
+#if NET6_0_OR_GREATER
+    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        return _handlerFunc(request, cancellationToken).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+    }
+#endif
 }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RequestMessageSnapshotStrategyTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Internal/RequestMessageSnapshotStrategyTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Internal;
 public class RequestMessageSnapshotStrategyTests
 {
     [Fact]
-    public async Task SendAsync_EnsureSnapshotAttached()
+    public async Task ExecuteAsync_EnsureSnapshotAttached()
     {
         var strategy = Create();
         var context = ResilienceContextPool.Shared.Get();
@@ -32,7 +32,7 @@ public class RequestMessageSnapshotStrategyTests
     }
 
     [Fact]
-    public void ExecuteAsync_requestMessageNotFound_Throws()
+    public void ExecuteAsync_RequestMessageNotFound_Throws()
     {
         var strategy = Create();
 

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
@@ -35,7 +35,7 @@ public sealed partial class HttpClientBuilderExtensionsTests : IDisposable
     public void Dispose()
         => _serviceProvider?.Dispose();
 
-    private static Task SendRequest(HttpClient client, string url, bool asynchronous)
+    private static Task<HttpResponseMessage> SendRequest(HttpClient client, string url, bool asynchronous)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
 

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Standard.cs
@@ -35,6 +35,24 @@ public sealed partial class HttpClientBuilderExtensionsTests : IDisposable
     public void Dispose()
         => _serviceProvider?.Dispose();
 
+    private static Task SendRequest(HttpClient client, string url, bool asynchronous)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+#if NET6_0_OR_GREATER
+        if (asynchronous)
+        {
+            return client.SendAsync(request, default);
+        }
+        else
+        {
+            return Task.FromResult(client.Send(request, default));
+        }
+#else
+        return client.SendAsync(request, default);
+#endif
+    }
+
     private HttpClient CreateClient(string name = BuilderName)
     {
         _serviceProvider ??= _builder.Services.BuildServiceProvider();
@@ -197,8 +215,13 @@ public sealed partial class HttpClientBuilderExtensionsTests : IDisposable
         Assert.NotNull(pipeline);
     }
 
-    [Fact]
-    public async Task DynamicReloads_Ok()
+    [Theory]
+#if NET6_0_OR_GREATER
+    [CombinatorialData]
+#else
+    [InlineData(true)]
+#endif
+    public async Task DynamicReloads_Ok(bool asynchronous = true)
     {
         // arrange
         var requests = new List<HttpRequestMessage>();
@@ -224,13 +247,13 @@ public sealed partial class HttpClientBuilderExtensionsTests : IDisposable
         var client = CreateClient();
 
         // act && assert
-        await client.GetAsync("https://dummy");
+        await SendRequest(client, "https://dummy", asynchronous);
         requests.Should().HaveCount(7);
 
         requests.Clear();
         reloadAction(new() { { "standard:Retry:MaxRetryAttempts", "10" } });
 
-        await client.GetAsync("https://dummy");
+        await SendRequest(client, "https://dummy", asynchronous);
         requests.Should().HaveCount(11);
     }
 

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/ResilienceHandlerTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/ResilienceHandlerTest.cs
@@ -17,10 +17,14 @@ namespace Microsoft.Extensions.Http.Resilience.Test.Internals;
 
 public class ResilienceHandlerTest
 {
+    [Theory]
+#if NET6_0_OR_GREATER
+    [CombinatorialData]
+#else
     [InlineData(true)]
     [InlineData(false)]
-    [Theory]
-    public async Task SendAsync_EnsureRequestMetadataFlows(bool resilienceContextSet)
+#endif
+    public async Task Send_EnsureRequestMetadataFlows(bool resilienceContextSet, bool asynchronous = true)
     {
         using var handler = new ResilienceHandler(ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
@@ -35,7 +39,7 @@ public class ResilienceHandlerTest
 
         handler.InnerHandler = new TestHandlerStub(HttpStatusCode.OK);
 
-        await invoker.SendAsync(request, default);
+        await InvokeHandler(invoker, request, asynchronous);
 
         if (resilienceContextSet)
         {
@@ -51,10 +55,14 @@ public class ResilienceHandlerTest
         }
     }
 
+    [Theory]
+#if NET6_0_OR_GREATER
+    [CombinatorialData]
+#else
     [InlineData(true)]
     [InlineData(false)]
-    [Theory]
-    public async Task SendAsync_EnsureExecutionContext(bool executionContextSet)
+#endif
+    public async Task Send_EnsureExecutionContext(bool executionContextSet, bool asynchronous = true)
     {
         using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
@@ -67,7 +75,7 @@ public class ResilienceHandlerTest
 
         handler.InnerHandler = new TestHandlerStub(HttpStatusCode.OK);
 
-        await invoker.SendAsync(request, default);
+        await InvokeHandler(invoker, request, asynchronous);
 
         if (executionContextSet)
         {
@@ -79,10 +87,14 @@ public class ResilienceHandlerTest
         }
     }
 
+    [Theory]
+#if NET6_0_OR_GREATER
+    [CombinatorialData]
+#else
     [InlineData(true)]
     [InlineData(false)]
-    [Theory]
-    public async Task SendAsync_EnsureInvoker(bool executionContextSet)
+#endif
+    public async Task Send_EnsureInvoker(bool executionContextSet, bool asynchronous = true)
     {
         using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
@@ -101,13 +113,18 @@ public class ResilienceHandlerTest
             return Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.Created });
         });
 
-        var response = await invoker.SendAsync(request, default);
+        var response = await InvokeHandler(invoker, request, asynchronous);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
-    [Fact]
-    public async Task SendAsync_EnsureCancellationTokenFlowsToResilienceContext()
+    [Theory]
+#if NET6_0_OR_GREATER
+    [CombinatorialData]
+#else
+    [InlineData(true)]
+#endif
+    public async Task Send_EnsureCancellationTokenFlowsToResilienceContext(bool asynchronous = true)
     {
         using var source = new CancellationTokenSource();
         using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
@@ -121,13 +138,18 @@ public class ResilienceHandlerTest
             return Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.Created });
         });
 
-        var response = await invoker.SendAsync(request, source.Token);
+        var response = await InvokeHandler(invoker, request, asynchronous, source.Token);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
-    [Fact]
-    public async Task SendAsync_Exception_EnsureRethrown()
+    [Theory]
+#if NET6_0_OR_GREATER
+    [CombinatorialData]
+#else
+    [InlineData(true)]
+#endif
+    public async Task Send_Exception_EnsureRethrown(bool asynchronous = true)
     {
         using var handler = new ResilienceHandler(_ => ResiliencePipeline<HttpResponseMessage>.Empty);
         using var invoker = new HttpMessageInvoker(handler);
@@ -135,6 +157,26 @@ public class ResilienceHandlerTest
 
         handler.InnerHandler = new TestHandlerStub((_, _) => throw new InvalidOperationException());
 
-        await invoker.Invoking(i => i.SendAsync(request, default)).Should().ThrowAsync<InvalidOperationException>();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InvokeHandler(invoker, request, asynchronous));
+    }
+
+    private static Task<HttpResponseMessage> InvokeHandler(
+        HttpMessageInvoker invoker,
+        HttpRequestMessage request,
+        bool asynchronous,
+        CancellationToken cancellationToken = default)
+    {
+#if NET6_0_OR_GREATER
+        if (asynchronous)
+        {
+            return invoker.SendAsync(request, cancellationToken);
+        }
+        else
+        {
+            return Task.FromResult(invoker.Send(request, cancellationToken));
+        }
+#else
+        return invoker.SendAsync(request, cancellationToken);
+#endif
     }
 }


### PR DESCRIPTION
The PR adds support of the HTTP resilience for synchronous HttpClient requests. This is achieved by implementing a synchronous method `Send` in the `ResilienceHandler`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5333)

Resolves #5236 