### PR TITLE
Add support for arrays, enums and primitive types

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
@@ -191,13 +191,7 @@ public static class ChatClientStructuredOutputExtensions
         try
         {
             var result = await chatClient.CompleteAsync(chatMessages, options, cancellationToken).ConfigureAwait(false);
-            if (wrapped)
-            {
-                // We don't initialize the dictionary unless we need it, to avoid unnecessary allocations.
-                result.AdditionalProperties ??= [];
-                result.AdditionalProperties["$wrapped"] = true;
-            }
-
+            result.SetWrapped(wrapped);
             return new ChatCompletion<T>(result, serializerOptions);
         }
         finally
@@ -207,5 +201,20 @@ public static class ChatClientStructuredOutputExtensions
                 _ = chatMessages.Remove(promptAugmentation);
             }
         }
+    }
+
+    internal static bool IsWrapped(this ChatCompletion completion) =>
+        completion.AdditionalProperties?.TryGetValue("$wrapped", out var value) == true && value is bool wrapped && wrapped;
+
+    private static void SetWrapped(this ChatCompletion completion, bool wrapped)
+    {
+        if (!wrapped)
+        {
+            return;
+        }
+
+        // We don't initialize the dictionary unless we need it, to avoid unnecessary allocations.
+        completion.AdditionalProperties ??= [];
+        completion.AdditionalProperties["$wrapped"] = true;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatCompletion{T}.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatCompletion{T}.cs
@@ -126,11 +126,10 @@ public class ChatCompletion<T> : ChatCompletion
         }
 
         T? deserialized = default;
-        var wrapped = AdditionalProperties?.TryGetValue("$wrapped", out var isWrappedValue) == true && isWrappedValue is bool isWrappedBool && isWrappedBool;
 
         // If there's an exception here, we want it to propagate, since the Result property is meant to throw directly
 
-        if (wrapped)
+        if (this.IsWrapped())
         {
             var doc = JsonDocument.Parse(json!);
             if (doc.RootElement.TryGetProperty("data", out var data))

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -579,15 +580,89 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
+        // For openai, we can use the native JSON schema support
         var response = await _chatClient.CompleteAsync<Person>("""
             Who is described in the following sentence?
             Jimbo Smith is a 35-year-old software developer from Cardiff, Wales.
-            """);
+            """,
+            useNativeJsonSchema: _chatClient.Metadata.ProviderName == "openai");
 
         Assert.Equal("Jimbo Smith", response.Result.FullName);
         Assert.Equal(35, response.Result.AgeInYears);
         Assert.Contains("Cardiff", response.Result.HomeTown);
         Assert.Equal(JobType.Programmer, response.Result.Job);
+    }
+
+    [ConditionalFact]
+    public virtual async Task CompleteAsync_StructuredOutputArray()
+    {
+        SkipIfNotEnabled();
+
+        var response = await _chatClient.CompleteAsync<Person[]>("""
+            Who are described in the following sentence?
+            Jimbo Smith is a 35-year-old software developer from Cardiff, Wales.
+            Josh Simpson is a 25-year-old software developer from Newport, Wales.
+            """,
+            useNativeJsonSchema: _chatClient.Metadata.ProviderName == "openai");
+
+        Assert.Equal(2, response.Result.Length);
+        Assert.Contains(response.Result, x => x.FullName == "Jimbo Smith");
+        Assert.Contains(response.Result, x => x.FullName == "Josh Simpson");
+    }
+
+    [ConditionalFact]
+    public virtual async Task CompleteAsync_StructuredOutputInteger()
+    {
+        SkipIfNotEnabled();
+
+        var response = await _chatClient.CompleteAsync<int>("""
+            As of today (october 2024), Jimbo Smith is a 35-year-old software developer from Cardiff, Wales.
+            Which year was he born in?
+            """,
+            useNativeJsonSchema: _chatClient.Metadata.ProviderName == "openai");
+
+        Assert.Equal(1989, response.Result);
+    }
+
+    [ConditionalFact]
+    public virtual async Task CompleteAsync_StructuredOutputString()
+    {
+        SkipIfNotEnabled();
+
+        var response = await _chatClient.CompleteAsync<string>("""
+            The software developer, Jimbo Smith, is a 35-year-old software developer from Cardiff, Wales.
+            What's his full name?
+            """,
+            useNativeJsonSchema: _chatClient.Metadata.ProviderName == "openai");
+
+        Assert.Equal("Jimbo Smith", response.Result);
+    }
+
+    [ConditionalFact]
+    public virtual async Task CompleteAsync_StructuredOutputBool()
+    {
+        SkipIfNotEnabled();
+
+        var response = await _chatClient.CompleteAsync<bool>("""
+            The software developer, Jimbo Smith, is a 35-year-old software developer from Cardiff, Wales.
+            Is he a medical doctor?
+            """,
+            useNativeJsonSchema: _chatClient.Metadata.ProviderName == "openai");
+
+        Assert.False(response.Result);
+    }
+
+    [ConditionalFact]
+    public virtual async Task CompleteAsync_StructuredOutputEnum()
+    {
+        SkipIfNotEnabled();
+
+        var response = await _chatClient.CompleteAsync<Architecture>("""
+            I'm using a Macbook Pro with an M2 chip. What architecture am I using?
+            """,
+            useNativeJsonSchema: _chatClient.Metadata.ProviderName == "openai");
+
+        Assert.Equal(Architecture.Arm64, response.Result);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Structured outputs in OpenAI require an `object` schema object. By detecting this situation and wrapping always in a `Payload<T>(T Data)` record, we significantly improve the developer experience by making the API transparent to that limitation (which might even be a temporary one?).

The approach works for both OpenAI as well as Azure Inference without native structured outputs. In order to signal a wrapped result to the `ChatCompletion<T>`, we use the `AdditionalProperties` dictionary with a non-standard `$wrapped` property which is a typical convention for JSON properties that are not intended for end-user consumption (like $schema).

NOTE: there will be significant conflicts with https://github.com/dotnet/extensions/pull/5513, so I'll adjust after that merge, if this is deemed a useful addition 🙏 

Fixes #5521
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5522)