### PR TITLE
Use Configuration Binder in HeaderParsing

### DIFF
--- a/src/Libraries/Microsoft.AspNetCore.HeaderParsing/Microsoft.AspNetCore.HeaderParsing.csproj
+++ b/src/Libraries/Microsoft.AspNetCore.HeaderParsing/Microsoft.AspNetCore.HeaderParsing.csproj
@@ -8,14 +8,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreTargetFrameworks)</TargetFrameworks>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <UseLoggingGenerator>true</UseLoggingGenerator>
     <UseMetricsGenerator>true</UseMetricsGenerator>
     <InjectExperimentalAttributeOnLegacy>true</InjectExperimentalAttributeOnLegacy>
     <InjectGetOrAddOnLegacy>true</InjectGetOrAddOnLegacy>
-
-    <!-- using the ConfigurationBinder source generator is blocked by https://github.com/dotnet/runtime/issues/94547 -->
-    <IsAotCompatible>false</IsAotCompatible>
-    <NoWarn>$(NoWarn);IL2026</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/94547 has been fixed in 9.0. We can now use the Configuration Binder in HeaderParsing.

This fixes the last AOT warning in the repo.

Fix #4914

NOTE: this targets the `dev` branch, since the underlying issue is only fixed in 9.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5368)