### PR TITLE
HybridCache: ensure that Size is always specified in L1

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.CacheItem.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.CacheItem.cs
@@ -87,6 +87,8 @@ internal partial class DefaultHybridCache
 
     internal abstract class CacheItem<T> : CacheItem
     {
+        public abstract bool TryGetSize(out long size);
+
         // attempt to get a value that was *not* previously reserved
         public abstract bool TryGetValue(out T value);
 

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.ImmutableCacheItem.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.ImmutableCacheItem.cs
@@ -13,6 +13,8 @@ internal partial class DefaultHybridCache
 
         private T _value = default!; // deferred until SetValue
 
+        public long Size { get; private set; } = -1;
+
         public override bool DebugIsImmutable => true;
 
         // get a shared instance that passes as "reserved"; doesn't need to be 100% singleton,
@@ -30,12 +32,22 @@ internal partial class DefaultHybridCache
             return obj;
         }
 
-        public void SetValue(T value) => _value = value;
+        public void SetValue(T value, long size)
+        {
+            _value = value;
+            Size = size;
+        }
 
         public override bool TryGetValue(out T value)
         {
             value = _value;
             return true; // always available
+        }
+
+        public override bool TryGetSize(out long size)
+        {
+            size = Size;
+            return size >= 0;
         }
 
         public override bool TryReserveBuffer(out BufferChunk buffer)

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.L2.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.L2.cs
@@ -34,7 +34,7 @@ internal partial class DefaultHybridCache
                 return new(GetValidPayloadSegment(pendingLegacy.Result)); // already complete
 
             case CacheFeatures.BackendCache | CacheFeatures.BackendBuffers: // IBufferWriter<byte>-based
-                var writer = RecyclableArrayBufferWriter<byte>.Create(MaximumPayloadBytes);
+                RecyclableArrayBufferWriter<byte> writer = RecyclableArrayBufferWriter<byte>.Create(MaximumPayloadBytes);
                 var cache = Unsafe.As<IBufferDistributedCache>(_backendCache!); // type-checked already
                 var pendingBuffers = cache.TryGetAsync(key, writer, token);
                 if (!pendingBuffers.IsCompletedSuccessfully)
@@ -99,7 +99,7 @@ internal partial class DefaultHybridCache
             // intentionally use manual Dispose rather than "using"; confusingly, it is Dispose()
             // that actually commits the add - so: if we fault, we don't want to try
             // committing a partially configured cache entry
-            var cacheEntry = _localCache.CreateEntry(key);
+            ICacheEntry cacheEntry = _localCache.CreateEntry(key);
             cacheEntry.AbsoluteExpirationRelativeToNow = options?.LocalCacheExpiration ?? _defaultLocalCacheExpiration;
             cacheEntry.Value = value;
 

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
@@ -177,7 +177,7 @@ internal partial class DefaultHybridCache
                 if ((Key.Flags & HybridCacheEntryFlags.DisableUnderlyingData) == 0)
                 {
                     // invoke the callback supplied by the caller
-                    var newValue = await _underlying!(_state!, SharedToken).ConfigureAwait(false);
+                    T newValue = await _underlying!(_state!, SharedToken).ConfigureAwait(false);
 
                     // If we're writing this value *anywhere*, we're going to need to serialize; this is obvious
                     // in the case of L2, but we also need it for L1, because MemoryCache might be enforcing

--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/DefaultHybridCache.StampedeStateT.cs
@@ -14,7 +14,7 @@ internal partial class DefaultHybridCache
 {
     internal sealed class StampedeState<TState, T> : StampedeState
     {
-        const HybridCacheEntryFlags FlagsDisableL1AndL2 = HybridCacheEntryFlags.DisableLocalCacheWrite | HybridCacheEntryFlags.DisableDistributedCacheWrite;
+        private const HybridCacheEntryFlags FlagsDisableL1AndL2 = HybridCacheEntryFlags.DisableLocalCacheWrite | HybridCacheEntryFlags.DisableDistributedCacheWrite;
 
         private readonly TaskCompletionSource<CacheItem<T>>? _result;
         private TState? _state;
@@ -39,9 +39,6 @@ internal partial class DefaultHybridCache
         }
 
         public override Type Type => typeof(T);
-
-        [DoesNotReturn]
-        private static CacheItem<T> ThrowUnexpectedCacheItem() => throw new InvalidOperationException("Unexpected cache item");
 
         public void QueueUserWorkItem(in TState state, Func<TState, CancellationToken, ValueTask<T>> underlying, HybridCacheEntryOptions? options)
         {
@@ -156,6 +153,9 @@ internal partial class DefaultHybridCache
             static async Task<T> AwaitedAsync(Task<CacheItem<T>> task)
                 => (await task.ConfigureAwait(false)).GetReservedValue();
         }
+
+        [DoesNotReturn]
+        private static CacheItem<T> ThrowUnexpectedCacheItem() => throw new InvalidOperationException("Unexpected cache item");
 
         [SuppressMessage("Resilience", "EA0014:The async method doesn't support cancellation", Justification = "In this case the cancellation token is provided internally via SharedToken")]
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exception is passed through to faulted task result")]

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/BufferReleaseTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/BufferReleaseTests.cs
@@ -19,7 +19,7 @@ public class BufferReleaseTests // note that buffer ref-counting is only enabled
         var services = new ServiceCollection();
         config?.Invoke(services);
         services.AddHybridCache();
-        var provider = services.BuildServiceProvider();
+        ServiceProvider provider = services.BuildServiceProvider();
         cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
         return provider;
     }
@@ -117,8 +117,8 @@ public class BufferReleaseTests // note that buffer ref-counting is only enabled
         // prep the backend with our data
         var key = Me();
         Assert.NotNull(cache.BackendCache);
-        var serializer = cache.GetSerializer<Customer>();
-        using (var writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue))
+        IHybridCacheSerializer<Customer> serializer = cache.GetSerializer<Customer>();
+        using (RecyclableArrayBufferWriter<byte> writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue))
         {
             serializer.Serialize(await GetAsync(), writer);
             cache.BackendCache.Set(key, writer.ToArray());
@@ -176,8 +176,8 @@ public class BufferReleaseTests // note that buffer ref-counting is only enabled
         // prep the backend with our data
         var key = Me();
         Assert.NotNull(cache.BackendCache);
-        var serializer = cache.GetSerializer<Customer>();
-        using (var writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue))
+        IHybridCacheSerializer<Customer> serializer = cache.GetSerializer<Customer>();
+        using (RecyclableArrayBufferWriter<byte> writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue))
         {
             serializer.Serialize(await GetAsync(), writer);
             cache.BackendCache.Set(key, writer.ToArray());

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/DistributedCacheTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/DistributedCacheTests.cs
@@ -185,7 +185,7 @@ public abstract class DistributedCacheTests
         Assert.Equal(size, expected.Length);
         cache.Set(key, payload, _fiveMinutes);
 
-        var writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue);
+        RecyclableArrayBufferWriter<byte> writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue);
         Assert.True(cache.TryGet(key, writer));
         Assert.True(expected.Span.SequenceEqual(writer.GetCommittedMemory().Span));
         writer.ResetInPlace();
@@ -247,7 +247,7 @@ public abstract class DistributedCacheTests
         Assert.Equal(size, expected.Length);
         await cache.SetAsync(key, payload, _fiveMinutes);
 
-        var writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue);
+        RecyclableArrayBufferWriter<byte> writer = RecyclableArrayBufferWriter<byte>.Create(int.MaxValue);
         Assert.True(await cache.TryGetAsync(key, writer));
         Assert.True(expected.Span.SequenceEqual(writer.GetCommittedMemory().Span));
         writer.ResetInPlace();

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/FunctionalTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/FunctionalTests.cs
@@ -13,7 +13,7 @@ public class FunctionalTests
         var services = new ServiceCollection();
         config?.Invoke(services);
         services.AddHybridCache();
-        var provider = services.BuildServiceProvider();
+        ServiceProvider provider = services.BuildServiceProvider();
         cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
         return provider;
     }

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/L2Tests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/L2Tests.cs
@@ -38,7 +38,7 @@ public class L2Tests(ITestOutputHelper log)
         var localCache = new MemoryDistributedCache(localCacheOptions);
         services.AddSingleton<IDistributedCache>(buffers ? new BufferLoggingCache(Log, localCache) : new LoggingCache(Log, localCache));
         services.AddHybridCache();
-        var provider = services.BuildServiceProvider();
+        ServiceProvider provider = services.BuildServiceProvider();
         cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
         return provider;
     }

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/RedisTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/RedisTests.cs
@@ -45,7 +45,7 @@ public class RedisTests : DistributedCacheTests, IClassFixture<RedisFixture>
         var services = new ServiceCollection();
         await ConfigureAsync(services);
         services.AddHybridCache();
-        var provider = services.BuildServiceProvider(); // not "using" - that will tear down our redis; use the fixture for that
+        ServiceProvider provider = services.BuildServiceProvider(); // not "using" - that will tear down our redis; use the fixture for that
 
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
         if (cache.BackendCache is null)

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SampleUsage.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SampleUsage.cs
@@ -16,7 +16,7 @@ public class SampleUsage
         var services = new ServiceCollection();
         services.AddDistributedMemoryCache();
         services.AddTransient<SomeDCService>();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
 
         var obj = provider.GetRequiredService<SomeDCService>();
         string name = "abc";
@@ -36,7 +36,7 @@ public class SampleUsage
         var services = new ServiceCollection();
         services.AddHybridCache();
         services.AddTransient<SomeHCService>();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
 
         var obj = provider.GetRequiredService<SomeHCService>();
         string name = "abc";
@@ -56,7 +56,7 @@ public class SampleUsage
         var services = new ServiceCollection();
         services.AddHybridCache();
         services.AddTransient<SomeHCServiceNoCapture>();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
 
         var obj = provider.GetRequiredService<SomeHCServiceNoCapture>();
         string name = "abc";
@@ -76,7 +76,7 @@ public class SampleUsage
         var services = new ServiceCollection();
         services.AddHybridCache();
         services.AddTransient<SomeHCServiceNoCaptureObjReuse>();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
 
         var obj = provider.GetRequiredService<SomeHCServiceNoCaptureObjReuse>();
         string name = "abc";

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ServiceConstructionTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/ServiceConstructionTests.cs
@@ -27,7 +27,7 @@ public class ServiceConstructionTests
     {
         var services = new ServiceCollection();
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         Assert.IsType<DefaultHybridCache>(provider.GetService<HybridCache>());
     }
 
@@ -40,7 +40,7 @@ public class ServiceConstructionTests
             options.MaximumKeyLength = 937;
             options.DefaultEntryOptions = new() { Expiration = TimeSpan.FromSeconds(120), Flags = HybridCacheEntryFlags.DisableLocalCacheRead };
         });
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var obj = Assert.IsType<DefaultHybridCache>(provider.GetService<HybridCache>());
         var options = obj.Options;
         Assert.Equal(937, options.MaximumKeyLength);
@@ -88,7 +88,7 @@ public class ServiceConstructionTests
     {
         var services = new ServiceCollection();
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = provider.GetRequiredService<HybridCache>();
 
         var expected = Guid.NewGuid().ToString();
@@ -101,7 +101,7 @@ public class ServiceConstructionTests
     {
         var services = new ServiceCollection();
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = provider.GetRequiredService<HybridCache>();
 
         var expected = Guid.NewGuid().ToString();
@@ -114,7 +114,7 @@ public class ServiceConstructionTests
     {
         var services = new ServiceCollection();
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         Assert.IsType<InbuiltTypeSerializer>(cache.GetSerializer<string>());
@@ -128,7 +128,7 @@ public class ServiceConstructionTests
     {
         var services = new ServiceCollection();
         services.AddHybridCache().AddSerializer<Customer, CustomerSerializer>();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         Assert.IsType<CustomerSerializer>(cache.GetSerializer<Customer>());
@@ -140,7 +140,7 @@ public class ServiceConstructionTests
     {
         var services = new ServiceCollection();
         services.AddHybridCache().AddSerializerFactory<CustomFactory>();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         Assert.IsType<CustomerSerializer>(cache.GetSerializer<Customer>());
@@ -163,7 +163,7 @@ public class ServiceConstructionTests
         }
 
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         Assert.Null(cache.BackendCache);
@@ -175,7 +175,7 @@ public class ServiceConstructionTests
         var services = new ServiceCollection();
         services.AddSingleton<IDistributedCache, CustomMemoryDistributedCache>();
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         Assert.NotNull(cache.BackendCache);
@@ -198,7 +198,7 @@ public class ServiceConstructionTests
 
         services.AddSingleton<IMemoryCache, CustomMemoryCache>();
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         Assert.NotNull(cache.BackendCache);

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Caching.Hybrid.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Caching.Hybrid.Tests;
+
+public class SizeTests
+{
+    [Theory]
+    [InlineData(null, true)] // does not enforce size limits
+    [InlineData(8L, false)] // unreasonably small limt; chosen because our test string has length 12 - hence no expectation to find the second time
+    [InlineData(1024L, true)] // reasonable size limit
+    public async Task ValidateSizeLimit_Immutable(long? sizeLimit, bool expectFromL1)
+    {
+        var services = new ServiceCollection();
+        services.AddMemoryCache(options => options.SizeLimit = sizeLimit);
+        services.AddHybridCache();
+        using var provider = services.BuildServiceProvider();
+        var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
+
+        const string Key = "abc";
+
+        // this looks weird; it is intentionally not a const - we want to check
+        // same instance without worrying about interning from raw literals
+        string expected = new("simple value".ToArray());
+        var actual = await cache.GetOrCreateAsync<string>(Key, ct => new(expected));
+
+        // expect same contents
+        Assert.Equal(expected, actual);
+
+        // expect same instance, because string is special-cased as a type
+        // that doesn't need defensive copies
+        Assert.Same(expected, actual);
+
+        // rinse and repeat, to check we get the value from L1
+        actual = await cache.GetOrCreateAsync<string>(Key, ct => new(Guid.NewGuid().ToString()));
+
+        if (expectFromL1)
+        {
+            // expect same contents from L1
+            Assert.Equal(expected, actual);
+
+            // expect same instance, because string is special-cased as a type
+            // that doesn't need defensive copies
+            Assert.Same(expected, actual);
+        }
+        else
+        {
+            // L1 cache not used
+            Assert.NotEqual(expected, actual);
+        }
+    }
+
+    [Theory]
+    [InlineData(null, true)] // does not enforce size limits
+    [InlineData(8L, false)] // unreasonably small limt; chosen because our test string has length 12 - hence no expectation to find the second time
+    [InlineData(1024L, true)] // reasonable size limit
+    public async Task ValidateSizeLimit_Mutable(long? sizeLimit, bool expectFromL1)
+    {
+        var services = new ServiceCollection();
+        services.AddMemoryCache(options => options.SizeLimit = sizeLimit);
+        services.AddHybridCache();
+        using var provider = services.BuildServiceProvider();
+        var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
+
+        const string Key = "abc";
+
+        string expected = "simple value";
+        var actual = await cache.GetOrCreateAsync<MutablePoco>(Key, ct => new(new MutablePoco { Value = expected }));
+
+        // expect same contents
+        Assert.Equal(expected, actual.Value);
+
+        // rinse and repeat, to check we get the value from L1
+        actual = await cache.GetOrCreateAsync<MutablePoco>(Key, ct => new(new MutablePoco { Value = Guid.NewGuid().ToString() }));
+
+        if (expectFromL1)
+        {
+            // expect same contents from L1
+            Assert.Equal(expected, actual.Value);
+        }
+        else
+        {
+            // L1 cache not used
+            Assert.NotEqual(expected, actual.Value);
+        }
+    }
+
+    public class MutablePoco
+    {
+        public string Value { get; set; } = "";
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
@@ -10,7 +10,7 @@ public class SizeTests
 {
     [Theory]
     [InlineData(null, true)] // does not enforce size limits
-    [InlineData(8L, false)] // unreasonably small limt; chosen because our test string has length 12 - hence no expectation to find the second time
+    [InlineData(8L, false)] // unreasonably small limit; chosen because our test string has length 12 - hence no expectation to find the second time
     [InlineData(1024L, true)] // reasonable size limit
     public async Task ValidateSizeLimit_Immutable(long? sizeLimit, bool expectFromL1)
     {
@@ -55,7 +55,7 @@ public class SizeTests
 
     [Theory]
     [InlineData(null, true)] // does not enforce size limits
-    [InlineData(8L, false)] // unreasonably small limt; chosen because our test string has length 12 - hence no expectation to find the second time
+    [InlineData(8L, false)] // unreasonably small limit; chosen because our test string has length 12 - hence no expectation to find the second time
     [InlineData(1024L, true)] // reasonable size limit
     public async Task ValidateSizeLimit_Mutable(long? sizeLimit, bool expectFromL1)
     {

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/SizeTests.cs
@@ -17,7 +17,7 @@ public class SizeTests
         var services = new ServiceCollection();
         services.AddMemoryCache(options => options.SizeLimit = sizeLimit);
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         const string Key = "abc";
@@ -62,7 +62,7 @@ public class SizeTests
         var services = new ServiceCollection();
         services.AddMemoryCache(options => options.SizeLimit = sizeLimit);
         services.AddHybridCache();
-        using var provider = services.BuildServiceProvider();
+        using ServiceProvider provider = services.BuildServiceProvider();
         var cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
 
         const string Key = "abc";

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/StampedeTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/StampedeTests.cs
@@ -24,7 +24,7 @@ public class StampedeTests
                 Flags = HybridCacheEntryFlags.DisableDistributedCache | HybridCacheEntryFlags.DisableLocalCache
             };
         });
-        var provider = services.BuildServiceProvider();
+        ServiceProvider provider = services.BuildServiceProvider();
         cache = Assert.IsType<DefaultHybridCache>(provider.GetRequiredService<HybridCache>());
         return provider;
     }


### PR DESCRIPTION
Context: https://github.com/dotnet/aspnetcore/discussions/57582 - `MemoryCache` *may* (opt-in) be enforcing size constraints; to satisfy that scenario, every L1 "set" operation must include an [`ICacheEntry.Size`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.caching.memory.icacheentry.size)

(primary review here is probably from aspnetcore; all eyes are welcome, of course)

At first this sounds simple, but it means that we may need to serialize before we set the result, but we want to retain that buffer for the L2 write, which happens after we've supplied the value to the consumer. This requires a little bit of additional gymnastics; lots of comments included. Note also that `BufferReleaseTests` already has tests to ensure correct buffer release semantics.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5420)