### PR TITLE
Fix test warning in 9.0

### DIFF
--- a/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.LogProperties.cs
+++ b/test/Generators/Microsoft.Gen.Logging/Unit/ParserTests.LogProperties.cs
@@ -482,8 +482,7 @@ public partial class ParserTests
                 Assembly.GetAssembly(typeof(DateTime))!,
             },
             [source],
-            symbols)
-            .ConfigureAwait(false);
+            symbols);
 
         Assert.Empty(d);
         await Verifier.Verify(r[0].SourceText.ToString())


### PR DESCRIPTION
Test methods should not call ConfigureAwait(false), as it may bypass parallelization limits. Omit ConfigureAwait, or use ConfigureAwait(true) to avoid CA2007. (https://xunit.net/xunit.analyzers/rules/xUnit1030)

This is blocking #5435 

See https://github.com/dotnet/extensions/pull/5435/checks?check_run_id=30404388453

cc @rwoll
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5437)