### PR TITLE
Make capping happen after scale of the CPU usage in ResourceUtilization

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
@@ -38,8 +38,7 @@ internal static class Calculator
         long newUsageTicks = second.KernelTimeSinceStart.Ticks + second.UserTimeSinceStart.Ticks;
         long totalUsageTickDelta = newUsageTicks - oldUsageTicks;
 
-        var utilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
-        var cpuUtilization = Math.Min(Hundred, utilization);
+        var cpuUtilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
 
         return new ResourceUtilization(cpuUtilization, second.MemoryUsageInBytes, systemResources, second);
     }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Calculator.cs
@@ -38,7 +38,7 @@ internal static class Calculator
         long newUsageTicks = second.KernelTimeSinceStart.Ticks + second.UserTimeSinceStart.Ticks;
         long totalUsageTickDelta = newUsageTicks - oldUsageTicks;
 
-        var cpuUtilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
+        double cpuUtilization = Math.Max(0.0, totalUsageTickDelta / totalSystemTicks * Hundred);
 
         return new ResourceUtilization(cpuUtilization, second.MemoryUsageInBytes, systemResources, second);
     }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilization.cs
@@ -57,7 +57,7 @@ public readonly struct ResourceUtilization
             guaranteedCpuUnits = 1;
         }
 
-        CpuUsedPercentage = Throw.IfLessThan(cpuUsedPercentage / guaranteedCpuUnits, 0.0);
+        CpuUsedPercentage = Math.Min(Hundred, Throw.IfLessThan(cpuUsedPercentage / guaranteedCpuUnits, 0.0));
         MemoryUsedInBytes = Throw.IfLessThan(memoryUsedInBytes, 0);
         SystemResources = systemResources;
         MemoryUsedPercentage = Math.Min(Hundred, (double)MemoryUsedInBytes / systemResources.GuaranteedMemoryInBytes * Hundred);

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/CalculatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/CalculatorTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Security.AccessControl;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/extensions/issues/5387
The range of cpuUtilization we calculated from Snapshot in the Calculator is [0, 100*request]. We shouldn't capping the value to 100 in this step. 
Instead, we should have the capping after we scale the utilization value to [0,100] by divide GuaranteedCpuUnits in the ResourceUtilization constructor.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5388)