### PR TITLE
Clarify HttpRetryStrategyOptions/HttpHedgingStrategyOptions XML doc

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HttpHedgingStrategyOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HttpHedgingStrategyOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http;
 using System.Threading.Tasks;
+using Polly.CircuitBreaker;
 using Polly.Hedging;
 using Polly.Timeout;
 
@@ -19,7 +20,7 @@ public class HttpHedgingStrategyOptions : HedgingStrategyOptions<HttpResponseMes
     /// <remarks>
     /// By default, the options are configured to handle only transient failures.
     /// Specifically, this includes HTTP status codes 408, 429, 500 and above, 
-    /// as well as <see cref="HttpRequestException"/> and <see cref="TimeoutRejectedException"/> exceptions.
+    /// as well as <see cref="HttpRequestException"/>, <see cref="BrokenCircuitException"/>, and <see cref="TimeoutRejectedException"/> exceptions.
     /// </remarks>
     public HttpHedgingStrategyOptions()
     {

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HttpHedgingStrategyOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HttpHedgingStrategyOptions.cs
@@ -4,6 +4,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Polly.Hedging;
+using Polly.Timeout;
 
 namespace Microsoft.Extensions.Http.Resilience;
 
@@ -16,8 +17,9 @@ public class HttpHedgingStrategyOptions : HedgingStrategyOptions<HttpResponseMes
     /// Initializes a new instance of the <see cref="HttpHedgingStrategyOptions"/> class.
     /// </summary>
     /// <remarks>
-    /// By default, the options are set to handle only transient failures,
-    /// that is, timeouts, 5xx responses, and <see cref="HttpRequestException"/> exceptions.
+    /// By default, the options are configured to handle only transient failures.
+    /// Specifically, this includes HTTP status codes 408, 429, 500 and above, 
+    /// as well as <see cref="HttpRequestException"/> and <see cref="TimeoutRejectedException"/> exceptions.
     /// </remarks>
     public HttpHedgingStrategyOptions()
     {

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpRetryStrategyOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpRetryStrategyOptions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Http.Resilience.Internal;
 using Polly;
 using Polly.Retry;
+using Polly.Timeout;
 
 namespace Microsoft.Extensions.Http.Resilience;
 
@@ -21,8 +22,10 @@ public class HttpRetryStrategyOptions : RetryStrategyOptions<HttpResponseMessage
     /// Initializes a new instance of the <see cref="HttpRetryStrategyOptions"/> class.
     /// </summary>
     /// <remarks>
-    /// By default, the options are set to handle only transient failures,
-    /// that is, timeouts, 5xx responses, and <see cref="HttpRequestException"/> exceptions.
+    /// By default, the options are configured to handle only transient failures.
+    /// Specifically, this includes HTTP status codes 408, 429, 500 and above, 
+    /// as well as <see cref="HttpRequestException"/> and <see cref="TimeoutRejectedException"/> exceptions.
+    /// Additionally, if the response includes a <c>Retry-After</c> header, its value will be used to determine the delay before retrying.
     /// </remarks>
     public HttpRetryStrategyOptions()
     {

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpRetryStrategyOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Polly/HttpRetryStrategyOptions.cs
@@ -25,7 +25,6 @@ public class HttpRetryStrategyOptions : RetryStrategyOptions<HttpResponseMessage
     /// By default, the options are configured to handle only transient failures.
     /// Specifically, this includes HTTP status codes 408, 429, 500 and above, 
     /// as well as <see cref="HttpRequestException"/> and <see cref="TimeoutRejectedException"/> exceptions.
-    /// Additionally, if the response includes a <c>Retry-After</c> header, its value will be used to determine the delay before retrying.
     /// </remarks>
     public HttpRetryStrategyOptions()
     {


### PR DESCRIPTION
Clarify HttpRetryStrategyOptions/HttpHedgingStrategyOptions XML doc, specifically:
- The HTTP status code 429 was missing.
- Some exceptions were missing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5445)