### PR TITLE
Add KubernetesProbesOptionsValidator to ensure different ports for probes

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/KubernetesProbesExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/KubernetesProbesExtensions.cs
@@ -47,6 +47,10 @@ public static class KubernetesProbesExtensions
         _ = Throw.IfNull(services);
         _ = Throw.IfNull(configure);
 
+        _ = services
+            .AddOptionsWithValidateOnStart<KubernetesProbesOptions, KubernetesProbesOptionsValidator>()
+            .Configure(configure);
+
         var wrapperOptions = new KubernetesProbesOptions();
 
         return services

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/KubernetesProbesOptionsValidator.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.Probes/KubernetesProbesOptionsValidator.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Diagnostics.Probes;
+
+internal sealed class KubernetesProbesOptionsValidator : IValidateOptions<KubernetesProbesOptions>
+{
+    public ValidateOptionsResult Validate(string? name, KubernetesProbesOptions options)
+    {
+        var builder = new ValidateOptionsResultBuilder();
+
+        if (options.LivenessProbe.TcpPort == options.StartupProbe.TcpPort
+            || options.LivenessProbe.TcpPort == options.ReadinessProbe.TcpPort
+            || options.StartupProbe.TcpPort == options.ReadinessProbe.TcpPort)
+        {
+            builder.AddError("Liveness, startup and readiness probes must use different ports.");
+        }
+
+        return builder.Build();
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesOptionsValidatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesOptionsValidatorTests.cs
@@ -68,7 +68,7 @@ public class KubernetesProbesOptionsValidatorTests
     [Fact]
     public async Task Validator_WhenHostStarts_Succeeds()
     {
-        using IHost host = CreateHostBuilder(services =>
+        using IHost host = CreateHost(services =>
         {
             services.AddKubernetesProbes(options =>
             {
@@ -99,7 +99,7 @@ public class KubernetesProbesOptionsValidatorTests
     {
         Action action = () =>
         {
-            using IHost host = CreateHostBuilder(services =>
+            using IHost host = CreateHost(services =>
             {
                 services.AddKubernetesProbes(options =>
                 {
@@ -115,7 +115,7 @@ public class KubernetesProbesOptionsValidatorTests
         Assert.Throws<OptionsValidationException>(action);
     }
 
-    private static IHost CreateHostBuilder(Action<IServiceCollection> configureServices)
+    private static IHost CreateHost(Action<IServiceCollection> configureServices)
     {
         return Host.CreateDefaultBuilder()
             .ConfigureServices(configureServices)

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesOptionsValidatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesOptionsValidatorTests.cs
@@ -1,6 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Extensions.Diagnostics.Probes.Test;
@@ -11,7 +16,7 @@ public class KubernetesProbesOptionsValidatorTests
     public void Validator_DefaultValues_Succeeds()
     {
         var options = new KubernetesProbesOptions();
-        var result = new KubernetesProbesOptionsValidator().Validate(nameof(options), options);
+        ValidateOptionsResult result = new KubernetesProbesOptionsValidator().Validate(nameof(options), options);
 
         Assert.True(result.Succeeded);
     }
@@ -24,7 +29,7 @@ public class KubernetesProbesOptionsValidatorTests
         options.StartupProbe.TcpPort = 2306;
         options.ReadinessProbe.TcpPort = 2307;
 
-        var result = new KubernetesProbesOptionsValidator().Validate(nameof(options), options);
+        ValidateOptionsResult result = new KubernetesProbesOptionsValidator().Validate(nameof(options), options);
 
         Assert.True(result.Succeeded);
     }
@@ -38,7 +43,7 @@ public class KubernetesProbesOptionsValidatorTests
         options.ReadinessProbe.TcpPort = 2307;
 
         var validator = new KubernetesProbesOptionsValidator();
-        var result = validator.Validate(nameof(options), options);
+        ValidateOptionsResult result = validator.Validate(nameof(options), options);
         Assert.True(result.Failed);
 
         options.LivenessProbe.TcpPort = 2305;
@@ -58,5 +63,62 @@ public class KubernetesProbesOptionsValidatorTests
         options.ReadinessProbe.TcpPort = 2305;
         result = validator.Validate(nameof(options), options);
         Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public async Task Validator_WhenHostStarts_Succeeds()
+    {
+        using IHost host = CreateHostBuilder(services =>
+        {
+            services.AddKubernetesProbes(options =>
+            {
+                options.LivenessProbe.TcpPort = 22305;
+                options.StartupProbe.TcpPort = 22306;
+                options.ReadinessProbe.TcpPort = 22307;
+            }).AddHealthChecks();
+        });
+
+        try
+        {
+            host.Start();
+            await host.StopAsync();
+        }
+        catch (OptionsValidationException ex)
+        {
+            Assert.Fail("Unexpected OptionsValidationException: " + ex.Message);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail("Unexpected exception: " + ex.Message);
+            throw;
+        }
+    }
+
+    [Fact]
+    public void Validator_WhenHostStarts_Fails()
+    {
+        Action action = () =>
+        {
+            using IHost host = CreateHostBuilder(services =>
+            {
+                services.AddKubernetesProbes(options =>
+                {
+                    options.LivenessProbe.TcpPort = 22305;
+                    options.StartupProbe.TcpPort = 22305;
+                    options.ReadinessProbe.TcpPort = 22307;
+                }).AddHealthChecks();
+            });
+
+            host.Start();
+        };
+
+        Assert.Throws<OptionsValidationException>(action);
+    }
+
+    private static IHost CreateHostBuilder(Action<IServiceCollection> configureServices)
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureServices(configureServices)
+            .Build();
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesOptionsValidatorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.Probes.Tests/KubernetesProbesOptionsValidatorTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.Extensions.Diagnostics.Probes.Test;
+
+public class KubernetesProbesOptionsValidatorTests
+{
+    [Fact]
+    public void Validator_DefaultValues_Succeeds()
+    {
+        var options = new KubernetesProbesOptions();
+        var result = new KubernetesProbesOptionsValidator().Validate(nameof(options), options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validator_GivenValidOptions_Succeeds()
+    {
+        var options = new KubernetesProbesOptions();
+        options.LivenessProbe.TcpPort = 2305;
+        options.StartupProbe.TcpPort = 2306;
+        options.ReadinessProbe.TcpPort = 2307;
+
+        var result = new KubernetesProbesOptionsValidator().Validate(nameof(options), options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validator_GivenInvalidOptions_Fails()
+    {
+        var options = new KubernetesProbesOptions();
+        options.LivenessProbe.TcpPort = 2305;
+        options.StartupProbe.TcpPort = 2305;
+        options.ReadinessProbe.TcpPort = 2307;
+
+        var validator = new KubernetesProbesOptionsValidator();
+        var result = validator.Validate(nameof(options), options);
+        Assert.True(result.Failed);
+
+        options.LivenessProbe.TcpPort = 2305;
+        options.StartupProbe.TcpPort = 2306;
+        options.ReadinessProbe.TcpPort = 2305;
+        result = validator.Validate(nameof(options), options);
+        Assert.True(result.Failed);
+
+        options.LivenessProbe.TcpPort = 2305;
+        options.StartupProbe.TcpPort = 2306;
+        options.ReadinessProbe.TcpPort = 2306;
+        result = validator.Validate(nameof(options), options);
+        Assert.True(result.Failed);
+
+        options.LivenessProbe.TcpPort = 2305;
+        options.StartupProbe.TcpPort = 2305;
+        options.ReadinessProbe.TcpPort = 2305;
+        result = validator.Validate(nameof(options), options);
+        Assert.True(result.Failed);
+    }
+}


### PR DESCRIPTION
Add the KubernetesProbesOptionsValidator to check if the 3 Kubernetes probes (liveness, startup, readiness) use different ports.

### Context
If we set same ports for Kubernetes probes, it will cause issue below:
```
        builder.Services.AddKubernetesProbes(options =>
        {
            options.LivenessProbe.TcpPort = 2305;
            options.StartupProbe.TcpPort = 2305;
            options.ReadinessProbe.TcpPort = 2305;
        });
```

```
fail: Microsoft.Extensions.Diagnostics.Probes.TcpEndpointProbesService[1466257416]
      Error updating health status through TCP endpoint
      System.Net.Sockets.SocketException (10048): Only one usage of each socket address (protocol/network address/port) is normally permitted.
         at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName)
         at System.Net.Sockets.Socket.DoBind(EndPoint endPointSnapshot, SocketAddress socketAddress)
         at System.Net.Sockets.Socket.Bind(EndPoint localEP)
         at System.Net.Sockets.TcpListener.Start(Int32 backlog)
         at Microsoft.Extensions.Diagnostics.Probes.TcpEndpointProbesService.UpdateHealthStatusAsync(CancellationToken cancellationToken)
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5400)