### PR TITLE
Allowing tags to start with _

### DIFF
--- a/src/Generators/Microsoft.Gen.Metrics/Parser.cs
+++ b/src/Generators/Microsoft.Gen.Metrics/Parser.cs
@@ -22,7 +22,7 @@ internal sealed class Parser
     private const int MaxTagNames = 30;
 
     private static readonly Regex _regex = new("^[A-Z]+[A-za-z0-9]*$", RegexOptions.Compiled);
-    private static readonly Regex _regexTagNames = new("^[A-Za-z]+[A-Za-z0-9_.:-]*$", RegexOptions.Compiled);
+    private static readonly Regex _regexTagNames = new("^[A-Za-z_]+[A-Za-z0-9_.:-]*$", RegexOptions.Compiled);
     private static readonly SymbolDisplayFormat _typeSymbolFormat =
         SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
             SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);

--- a/test/Generators/Microsoft.Gen.Metrics/Unit/ParserTests.cs
+++ b/test/Generators/Microsoft.Gen.Metrics/Unit/ParserTests.cs
@@ -144,7 +144,7 @@ public partial class ParserTests
         var d = await RunGenerator(@"
             partial class C
             {
-                [Counter(""Env.Name"", ""clustr:region"", ""Req_Name"", ""Req-Status"")]
+                [Counter(""Env.Name"", ""clustr:region"", ""Req_Name"", ""Req-Status"", ""_microsoft_metrics_namespace"")]
                 static partial TestCounter CreateMetricName(Meter meter, string env, string region);
             }");
 


### PR DESCRIPTION
Making it possible for tags to start with _

We want to use OT exporter with code gen. However, to override namespaces, we need to pass a tag which starts with "_"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5478)