### PR TITLE
Add NullRedactor to the RedactorProvider during initialization

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/RedactorProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/RedactorProvider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.Extensions.Compliance.Classification;
 using Microsoft.Extensions.Options;
 using Microsoft.Shared.Diagnostics;
@@ -41,7 +40,7 @@ internal sealed class RedactorProvider : IRedactorProvider
         if (!map.ContainsKey(DataClassification.None))
         {
             map.Add(DataClassification.None, typeof(NullRedactor));
-            redactors = redactors.Concat([NullRedactor.Instance]);
+            redactors = [.. redactors, NullRedactor.Instance];
         }
 
         var dict = new Dictionary<DataClassificationSet, Redactor>(map.Count);

--- a/src/Libraries/Microsoft.Extensions.Compliance.Redaction/RedactorProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Compliance.Redaction/RedactorProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.Extensions.Compliance.Classification;
 using Microsoft.Extensions.Options;
 using Microsoft.Shared.Diagnostics;
@@ -37,6 +38,12 @@ internal sealed class RedactorProvider : IRedactorProvider
 
     private static FrozenDictionary<DataClassificationSet, Redactor> GetClassRedactorMap(IEnumerable<Redactor> redactors, Dictionary<DataClassificationSet, Type> map)
     {
+        if (!map.ContainsKey(DataClassification.None))
+        {
+            map.Add(DataClassification.None, typeof(NullRedactor));
+            redactors = redactors.Concat([NullRedactor.Instance]);
+        }
+
         var dict = new Dictionary<DataClassificationSet, Redactor>(map.Count);
         foreach (var m in map)
         {
@@ -45,6 +52,7 @@ internal sealed class RedactorProvider : IRedactorProvider
                 if (r.GetType() == m.Value)
                 {
                     dict[m.Key] = r;
+                    break;
                 }
             }
         }

--- a/test/Libraries/Microsoft.Extensions.Compliance.Redaction.Tests/RedactorProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Compliance.Redaction.Tests/RedactorProviderTests.cs
@@ -11,6 +11,16 @@ namespace Microsoft.Extensions.Compliance.Redaction.Test;
 public class RedactorProviderTests
 {
     [Fact]
+    public void RedactorProvider_Returns_NullRedactor_For_NoneDataClassification()
+    {
+        var redactorProvider = new RedactorProvider(
+            redactors: [ErasingRedactor.Instance],
+            options: Microsoft.Extensions.Options.Options.Create(new RedactorProviderOptions()));
+
+        Assert.IsType<NullRedactor>(redactorProvider.GetRedactor(DataClassification.None));
+    }
+
+    [Fact]
     public void RedactorProvider_Returns_Redactor_For_Every_Data_Classification()
     {
         var dc = new DataClassification("Foo", "0x2");
@@ -38,13 +48,15 @@ public class RedactorProviderTests
             redactors: new Redactor[] { ErasingRedactor.Instance, NullRedactor.Instance },
             options: Microsoft.Extensions.Options.Options.Create(opt));
 
-        var r1 = redactorProvider.GetRedactor(_dataClassification1);
-        var r2 = redactorProvider.GetRedactor(_dataClassification2);
-        var r3 = redactorProvider.GetRedactor(_dataClassification3);
+        Redactor r1 = redactorProvider.GetRedactor(_dataClassification1);
+        Redactor r2 = redactorProvider.GetRedactor(_dataClassification2);
+        Redactor r3 = redactorProvider.GetRedactor(_dataClassification3);
+        Redactor r4 = redactorProvider.GetRedactor(DataClassification.None);
 
-        Assert.Equal(typeof(ErasingRedactor), r1.GetType());
-        Assert.Equal(typeof(NullRedactor), r2.GetType());
-        Assert.Equal(typeof(ErasingRedactor), r3.GetType());
+        Assert.IsType<ErasingRedactor>(r1);
+        Assert.IsType<NullRedactor>(r2);
+        Assert.IsType<ErasingRedactor>(r3);
+        Assert.IsType<NullRedactor>(r4);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #5265 - RedactorProvider returns ErasingRedactor for DataClassification.None type

Prior to this PR, the below unit test was failing because NullRedactor's not included in RedactorProvider's `_classRedactors` by default.
```
    [Fact]
    public void RedactorProvider_Returns_NullRedactor_For_NoneDataClassification()
    {
        var redactorProvider = new RedactorProvider(
            redactors: [ErasingRedactor.Instance],
            options: Microsoft.Extensions.Options.Options.Create(new RedactorProviderOptions()));

        Assert.IsType<NullRedactor>(redactorProvider.GetRedactor(DataClassification.None));
    }
```

This PR adds the `NullRedactor` to `RedactorProvider` when being initialized if the redactorMap doesn't contain `DataClassification.None`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5424)