### PR TITLE
Flip default on FunctionInvokingChatClient.ConcurrentInvocation

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -82,15 +82,14 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// <remarks>
     /// <para>
     /// An individual response from the inner client may contain multiple function call requests.
-    /// By default, such function calls may be issued to execute concurrently with each other. Set
-    /// <see cref="ConcurrentInvocation"/> to false to disable such concurrent invocation and force
-    /// the functions to be invoked serially.
+    /// By default, such function calls are processed serially. Set <see cref="ConcurrentInvocation"/> to
+    /// true to enable concurrent invocation such that multiple function calls may execute in parallel.
     /// </para>
     /// <para>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </para>
     /// </remarks>
-    public bool ConcurrentInvocation { get; set; } = true;
+    public bool ConcurrentInvocation { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to keep intermediate messages in the chat history.

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -83,7 +83,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
     /// <para>
     /// An individual response from the inner client may contain multiple function call requests.
     /// By default, such function calls are processed serially. Set <see cref="ConcurrentInvocation"/> to
-    /// true to enable concurrent invocation such that multiple function calls may execute in parallel.
+    /// <see langword="true"/> to enable concurrent invocation such that multiple function calls may execute in parallel.
     /// </para>
     /// <para>
     /// The default value is <see langword="false"/>.


### PR DESCRIPTION
For better reliability, default ConcurrentInvocation to false, so that it doesn't introduce concurrency / parallelism where there wasn't any.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5485)