### PR TITLE
ResourceUtilizationHealthCheck - Report both CPU and Memory issues

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/ResourceUtilizationHealthCheck.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/ResourceUtilizationHealthCheck.cs
@@ -53,18 +53,17 @@ internal sealed class ResourceUtilizationHealthCheck : IHealthCheck
             string message = string.Empty;
             if (cpuUnhealthy && memoryUnhealthy)
             {
-                message = "CPU and Memory";
+                message = "CPU and memory usage is above the limit";
             }
             else if (cpuUnhealthy)
             {
-                message = "CPU";
+                message = "CPU usage is above the limit";
             }
             else
             {
-                message = "Memory";
+                message = "Memory usage is above the limit";
             }
 
-            message += " usage is above the limit";
             return Task.FromResult(HealthCheckResult.Unhealthy(message, default, data));
         }
 
@@ -76,18 +75,17 @@ internal sealed class ResourceUtilizationHealthCheck : IHealthCheck
             string message = string.Empty;
             if (cpuDegraded && memoryDegraded)
             {
-                message = "CPU and Memory";
+                message = "CPU and memory usage is close to the limit";
             }
             else if (cpuDegraded)
             {
-                message = "CPU";
+                message = "CPU usage is close to the limit";
             }
             else
             {
-                message = "Memory";
+                message = "Memory usage is close to the limit";
             }
 
-            message += " usage is close to the limit";
             return Task.FromResult(HealthCheckResult.Degraded(message, default, data));
         }
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.Tests/ResourceHealthCheckTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.Tests/ResourceHealthCheckTests.cs
@@ -54,7 +54,7 @@ public class ResourceHealthCheckTests
                 1000UL,
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.2, UnhealthyUtilizationPercentage = 0.4 },
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.2, UnhealthyUtilizationPercentage = 0.4 },
-                "CPU and Memory usage is close to the limit"
+                "CPU and memory usage is close to the limit"
             },
             new object[]
             {
@@ -64,7 +64,7 @@ public class ResourceHealthCheckTests
                 1000UL,
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.2, UnhealthyUtilizationPercentage = 0.4 },
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.2, UnhealthyUtilizationPercentage = 0.4 },
-                "CPU and Memory usage is above the limit"
+                "CPU and memory usage is above the limit"
             },
             new object[]
             {
@@ -74,7 +74,7 @@ public class ResourceHealthCheckTests
                 1000UL,
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.4, UnhealthyUtilizationPercentage = 0.2 },
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.4, UnhealthyUtilizationPercentage = 0.2 },
-                "CPU and Memory usage is above the limit"
+                "CPU and memory usage is above the limit"
             },
             new object[]
             {
@@ -84,7 +84,7 @@ public class ResourceHealthCheckTests
                 1000UL,
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.2 },
                 new ResourceUsageThresholds { DegradedUtilizationPercentage = 0.2 },
-                "CPU and Memory usage is close to the limit"
+                "CPU and memory usage is close to the limit"
             },
             new object[]
             {
@@ -94,7 +94,7 @@ public class ResourceHealthCheckTests
                 1000UL,
                 new ResourceUsageThresholds { UnhealthyUtilizationPercentage = 0.4 },
                 new ResourceUsageThresholds { UnhealthyUtilizationPercentage = 0.4 },
-                "CPU and Memory usage is above the limit"
+                "CPU and memory usage is above the limit"
             },
             new object[]
             {


### PR DESCRIPTION
Fixes #4677 

## Proposed changes

- Report both CPU and Memory issues when checking health based on resource utilization.

## Customer Impact

- Fixes an issue where only CPU or Memory issues are reported during a resource utilization health check, but not both.
- This change also includes the additional key-value pairs describing the health of each component in the health check result.

## Test methodology <!-- How did you ensure quality? -->

- Updated `ResourceHealthCheckTests` to accommodate for this change.
- Ran all tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5407)