### PR TITLE
Register internal ResourceMonitor with ResourceUtilizationHealthCheck

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/ResourceUtilizationHealthCheckExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/ResourceUtilizationHealthCheckExtensions.cs
@@ -28,6 +28,8 @@ public static class ResourceUtilizationHealthCheckExtensions
         _ = Throw.IfNull(builder);
         _ = Throw.IfNull(tags);
 
+        _ = builder.Services.AddResourceMonitoring();
+
         _ = builder.Services.AddOptionsWithValidateOnStart<ResourceUtilizationHealthCheckOptions, ResourceUtilizationHealthCheckOptionsValidator>();
         return builder.AddCheck<ResourceUtilizationHealthCheck>(HealthCheckName, tags: tags);
     }
@@ -43,6 +45,8 @@ public static class ResourceUtilizationHealthCheckExtensions
     {
         _ = Throw.IfNull(builder);
         _ = Throw.IfNull(tags);
+
+        _ = builder.Services.AddResourceMonitoring();
 
         _ = builder.Services.AddOptionsWithValidateOnStart<ResourceUtilizationHealthCheckOptions, ResourceUtilizationHealthCheckOptionsValidator>();
         return builder.AddCheck<ResourceUtilizationHealthCheck>(HealthCheckName, tags: tags);


### PR DESCRIPTION
Fixes #4560 

## What is changing

`ResourceUtilizationHealthCheck` depends on `IResourceMonitor` and requires an implementation of it to be registered first, which is also mentioned in #4560. Typically, users would achieve this by calling the `AddResourceMonitoring()` method which registers the internal [ResourceMonitorService](https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitorService.cs) for this purpose:
```
var serviceCollection = new ServiceCollection();
serviceCollection.AddResourceMonitoring();
serviceCollection.AddResourceUtilizationHealthCheck();
```
After this change, users don't have to call `AddResourceMonitoring()` and can just call `AddResourceUtilizationHealthCheck()` immediately:
```
var serviceCollection = new ServiceCollection();
serviceCollection.AddResourceUtilizationHealthCheck();
```
## Impact

- If you use `AddResourceMonitoring()` method call, you may omit it.
- If you use a custom implementation of `IResourceMonitor` and register it using the `AddSingleton<IResourceMonitor, TImplementation>()` method, then no action is required. 
- If you  use a custom implementation of `IResourceMonitor` and register it using the `TryAddSingleton<IResourceMonitor, TImplementation>()` method which is placed before `AddResourceUtilizationHealthCheck()`, then no action is required. For example, assuming the custom implementation `TImplementation` class name is `MyResourceMonitorService`, the following scenarios will continue to work as is:
	
	:white_check_mark: works:
	```
	// 1.
	var serviceCollection = new ServiceCollection();
	serviceCollection.AddSingleton<IResourceMonitor, MyResourceMonitorService>();
	serviceCollection.AddResourceUtilizationHealthCheck();
	```
	
	:white_check_mark: works:
	 ```
	// 2.
	var serviceCollection = new ServiceCollection();
	serviceCollection.AddResourceUtilizationHealthCheck();
	serviceCollection.AddSingleton<IResourceMonitor, MyResourceMonitorService>();
	```
	
	:white_check_mark: works:
	 ```
	// 3.
	var serviceCollection = new ServiceCollection();
	serviceCollection.TryAddSingleton<IResourceMonitor, MyResourceMonitorService>();
	serviceCollection.AddResourceUtilizationHealthCheck();
	```

- If you use `TryAddSingleton<IResourceMonitor, TImplementation>()` which is placed after the `AddResourceUtilizationHealthCheck()` method call, then the following will not work, because the internal [ResourceMonitorService](https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/ResourceMonitorService.cs) will be registered and used instead of the `MyResourceMonitorService`:

	:x: does not work:
	```
	// 4.
	var serviceCollection = new ServiceCollection();
	serviceCollection.AddResourceUtilizationHealthCheck();
	serviceCollection.TryAddSingleton<IResourceMonitor, MyResourceMonitorService>();
	```
	
	To fix that, please use either `AddSingleton<IResourceMonitor, TImplementation>()` extension methods, or place the registration before the `AddResourceUtilizationHealthCheck()` method call:
	
	:white_check_mark: works:
	```
	// 5.
	var serviceCollection = new ServiceCollection();
	serviceCollection.TryAddSingleton<IResourceMonitor, MyResourceMonitorService>();
	serviceCollection.AddResourceUtilizationHealthCheck();
	```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5413)

