### PR TITLE
Replace Network Type string with Const in ResourceMonitoring

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Network/LinuxNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Network/LinuxNetworkMetrics.cs
@@ -37,11 +37,12 @@ internal sealed class LinuxNetworkMetrics
 
     private IEnumerable<Measurement<long>> GetMeasurements()
     {
+        const string NetworkTypeKey = "network.type";
         const string NetworkStateKey = "system.network.state";
 
         // These are covered in https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md#attributes:
-        KeyValuePair<string, object?> tcpVersionFourTag = new("network.type", "ipv4");
-        KeyValuePair<string, object?> tcpVersionSixTag = new("network.type", "ipv6");
+        KeyValuePair<string, object?> tcpVersionFourTag = new(NetworkTypeKey, "ipv4");
+        KeyValuePair<string, object?> tcpVersionSixTag = new(NetworkTypeKey, "ipv6");
 
         List<Measurement<long>> measurements = new(24);
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Network/WindowsNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Network/WindowsNetworkMetrics.cs
@@ -37,11 +37,12 @@ internal sealed class WindowsNetworkMetrics
 
     private IEnumerable<Measurement<long>> GetMeasurements()
     {
+        const string NetworkTypeKey = "network.type";
         const string NetworkStateKey = "system.network.state";
 
         // These are covered in https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md#attributes:
-        KeyValuePair<string, object?> tcpVersionFourTag = new("network.type", "ipv4");
-        KeyValuePair<string, object?> tcpVersionSixTag = new("network.type", "ipv6");
+        KeyValuePair<string, object?> tcpVersionFourTag = new(NetworkTypeKey, "ipv4");
+        KeyValuePair<string, object?> tcpVersionSixTag = new(NetworkTypeKey, "ipv6");
 
         List<Measurement<long>> measurements = new(24);
 


### PR DESCRIPTION
There are 2 occurances for `network.type` as metry key in ResourceMonitoring's `WindowsNetworkMetrics` and `LinuxNetworkMetrics` classes.
We can replace them as a const string.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5398)