### PR TITLE
Remove x64 hardcoding from global.json runtimes

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,11 +5,11 @@
   "tools": {
     "dotnet": "9.0.100-rtm.24479.2",
     "runtimes": {
-      "dotnet/x64": [
+      "dotnet": [
         "8.0.0",
         "9.0.0-rc.1.24431.7"
       ],
-      "aspnetcore/x64": [
+      "aspnetcore": [
         "8.0.0",
         "9.0.0-rc.1.24452.1"
       ]


### PR DESCRIPTION
Resulting in a few errors in my arm64 dev machine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5488)