### PR TITLE
Revert correct Meter name

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -13,7 +13,6 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 {
     private const double One = 1.0;
     private const long Hundred = 100L;
-    private const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
 
     private readonly object _cpuLocker = new();
     private readonly object _memoryLocker = new();
@@ -63,7 +62,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(MeterName);
+        var meter = meterFactory.Create(ResourceUtilizationInstruments.MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuLimit, unit: "1");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -13,6 +13,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
 {
     private const double One = 1.0;
     private const long Hundred = 100L;
+    private const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
 
     private readonly object _cpuLocker = new();
     private readonly object _memoryLocker = new();
@@ -62,7 +63,7 @@ internal sealed class LinuxUtilizationProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
+        var meter = meterFactory.Create(MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ContainerCpuLimitUtilization, observeValue: () => CpuUtilization() * _scaleRelativeToCpuLimit, unit: "1");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceUtilizationInstruments.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 internal static class ResourceUtilizationInstruments
 {
     /// <summary>
+    /// The name of the ResourceMonitoring Meter.
+    /// </summary>
+    public const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
+
+    /// <summary>
     /// The name of an instrument to retrieve CPU limit consumption of all processes running inside a container or control group in range <c>[0, 1]</c>.
     /// </summary>
     /// <remarks>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
 {
     private const double Hundred = 100.0d;
+    private const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
 
     private readonly Lazy<MEMORYSTATUSEX> _memoryStatus;
 
@@ -105,7 +106,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
+        var meter = meterFactory.Create(MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         // Container based metrics:

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
 {
     private const double Hundred = 100.0d;
-    private const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
 
     private readonly Lazy<MEMORYSTATUSEX> _memoryStatus;
 
@@ -106,7 +105,7 @@ internal sealed class WindowsContainerSnapshotProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(MeterName);
+        var meter = meterFactory.Create(ResourceUtilizationInstruments.MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         // Container based metrics:

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 internal sealed class WindowsSnapshotProvider : ISnapshotProvider
 {
     private const double Hundred = 100.0d;
+    private const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
 
     public SystemResources Resources { get; }
 
@@ -81,7 +82,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(nameof(Microsoft.Extensions.Diagnostics.ResourceMonitoring));
+        var meter = meterFactory.Create(MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuPercentage);

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 internal sealed class WindowsSnapshotProvider : ISnapshotProvider
 {
     private const double Hundred = 100.0d;
-    private const string MeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
 
     public SystemResources Resources { get; }
 
@@ -82,7 +81,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
         // We don't dispose the meter because IMeterFactory handles that
         // An issue on analyzer side: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(MeterName);
+        var meter = meterFactory.Create(ResourceUtilizationInstruments.MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         _ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessCpuUtilization, observeValue: CpuPercentage);

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Helpers/TestMeterFactory.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Helpers/TestMeterFactory.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
+
+internal class TestMeterFactory : IMeterFactory
+{
+    public List<Meter> Meters { get; } = new List<Meter>();
+
+    public Meter Create(MeterOptions options)
+    {
+        var meter = new Meter(options.Name, options.Version, Array.Empty<KeyValuePair<string, object?>>(), scope: this);
+        Meters.Add(meter);
+
+        return meter;
+    }
+
+    public Meter Create(string name)
+    {
+        return Create(new MeterOptions(name)
+        {
+            Version = null,
+            Tags = null,
+            Scope = null
+        });
+    }
+
+    public void Dispose()
+    {
+        foreach (var meter in Meters)
+        {
+            meter.Dispose();
+        }
+
+        Meters.Clear();
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Metrics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.TestUtilities;
 using Moq;
@@ -190,5 +191,18 @@ public sealed class LinuxUtilizationProviderTests
         var logRecords = logger.Collector.GetSnapshot();
 
         return Verifier.Verify(logRecords).UseDirectory(VerifiedDataDirectory);
+    }
+
+    [Fact]
+    public void Provider_Creates_Meter_With_Correct_Name()
+    {
+        var options = Options.Options.Create<ResourceMonitoringOptions>(new());
+        using var meterFactory = new TestMeterFactory();
+
+        var parser = new DummyLinuxUtilizationParser();
+        _ = new LinuxUtilizationProvider(options, parser, meterFactory);
+
+        var meter = meterFactory.Meters.Single();
+        Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/Resources/DummyLinuxUtilizationParser.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux;
+
+namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test;
+
+internal class DummyLinuxUtilizationParser : ILinuxUtilizationParser
+{
+    public ulong GetAvailableMemoryInBytes() => 1;
+    public long GetCgroupCpuUsageInNanoseconds() => 0;
+    public float GetCgroupLimitedCpus() => 1;
+    public float GetCgroupRequestCpu() => 1;
+    public ulong GetHostAvailableMemory() => 0;
+    public float GetHostCpuCount() => 1;
+    public long GetHostCpuUsageInNanoseconds() => 0;
+    public ulong GetMemoryUsageInBytes() => 0;
+}

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Diagnostics.Metrics;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Time.Testing;
@@ -321,5 +323,17 @@ public sealed class WindowsContainerSnapshotProviderTests
         var logRecords = _logger.Collector.GetSnapshot();
 
         return Verifier.Verify(logRecords).UniqueForRuntime().UseDirectory(VerifiedDataDirectory);
+    }
+
+    [Fact]
+    public void Provider_Creates_Meter_With_Correct_Name()
+    {
+        var options = Options.Options.Create<ResourceMonitoringOptions>(new());
+        using var meterFactory = new TestMeterFactory();
+
+        _ = new WindowsContainerSnapshotProvider(_logger, meterFactory, options);
+
+        var meter = meterFactory.Meters.Single();
+        Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
@@ -331,7 +331,15 @@ public sealed class WindowsContainerSnapshotProviderTests
         var options = Options.Options.Create<ResourceMonitoringOptions>(new());
         using var meterFactory = new TestMeterFactory();
 
-        _ = new WindowsContainerSnapshotProvider(_logger, meterFactory, options);
+        _ = new WindowsContainerSnapshotProvider(
+            _memoryInfoMock.Object,
+            _systemInfoMock.Object,
+            _processInfoMock.Object,
+            _logger,
+            meterFactory,
+            () => _jobHandleMock.Object,
+            new FakeTimeProvider(),
+            new());
 
         var meter = meterFactory.Meters.Single();
         Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Diagnostics.Metrics;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
@@ -154,5 +156,16 @@ public sealed class WindowsSnapshotProviderTests
         // This is a synthetic test to have full test coverage:
         var usage = WindowsSnapshotProvider.GetMemoryUsageInBytes();
         Assert.InRange(usage, 0, long.MaxValue);
+    }
+
+    [Fact]
+    public void Provider_Creates_Meter_With_Correct_Name()
+    {
+        using var meterFactory = new TestMeterFactory();
+
+        _ = new WindowsSnapshotProvider(_fakeLogger, meterFactory, _options);
+
+        var meter = meterFactory.Meters.Single();
+        Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
@@ -158,7 +158,7 @@ public sealed class WindowsSnapshotProviderTests
         Assert.InRange(usage, 0, long.MaxValue);
     }
 
-    [Fact]
+    [ConditionalFact]
     public void Provider_Creates_Meter_With_Correct_Name()
     {
         using var meterFactory = new TestMeterFactory();


### PR DESCRIPTION
Fixes https://github.com/dotnet/extensions/issues/5404

Corrects a bug with wrong meter name that has been changed from Microsoft.Extensions.Diagnostics.ResourceMonitoring to ResourceMonitoring
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5403)