### PR TITLE
Sanitize structured output schema type name to satisfy restrictions

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
@@ -11,10 +11,10 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Schema;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
+using static Microsoft.Extensions.AI.FunctionCallHelpers;
 
 namespace Microsoft.Extensions.AI;
 
@@ -225,21 +225,4 @@ public static partial class ChatClientStructuredOutputExtensions
     [JsonSerializable(typeof(JsonNode))]
     [JsonSourceGenerationOptions(WriteIndented = true)]
     private sealed partial class JsonNodeContext : JsonSerializerContext;
-
-    /// <summary>
-    /// Remove characters from type name that are valid in metadata but shouldn't be used in a schema name.
-    /// Removes arrays and generic type parameters, and replaces invalid characters with underscores.
-    /// </summary>
-    private static string SanitizeMetadataName(string typeName) =>
-        InvalidNameCharsRegex().Replace(typeName, "_");
-
-    /// <summary>Regex that flags any character other than ASCII digits or letters or the underscore.</summary>
-#if NET
-    [GeneratedRegex("[^0-9A-Za-z_]")]
-    private static partial Regex InvalidNameCharsRegex();
-#else
-    private static Regex InvalidNameCharsRegex() => _invalidNameCharsRegex;
-    private static readonly Regex _invalidNameCharsRegex = new("[^0-9A-Za-z_]", RegexOptions.Compiled);
-#endif
-
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -21,11 +21,7 @@ using static Microsoft.Extensions.AI.FunctionCallHelpers;
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Provides factory methods for creating commonly-used implementations of <see cref="AIFunction"/>.</summary>
-public static
-#if NET
-    partial
-#endif
-    class AIFunctionFactory
+public static class AIFunctionFactory
 {
     internal const string UsesReflectionJsonSerializerMessage =
         "This method uses the reflection-based JsonSerializer which can break in trimmed or AOT applications.";
@@ -107,11 +103,7 @@ public static
         return new ReflectionAIFunction(method, target, options);
     }
 
-    private sealed
-#if NET
-        partial
-#endif
-        class ReflectionAIFunction : AIFunction
+    private sealed class ReflectionAIFunction : AIFunction
     {
         private readonly MethodInfo _method;
         private readonly object? _target;

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -12,11 +12,11 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Shared.Collections;
 using Microsoft.Shared.Diagnostics;
+using static Microsoft.Extensions.AI.FunctionCallHelpers;
 
 namespace Microsoft.Extensions.AI;
 
@@ -474,21 +474,5 @@ public static
 #pragma warning restore S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
             return specializedType.GetMethods(All).First(m => m.MetadataToken == genericMethodDefinition.MetadataToken);
         }
-
-        /// <summary>
-        /// Remove characters from method name that are valid in metadata but shouldn't be used in a method name.
-        /// This is primarily intended to remove characters emitted by for compiler-generated method name mangling.
-        /// </summary>
-        private static string SanitizeMetadataName(string methodName) =>
-            InvalidNameCharsRegex().Replace(methodName, "_");
-
-        /// <summary>Regex that flags any character other than ASCII digits or letters or the underscore.</summary>
-#if NET
-        [GeneratedRegex("[^0-9A-Za-z_]")]
-        private static partial Regex InvalidNameCharsRegex();
-#else
-        private static Regex InvalidNameCharsRegex() => _invalidNameCharsRegex;
-        private static readonly Regex _invalidNameCharsRegex = new("[^0-9A-Za-z_]", RegexOptions.Compiled);
-#endif
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
@@ -173,6 +173,40 @@ public class ChatClientStructuredOutputExtensionsTests
     }
 
     [Fact]
+    public async Task CanUseNativeStructuredOutputWithSanitizedTypeName()
+    {
+        var expectedResult = new Data<Animal> { Value = new Animal { Id = 1, FullName = "Tigger", Species = Species.Tiger } };
+        var expectedCompletion = new ChatCompletion([new ChatMessage(ChatRole.Assistant, JsonSerializer.Serialize(expectedResult))]);
+
+        using var client = new TestChatClient
+        {
+            CompleteAsyncCallback = (messages, options, cancellationToken) =>
+            {
+                var responseFormat = Assert.IsType<ChatResponseFormatJson>(options!.ResponseFormat);
+
+                Assert.Matches("^[a-zA-Z0-9_-]+$", responseFormat.SchemaName);
+
+                return Task.FromResult(expectedCompletion);
+            },
+        };
+
+        var chatHistory = new List<ChatMessage> { new(ChatRole.User, "Hello") };
+        var response = await client.CompleteAsync<Data<Animal>>(chatHistory, useNativeJsonSchema: true);
+
+        // The completion contains the deserialized result and other completion properties
+        Assert.Equal(1, response.Result!.Value!.Id);
+        Assert.Equal("Tigger", response.Result.Value.FullName);
+        Assert.Equal(Species.Tiger, response.Result.Value.Species);
+
+        // TryGetResult returns the same value
+        Assert.True(response.TryGetResult(out var tryGetResultOutput));
+        Assert.Same(response.Result, tryGetResultOutput);
+
+        // History remains unmutated
+        Assert.Equal("Hello", Assert.Single(chatHistory).Text);
+    }
+
+    [Fact]
     public async Task CanSpecifyCustomJsonSerializationOptions()
     {
         var jso = new JsonSerializerOptions
@@ -245,6 +279,11 @@ public class ChatClientStructuredOutputExtensionsTests
         public int Id { get; set; }
         public string? FullName { get; set; }
         public Species Species { get; set; }
+    }
+
+    private class Data<T>
+    {
+        public T? Value { get; set; }
     }
 
     private enum Species

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
@@ -184,7 +184,7 @@ public class ChatClientStructuredOutputExtensionsTests
             {
                 var responseFormat = Assert.IsType<ChatResponseFormatJson>(options!.ResponseFormat);
 
-                Assert.Matches("^[a-zA-Z0-9_-]+$", responseFormat.SchemaName);
+                Assert.Matches("Data_1", responseFormat.SchemaName);
 
                 return Task.FromResult(expectedCompletion);
             },


### PR DESCRIPTION
The underlying native schema support in OpenAI has specific requirements on valid schema names, as shown in the following exception when using either an array or any other generic type:

```
Unhandled exception. System.ClientModel.ClientResultException: HTTP 400 (invalid_request_error: invalid_value)
Parameter: response_format.json_schema.name

Invalid 'response_format.json_schema.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
   at OpenAI.ClientPipelineExtensions.ProcessMessageAsync(ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
```

This fix follows the approach used to sanitize function names, and sanitizes the schema name the same way.

Fixes #5501
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5504)