### PR TITLE
delete note that indicates that cgroups v2 are not supported

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/README.md
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/README.md
@@ -1,9 +1,6 @@
 # Microsoft.Extensions.Diagnostics.ResourceMonitoring
 
-Measures and reports processor and memory usage. This library utilizes control groups (cgroups) in Linux to monitor system resources.
-
-> [!NOTE]
-> Currently, it supports cgroups v1 but does not have support for cgroups v2.
+Measures and reports processor and memory usage. This library utilizes control groups (cgroups) including cgroups v2 in Linux to monitor system resources.
 
 ## Install the package
 


### PR DESCRIPTION
Deleted the Note in the README file that indicates that cgroups v2 are not supported since support was added in [#5068](https://github.com/dotnet/extensions/pull/5068)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5334)