### PR TITLE
Improve CachingChatClient's coalescing of streaming updates

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/AdditionalPropertiesDictionary.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/AdditionalPropertiesDictionary.cs
@@ -40,6 +40,13 @@ public sealed class AdditionalPropertiesDictionary : IDictionary<string, object?
 #endif
     }
 
+    /// <summary>Creates a shallow clone of the properties dictionary.</summary>
+    /// <returns>
+    /// A shallow clone of the properties dictionary. The instance will not be the same as the current instance,
+    /// but it will contain all of the same key-value pairs.
+    /// </returns>
+    public AdditionalPropertiesDictionary Clone() => new AdditionalPropertiesDictionary(_dictionary);
+
     /// <inheritdoc />
     public object? this[string key]
     {

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
@@ -73,6 +73,7 @@ public class ChatOptions
             ResponseFormat = ResponseFormat,
             ModelId = ModelId,
             ToolMode = ToolMode,
+            AdditionalProperties = AdditionalProperties?.Clone(),
         };
 
         if (StopSequences is not null)
@@ -83,11 +84,6 @@ public class ChatOptions
         if (Tools is not null)
         {
             options.Tools = new List<AITool>(Tools);
-        }
-
-        if (AdditionalProperties is not null)
-        {
-            options.AdditionalProperties = new(AdditionalProperties);
         }
 
         return options;

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGenerationOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Embeddings/EmbeddingGenerationOptions.cs
@@ -18,18 +18,10 @@ public class EmbeddingGenerationOptions
     /// The clone will have the same values for all properties as the original instance. Any collections, like <see cref="AdditionalProperties"/>
     /// are shallow-cloned, meaning a new collection instance is created, but any references contained by the collections are shared with the original.
     /// </remarks>
-    public virtual EmbeddingGenerationOptions Clone()
-    {
-        EmbeddingGenerationOptions options = new()
+    public virtual EmbeddingGenerationOptions Clone() =>
+        new()
         {
             ModelId = ModelId,
+            AdditionalProperties = AdditionalProperties?.Clone(),
         };
-
-        if (AdditionalProperties is not null)
-        {
-            options.AdditionalProperties = new(AdditionalProperties);
-        }
-
-        return options;
-    }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/CachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/CachingChatClient.cs
@@ -163,7 +163,6 @@ public abstract class CachingChatClient : DelegatingChatClient
                         TextContent nextContent = (TextContent)next.Contents[0];
                         _ = coalescedText.Append(nextContent.Text);
 
-                        coalesced.AdditionalProperties = MergeProperties(coalesced.AdditionalProperties, next.AdditionalProperties);
                         coalesced.AuthorName ??= next.AuthorName;
                         coalesced.CompletionId ??= next.CompletionId;
                         coalesced.CreatedAt ??= next.CreatedAt;
@@ -171,7 +170,6 @@ public abstract class CachingChatClient : DelegatingChatClient
                         coalesced.Role ??= next.Role;
 
                         coalescedContent.ModelId ??= nextContent.ModelId;
-                        coalescedContent.AdditionalProperties = MergeProperties(coalescedContent.AdditionalProperties, nextContent.AdditionalProperties);
                     }
 
                     // Complete the coalescing by patching the text of the coalesced node.
@@ -237,27 +235,4 @@ public abstract class CachingChatClient : DelegatingChatClient
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Task"/> representing the completion of the operation.</returns>
     protected abstract Task WriteCacheStreamingAsync(string key, IReadOnlyList<StreamingChatCompletionUpdate> value, CancellationToken cancellationToken);
-
-    /// <summary>Merges the properties from source into target.</summary>
-    /// <returns>
-    /// <paramref name="target"/> if <paramref name="target"/> is not <see langword="null"/> or if <paramref name="source"/> is <see langword="null"/> or empty.
-    /// Otherwise, a clone of <paramref name="source"/>.
-    /// </returns>
-    private static AdditionalPropertiesDictionary? MergeProperties(AdditionalPropertiesDictionary? target, AdditionalPropertiesDictionary? source)
-    {
-        if (source is { Count: > 0 })
-        {
-            if (target is null)
-            {
-                return source.Clone();
-            }
-
-            foreach (var entry in source)
-            {
-                target[entry.Key] = entry.Value;
-            }
-        }
-
-        return target;
-    }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
@@ -387,8 +387,6 @@ public class DistributedCachingChatClientTest
         var content = Assert.IsType<TextContent>(Assert.Single(item.Contents));
         Assert.Equal("Hello world, how are you?", content.Text);
         Assert.Equal("some model", content.ModelId);
-        Assert.NotNull(content.AdditionalProperties);
-        Assert.Equal(4, content.AdditionalProperties.Count);
     }
 
     [Fact]


### PR DESCRIPTION
- Avoid O(N^2) memory allocation in the length of the received text
- Propagate additional metadata from coalesced nodes
- Propagate metadata on the coalesced TextContent, like ModelId
- Expose whether to coalesce as a setting on the client

Fixes https://github.com/dotnet/extensions/issues/5481
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5514)