### PR TITLE
Update UseOpenTelemetry for latest genai spec updates

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatOptions.cs
@@ -18,6 +18,9 @@ public class ChatOptions
     /// <summary>Gets or sets the "nucleus sampling" factor (or "top p") for generating chat responses.</summary>
     public float? TopP { get; set; }
 
+    /// <summary>Gets or sets a count indicating how many of the most probable tokens the model should consider when generating the next part of the text.</summary>
+    public int? TopK { get; set; }
+
     /// <summary>Gets or sets the frequency penalty for generating chat responses.</summary>
     public float? FrequencyPenalty { get; set; }
 

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -299,7 +299,7 @@ public sealed partial class AzureAIInferenceChatClient : IChatClient
             // These properties are strongly-typed on ChatOptions but not on ChatCompletionsOptions.
             if (options.TopK is int topK)
             {
-                result.AdditionalProperties["top_k"] = BinaryData.FromObjectAsJson(topK, ToolCallJsonSerializerOptions);
+                result.AdditionalProperties["top_k"] = BinaryData.FromObjectAsJson(topK, JsonContext.Default.Options);
             }
 
             if (options.AdditionalProperties is { } props)
@@ -505,5 +505,6 @@ public sealed partial class AzureAIInferenceChatClient : IChatClient
     [JsonSerializable(typeof(AzureAIChatToolJson))]
     [JsonSerializable(typeof(IDictionary<string, object?>))]
     [JsonSerializable(typeof(JsonElement))]
+    [JsonSerializable(typeof(int))]
     private sealed partial class JsonContext : JsonSerializerContext;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -48,7 +48,7 @@ public sealed partial class AzureAIInferenceChatClient : IChatClient
         var providerUrl = typeof(ChatCompletionsClient).GetField("_endpoint", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(chatCompletionsClient) as Uri;
 
-        Metadata = new("AzureAIInference", providerUrl, modelId);
+        Metadata = new("az.ai.inference", providerUrl, modelId);
     }
 
     /// <summary>Gets or sets <see cref="JsonSerializerOptions"/> to use for any serialization activities related to tool call arguments and results.</summary>
@@ -296,13 +296,19 @@ public sealed partial class AzureAIInferenceChatClient : IChatClient
                 }
             }
 
+            // These properties are strongly-typed on ChatOptions but not on ChatCompletionsOptions.
+            if (options.TopK is int topK)
+            {
+                result.AdditionalProperties["top_k"] = BinaryData.FromObjectAsJson(topK, ToolCallJsonSerializerOptions);
+            }
+
             if (options.AdditionalProperties is { } props)
             {
                 foreach (var prop in props)
                 {
                     switch (prop.Key)
                     {
-                        // These properties are strongly-typed on the ChatCompletionsOptions class.
+                        // These properties are strongly-typed on the ChatCompletionsOptions class but not on the ChatOptions class.
                         case nameof(result.Seed) when prop.Value is long seed:
                             result.Seed = seed;
                             break;

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -259,7 +259,6 @@ public sealed class OllamaChatClient : IChatClient
             TransferMetadataValue<float>(nameof(OllamaRequestOptions.repeat_penalty), (options, value) => options.repeat_penalty = value);
             TransferMetadataValue<long>(nameof(OllamaRequestOptions.seed), (options, value) => options.seed = value);
             TransferMetadataValue<float>(nameof(OllamaRequestOptions.tfs_z), (options, value) => options.tfs_z = value);
-            TransferMetadataValue<int>(nameof(OllamaRequestOptions.top_k), (options, value) => options.top_k = value);
             TransferMetadataValue<float>(nameof(OllamaRequestOptions.typical_p), (options, value) => options.typical_p = value);
             TransferMetadataValue<bool>(nameof(OllamaRequestOptions.use_mmap), (options, value) => options.use_mmap = value);
             TransferMetadataValue<bool>(nameof(OllamaRequestOptions.use_mlock), (options, value) => options.use_mlock = value);
@@ -293,6 +292,11 @@ public sealed class OllamaChatClient : IChatClient
             if (options.TopP is float topP)
             {
                 (request.Options ??= new()).top_p = topP;
+            }
+
+            if (options.TopK is int topK)
+            {
+                (request.Options ??= new()).top_k = topK;
             }
         }
 

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -50,11 +50,10 @@ public sealed partial class OpenAIChatClient : IChatClient
         // The endpoint isn't currently exposed, so use reflection to get at it, temporarily. Once packages
         // implement the abstractions directly rather than providing adapters on top of the public APIs,
         // the package can provide such implementations separate from what's exposed in the public API.
-        string providerName = openAIClient.GetType().Name.StartsWith("Azure", StringComparison.Ordinal) ? "azureopenai" : "openai";
         Uri providerUrl = typeof(OpenAIClient).GetField("_endpoint", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(openAIClient) as Uri ?? _defaultOpenAIEndpoint;
 
-        Metadata = new(providerName, providerUrl, modelId);
+        Metadata = new("openai", providerUrl, modelId);
     }
 
     /// <summary>Initializes a new instance of the <see cref="OpenAIChatClient"/> class for the specified <see cref="ChatClient"/>.</summary>
@@ -69,13 +68,12 @@ public sealed partial class OpenAIChatClient : IChatClient
         // The endpoint and model aren't currently exposed, so use reflection to get at them, temporarily. Once packages
         // implement the abstractions directly rather than providing adapters on top of the public APIs,
         // the package can provide such implementations separate from what's exposed in the public API.
-        string providerName = chatClient.GetType().Name.StartsWith("Azure", StringComparison.Ordinal) ? "azureopenai" : "openai";
         Uri providerUrl = typeof(ChatClient).GetField("_endpoint", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(chatClient) as Uri ?? _defaultOpenAIEndpoint;
         string? model = typeof(ChatClient).GetField("_model", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(chatClient) as string;
 
-        Metadata = new(providerName, providerUrl, model);
+        Metadata = new("openai", providerUrl, model);
     }
 
     /// <summary>Gets or sets <see cref="JsonSerializerOptions"/> to use for any serialization activities related to tool call arguments and results.</summary>

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIEmbeddingGenerator.cs
@@ -52,12 +52,11 @@ public sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embed
         // The endpoint isn't currently exposed, so use reflection to get at it, temporarily. Once packages
         // implement the abstractions directly rather than providing adapters on top of the public APIs,
         // the package can provide such implementations separate from what's exposed in the public API.
-        string providerName = openAIClient.GetType().Name.StartsWith("Azure", StringComparison.Ordinal) ? "azureopenai" : "openai";
         string providerUrl = (typeof(OpenAIClient).GetField("_endpoint", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(openAIClient) as Uri)?.ToString() ??
             DefaultOpenAIEndpoint;
 
-        Metadata = CreateMetadata(dimensions, providerName, providerUrl, modelId);
+        Metadata = CreateMetadata("openai", providerUrl, modelId, dimensions);
     }
 
     /// <summary>Initializes a new instance of the <see cref="OpenAIEmbeddingGenerator"/> class.</summary>
@@ -78,7 +77,6 @@ public sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embed
         // The endpoint and model aren't currently exposed, so use reflection to get at them, temporarily. Once packages
         // implement the abstractions directly rather than providing adapters on top of the public APIs,
         // the package can provide such implementations separate from what's exposed in the public API.
-        string providerName = embeddingClient.GetType().Name.StartsWith("Azure", StringComparison.Ordinal) ? "azureopenai" : "openai";
         string providerUrl = (typeof(EmbeddingClient).GetField("_endpoint", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(embeddingClient) as Uri)?.ToString() ??
             DefaultOpenAIEndpoint;
@@ -86,11 +84,11 @@ public sealed class OpenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embed
         FieldInfo? modelField = typeof(EmbeddingClient).GetField("_model", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
         string? model = modelField?.GetValue(embeddingClient) as string;
 
-        Metadata = CreateMetadata(dimensions, providerName, providerUrl, model);
+        Metadata = CreateMetadata("openai", providerUrl, model, dimensions);
     }
 
     /// <summary>Creates the <see cref="EmbeddingGeneratorMetadata"/> for this instance.</summary>
-    private static EmbeddingGeneratorMetadata CreateMetadata(int? dimensions, string providerName, string providerUrl, string? model) =>
+    private static EmbeddingGeneratorMetadata CreateMetadata(string providerName, string providerUrl, string? model, int? dimensions) =>
         new(providerName, Uri.TryCreate(providerUrl, UriKind.Absolute, out Uri? providerUri) ? providerUri : null, model, dimensions);
 
     /// <inheritdoc />

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClient.cs
@@ -4,14 +4,21 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Shared.Diagnostics;
+
+#pragma warning disable S1135 // Track uses of "TODO" tags
+#pragma warning disable S3358 // Ternary operators should not be nested
 
 namespace Microsoft.Extensions.AI;
 
@@ -20,34 +27,40 @@ namespace Microsoft.Extensions.AI;
 /// The draft specification this follows is available at https://opentelemetry.io/docs/specs/semconv/gen-ai/.
 /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
 /// </remarks>
-public sealed class OpenTelemetryChatClient : DelegatingChatClient
+public sealed partial class OpenTelemetryChatClient : DelegatingChatClient
 {
+    private const LogLevel EventLogLevel = LogLevel.Information;
+
     private readonly ActivitySource _activitySource;
     private readonly Meter _meter;
+    private readonly ILogger _logger;
 
     private readonly Histogram<int> _tokenUsageHistogram;
     private readonly Histogram<double> _operationDurationHistogram;
 
     private readonly string? _modelId;
-    private readonly string? _modelProvider;
-    private readonly string? _endpointAddress;
-    private readonly int _endpointPort;
+    private readonly string? _system;
+    private readonly string? _serverAddress;
+    private readonly int _serverPort;
 
     private JsonSerializerOptions _jsonSerializerOptions;
 
     /// <summary>Initializes a new instance of the <see cref="OpenTelemetryChatClient"/> class.</summary>
     /// <param name="innerClient">The underlying <see cref="IChatClient"/>.</param>
+    /// <param name="logger">The <see cref="ILogger"/> to use for emitting events.</param>
     /// <param name="sourceName">An optional source name that will be used on the telemetry data.</param>
-    public OpenTelemetryChatClient(IChatClient innerClient, string? sourceName = null)
+    public OpenTelemetryChatClient(IChatClient innerClient, ILogger? logger = null, string? sourceName = null)
         : base(innerClient)
     {
         Debug.Assert(innerClient is not null, "Should have been validated by the base ctor");
 
+        _logger = logger ?? NullLogger.Instance;
+
         ChatClientMetadata metadata = innerClient!.Metadata;
         _modelId = metadata.ModelId;
-        _modelProvider = metadata.ProviderName;
-        _endpointAddress = metadata.ProviderUri?.GetLeftPart(UriPartial.Path);
-        _endpointPort = metadata.ProviderUri?.Port ?? 0;
+        _system = metadata.ProviderName;
+        _serverAddress = metadata.ProviderUri?.GetLeftPart(UriPartial.Path);
+        _serverPort = metadata.ProviderUri?.Port ?? 0;
 
         string name = string.IsNullOrEmpty(sourceName) ? OpenTelemetryConsts.DefaultSourceName : sourceName!;
         _activitySource = new(name);
@@ -88,27 +101,32 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether potentially sensitive information (e.g. prompts) should be included in telemetry.
+    /// Gets or sets a value indicating whether potentially sensitive information should be included in telemetry.
     /// </summary>
     /// <remarks>
-    /// The value is <see langword="false"/> by default, meaning that telemetry will include metadata such as token counts but not the raw text of prompts or completions.
+    /// The value is <see langword="false"/> by default, meaning that telemetry will include metadata such as token counts but not raw inputs
+    /// and outputs such as message content, function call arguments, and function call results.
     /// </remarks>
     public bool EnableSensitiveData { get; set; }
 
     /// <inheritdoc/>
     public override async Task<ChatCompletion> CompleteAsync(IList<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
     {
+        _ = Throw.IfNull(chatMessages);
         _jsonSerializerOptions.MakeReadOnly();
 
-        using Activity? activity = StartActivity(chatMessages, options);
+        using Activity? activity = CreateAndConfigureActivity(options);
         Stopwatch? stopwatch = _operationDurationHistogram.Enabled ? Stopwatch.StartNew() : null;
         string? requestModelId = options?.ModelId ?? _modelId;
 
-        ChatCompletion? response = null;
+        LogChatMessages(chatMessages);
+
+        ChatCompletion? completion = null;
         Exception? error = null;
         try
         {
-            response = await base.CompleteAsync(chatMessages, options, cancellationToken).ConfigureAwait(false);
+            completion = await base.CompleteAsync(chatMessages, options, cancellationToken).ConfigureAwait(false);
+            return completion;
         }
         catch (Exception ex)
         {
@@ -117,35 +135,37 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
         }
         finally
         {
-            SetCompletionResponse(activity, requestModelId, response, error, stopwatch);
+            TraceCompletion(activity, requestModelId, completion, error, stopwatch);
         }
-
-        return response;
     }
 
     /// <inheritdoc/>
     public override async IAsyncEnumerable<StreamingChatCompletionUpdate> CompleteStreamingAsync(
         IList<ChatMessage> chatMessages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        _ = Throw.IfNull(chatMessages);
         _jsonSerializerOptions.MakeReadOnly();
 
-        using Activity? activity = StartActivity(chatMessages, options);
+        using Activity? activity = CreateAndConfigureActivity(options);
         Stopwatch? stopwatch = _operationDurationHistogram.Enabled ? Stopwatch.StartNew() : null;
         string? requestModelId = options?.ModelId ?? _modelId;
 
-        IAsyncEnumerable<StreamingChatCompletionUpdate> response;
+        LogChatMessages(chatMessages);
+
+        IAsyncEnumerable<StreamingChatCompletionUpdate> updates;
         try
         {
-            response = base.CompleteStreamingAsync(chatMessages, options, cancellationToken);
+            updates = base.CompleteStreamingAsync(chatMessages, options, cancellationToken);
         }
         catch (Exception ex)
         {
-            SetCompletionResponse(activity, requestModelId, null, ex, stopwatch);
+            TraceCompletion(activity, requestModelId, completion: null, ex, stopwatch);
             throw;
         }
 
-        var responseEnumerator = response.ConfigureAwait(false).GetAsyncEnumerator();
-        List<StreamingChatCompletionUpdate>? streamedContents = activity is not null ? [] : null;
+        var responseEnumerator = updates.ConfigureAwait(false).GetAsyncEnumerator();
+        List<StreamingChatCompletionUpdate> trackedUpdates = [];
+        Exception? error = null;
         try
         {
             while (true)
@@ -162,122 +182,97 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
                 }
                 catch (Exception ex)
                 {
-                    SetCompletionResponse(activity, requestModelId, null, ex, stopwatch);
+                    error = ex;
                     throw;
                 }
 
-                streamedContents?.Add(update);
+                trackedUpdates.Add(update);
                 yield return update;
             }
         }
         finally
         {
-            if (activity is not null)
-            {
-                UsageContent? usageContent = streamedContents?.SelectMany(c => c.Contents).OfType<UsageContent>().LastOrDefault();
-                SetCompletionResponse(
-                    activity,
-                    stopwatch,
-                    requestModelId,
-                    OrganizeStreamingContent(streamedContents),
-                    streamedContents?.SelectMany(c => c.Contents).OfType<FunctionCallContent>(),
-                    usage: usageContent?.Details);
-            }
+            TraceCompletion(activity, requestModelId, ComposeStreamingUpdatesIntoChatCompletion(trackedUpdates), error, stopwatch);
 
             await responseEnumerator.DisposeAsync();
         }
     }
 
-    /// <summary>Gets a value indicating whether diagnostics are enabled.</summary>
-    private bool Enabled => _activitySource.HasListeners();
-
-    /// <summary>Convert chat history to a string aligned with the OpenAI format.</summary>
-    private static string ToOpenAIFormat(IEnumerable<ChatMessage> messages, JsonSerializerOptions serializerOptions)
+    /// <summary>Creates a <see cref="ChatCompletion"/> from a collection of <see cref="StreamingChatCompletionUpdate"/> instances.</summary>
+    /// <remarks>
+    /// This only propagates information that's later used by the telemetry. If additional information from the <see cref="ChatCompletion"/>
+    /// is needed, this implementation should be updated to include it.
+    /// </remarks>
+    private static ChatCompletion ComposeStreamingUpdatesIntoChatCompletion(
+        List<StreamingChatCompletionUpdate> updates)
     {
-        var sb = new StringBuilder().Append('[');
-
-        string messageSeparator = string.Empty;
-        foreach (var message in messages)
-        {
-            _ = sb.Append(messageSeparator);
-            messageSeparator = ", \n";
-
-            string text = string.Concat(message.Contents.OfType<TextContent>().Select(c => c.Text));
-            _ = sb.Append("{\"role\": \"").Append(message.Role).Append("\", \"content\": ").Append(JsonSerializer.Serialize(text, serializerOptions.GetTypeInfo(typeof(string))));
-
-            if (message.Contents.OfType<FunctionCallContent>().Any())
-            {
-                _ = sb.Append(", \"tool_calls\": ").Append('[');
-
-                string messageItemSeparator = string.Empty;
-                foreach (var functionCall in message.Contents.OfType<FunctionCallContent>())
-                {
-                    _ = sb.Append(messageItemSeparator);
-                    messageItemSeparator = ", \n";
-
-                    _ = sb.Append("{\"id\": \"").Append(functionCall.CallId)
-                          .Append("\", \"function\": {\"arguments\": ").Append(JsonSerializer.Serialize(functionCall.Arguments, serializerOptions.GetTypeInfo(typeof(IDictionary<string, object?>))))
-                          .Append(", \"name\": \"").Append(functionCall.Name)
-                          .Append("\"}, \"type\": \"function\"}");
-                }
-
-                _ = sb.Append(']');
-            }
-
-            _ = sb.Append('}');
-        }
-
-        _ = sb.Append(']');
-        return sb.ToString();
-    }
-
-    /// <summary>Organize streaming content by choice index.</summary>
-    private static Dictionary<int, List<StreamingChatCompletionUpdate>> OrganizeStreamingContent(IEnumerable<StreamingChatCompletionUpdate>? contents)
-    {
+        // Group updates by choice index.
         Dictionary<int, List<StreamingChatCompletionUpdate>> choices = [];
-        if (contents is null)
+        foreach (var update in updates)
         {
-            return choices;
-        }
-
-        foreach (var content in contents)
-        {
-            if (!choices.TryGetValue(content.ChoiceIndex, out var choiceContents))
+            if (!choices.TryGetValue(update.ChoiceIndex, out var choiceContents))
             {
-                choices[content.ChoiceIndex] = choiceContents = [];
+                choices[update.ChoiceIndex] = choiceContents = [];
             }
 
-            choiceContents.Add(content);
+            choiceContents.Add(update);
         }
 
-        return choices;
+        // Add a ChatMessage for each choice.
+        string? id = null;
+        ChatFinishReason? finishReason = null;
+        string? modelId = null;
+        List<ChatMessage> messages = new(choices.Count);
+        foreach (var choice in choices.OrderBy(c => c.Key))
+        {
+            ChatRole? role = null;
+            List<AIContent> items = [];
+            foreach (var update in choice.Value)
+            {
+                id ??= update.CompletionId;
+                finishReason ??= update.FinishReason;
+                role ??= update.Role;
+                items.AddRange(update.Contents);
+                modelId ??= update.Contents.FirstOrDefault(c => c.ModelId is not null)?.ModelId;
+            }
+
+            messages.Add(new ChatMessage(role ?? ChatRole.Assistant, items));
+        }
+
+        return new(messages)
+        {
+            CompletionId = id,
+            FinishReason = finishReason,
+            ModelId = modelId,
+            Usage = updates.SelectMany(c => c.Contents).OfType<UsageContent>().LastOrDefault()?.Details,
+        };
     }
 
     /// <summary>Creates an activity for a chat completion request, or returns null if not enabled.</summary>
-    private Activity? StartActivity(IList<ChatMessage> chatMessages, ChatOptions? options)
+    private Activity? CreateAndConfigureActivity(ChatOptions? options)
     {
         Activity? activity = null;
-        if (Enabled)
+        if (_activitySource.HasListeners())
         {
             string? modelId = options?.ModelId ?? _modelId;
 
             activity = _activitySource.StartActivity(
-                $"chat.completions {modelId}",
+                $"{OpenTelemetryConsts.GenAI.Chat} {modelId}",
                 ActivityKind.Client,
                 default(ActivityContext),
                 [
-                    new(OpenTelemetryConsts.GenAI.Operation.Name, "chat"),
+                    new(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.Chat),
                     new(OpenTelemetryConsts.GenAI.Request.Model, modelId),
-                    new(OpenTelemetryConsts.GenAI.System, _modelProvider),
+                    new(OpenTelemetryConsts.GenAI.SystemName, _system),
                 ]);
 
             if (activity is not null)
             {
-                if (_endpointAddress is not null)
+                if (_serverAddress is not null)
                 {
                     _ = activity
-                        .SetTag(OpenTelemetryConsts.Server.Address, _endpointAddress)
-                        .SetTag(OpenTelemetryConsts.Server.Port, _endpointPort);
+                        .SetTag(OpenTelemetryConsts.Server.Address, _serverAddress)
+                        .SetTag(OpenTelemetryConsts.Server.Port, _serverPort);
                 }
 
                 if (options is not null)
@@ -307,7 +302,7 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
                         _ = activity.SetTag(OpenTelemetryConsts.GenAI.Request.Temperature, temperature);
                     }
 
-                    if (options.AdditionalProperties?.TryGetValue("top_k", out double topK) is true)
+                    if (options.TopK is int topK)
                     {
                         _ = activity.SetTag(OpenTelemetryConsts.GenAI.Request.TopK, topK);
                     }
@@ -316,13 +311,26 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
                     {
                         _ = activity.SetTag(OpenTelemetryConsts.GenAI.Request.TopP, top_p);
                     }
-                }
 
-                if (EnableSensitiveData)
-                {
-                    _ = activity.AddEvent(new ActivityEvent(
-                        OpenTelemetryConsts.GenAI.Content.Prompt,
-                        tags: new ActivityTagsCollection([new(OpenTelemetryConsts.GenAI.Prompt, ToOpenAIFormat(chatMessages, _jsonSerializerOptions))])));
+                    if (_system is not null)
+                    {
+                        if (options.ResponseFormat is not null)
+                        {
+                            string responseFormat = options.ResponseFormat switch
+                            {
+                                ChatResponseFormatText => "text",
+                                ChatResponseFormatJson { Schema: null } => "json_schema",
+                                ChatResponseFormatJson => "json_object",
+                                _ => "_OTHER",
+                            };
+                            _ = activity.SetTag(OpenTelemetryConsts.GenAI.Request.PerProvider(_system, "response_format"), responseFormat);
+                        }
+
+                        if (options.AdditionalProperties?.TryGetValue("seed", out long seed) is true)
+                        {
+                            _ = activity.SetTag(OpenTelemetryConsts.GenAI.Request.PerProvider(_system, "seed"), seed);
+                        }
+                    }
                 }
             }
         }
@@ -331,23 +339,18 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
     }
 
     /// <summary>Adds chat completion information to the activity.</summary>
-    private void SetCompletionResponse(
+    private void TraceCompletion(
         Activity? activity,
         string? requestModelId,
-        ChatCompletion? completions,
+        ChatCompletion? completion,
         Exception? error,
         Stopwatch? stopwatch)
     {
-        if (!Enabled)
-        {
-            return;
-        }
-
         if (_operationDurationHistogram.Enabled && stopwatch is not null)
         {
             TagList tags = default;
 
-            AddMetricTags(ref tags, requestModelId, completions);
+            AddMetricTags(ref tags, requestModelId, completion);
             if (error is not null)
             {
                 tags.Add(OpenTelemetryConsts.Error.Type, error.GetType().FullName);
@@ -356,13 +359,13 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
             _operationDurationHistogram.Record(stopwatch.Elapsed.TotalSeconds, tags);
         }
 
-        if (_tokenUsageHistogram.Enabled && completions?.Usage is { } usage)
+        if (_tokenUsageHistogram.Enabled && completion?.Usage is { } usage)
         {
             if (usage.InputTokenCount is int inputTokens)
             {
                 TagList tags = default;
                 tags.Add(OpenTelemetryConsts.GenAI.Token.Type, "input");
-                AddMetricTags(ref tags, requestModelId, completions);
+                AddMetricTags(ref tags, requestModelId, completion);
                 _tokenUsageHistogram.Record(inputTokens);
             }
 
@@ -370,139 +373,231 @@ public sealed class OpenTelemetryChatClient : DelegatingChatClient
             {
                 TagList tags = default;
                 tags.Add(OpenTelemetryConsts.GenAI.Token.Type, "output");
-                AddMetricTags(ref tags, requestModelId, completions);
+                AddMetricTags(ref tags, requestModelId, completion);
                 _tokenUsageHistogram.Record(outputTokens);
             }
         }
 
-        if (activity is null)
-        {
-            return;
-        }
-
         if (error is not null)
         {
-            _ = activity
+            _ = activity?
                 .SetTag(OpenTelemetryConsts.Error.Type, error.GetType().FullName)
                 .SetStatus(ActivityStatusCode.Error, error.Message);
-            return;
         }
 
-        if (completions is not null)
+        if (completion is not null)
         {
-            if (completions.FinishReason is ChatFinishReason finishReason)
+            LogChatCompletion(completion);
+
+            if (activity is not null)
             {
-#pragma warning disable CA1308 // Normalize strings to uppercase
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.FinishReasons, $"[\"{finishReason.Value.ToLowerInvariant()}\"]");
-#pragma warning restore CA1308
-            }
-
-            if (!string.IsNullOrWhiteSpace(completions.CompletionId))
-            {
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.Id, completions.CompletionId);
-            }
-
-            if (completions.ModelId is not null)
-            {
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.Model, completions.ModelId);
-            }
-
-            if (completions.Usage?.InputTokenCount is int inputTokens)
-            {
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.InputTokens, inputTokens);
-            }
-
-            if (completions.Usage?.OutputTokenCount is int outputTokens)
-            {
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.OutputTokens, outputTokens);
-            }
-
-            if (EnableSensitiveData)
-            {
-                _ = activity.AddEvent(new ActivityEvent(
-                    OpenTelemetryConsts.GenAI.Content.Completion,
-                    tags: new ActivityTagsCollection([new(OpenTelemetryConsts.GenAI.Completion, ToOpenAIFormat(completions.Choices, _jsonSerializerOptions))])));
-            }
-        }
-    }
-
-    /// <summary>Adds streaming chat completion information to the activity.</summary>
-    private void SetCompletionResponse(
-        Activity? activity,
-        Stopwatch? stopwatch,
-        string? requestModelId,
-        Dictionary<int, List<StreamingChatCompletionUpdate>> choices,
-        IEnumerable<FunctionCallContent>? toolCalls,
-        UsageDetails? usage)
-    {
-        if (activity is null || !Enabled || choices.Count == 0)
-        {
-            return;
-        }
-
-        string? id = null;
-        ChatFinishReason? finishReason = null;
-        string? modelId = null;
-        List<ChatMessage> messages = new(choices.Count);
-
-        foreach (var choice in choices)
-        {
-            ChatRole? role = null;
-            List<AIContent> items = [];
-            foreach (var update in choice.Value)
-            {
-                id ??= update.CompletionId;
-                role ??= update.Role;
-                finishReason ??= update.FinishReason;
-                foreach (AIContent content in update.Contents)
+                if (completion.FinishReason is ChatFinishReason finishReason)
                 {
-                    items.Add(content);
-                    modelId ??= content.ModelId;
+#pragma warning disable CA1308 // Normalize strings to uppercase
+                    _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.FinishReasons, $"[\"{finishReason.Value.ToLowerInvariant()}\"]");
+#pragma warning restore CA1308
+                }
+
+                if (!string.IsNullOrWhiteSpace(completion.CompletionId))
+                {
+                    _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.Id, completion.CompletionId);
+                }
+
+                if (completion.ModelId is not null)
+                {
+                    _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.Model, completion.ModelId);
+                }
+
+                if (completion.Usage?.InputTokenCount is int inputTokens)
+                {
+                    _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.InputTokens, inputTokens);
+                }
+
+                if (completion.Usage?.OutputTokenCount is int outputTokens)
+                {
+                    _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.OutputTokens, outputTokens);
                 }
             }
-
-            messages.Add(new ChatMessage(role ?? ChatRole.Assistant, items));
         }
 
-        if (toolCalls is not null && messages.FirstOrDefault()?.Contents is { } c)
+        void AddMetricTags(ref TagList tags, string? requestModelId, ChatCompletion? completions)
         {
-            foreach (var functionCall in toolCalls)
+            tags.Add(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.Chat);
+
+            if (requestModelId is not null)
             {
-                c.Add(functionCall);
+                tags.Add(OpenTelemetryConsts.GenAI.Request.Model, requestModelId);
+            }
+
+            tags.Add(OpenTelemetryConsts.GenAI.SystemName, _system);
+
+            if (_serverAddress is string endpointAddress)
+            {
+                tags.Add(OpenTelemetryConsts.Server.Address, endpointAddress);
+                tags.Add(OpenTelemetryConsts.Server.Port, _serverPort);
+            }
+
+            if (completions?.ModelId is string responseModel)
+            {
+                tags.Add(OpenTelemetryConsts.GenAI.Response.Model, responseModel);
+            }
+        }
+    }
+
+    private void LogChatMessages(IEnumerable<ChatMessage> messages)
+    {
+        if (!_logger.IsEnabled(EventLogLevel))
+        {
+            return;
+        }
+
+        foreach (ChatMessage message in messages)
+        {
+            if (message.Role == ChatRole.Assistant)
+            {
+                Log(new(1, OpenTelemetryConsts.GenAI.Assistant.Message),
+                    JsonSerializer.Serialize(CreateAssistantEvent(message), OtelContext.Default.AssistantEvent));
+            }
+            else if (message.Role == ChatRole.Tool)
+            {
+                foreach (FunctionResultContent frc in message.Contents.OfType<FunctionResultContent>())
+                {
+                    Log(new(1, OpenTelemetryConsts.GenAI.Tool.Message),
+                        JsonSerializer.Serialize(new()
+                        {
+                            Id = frc.CallId,
+                            Content = EnableSensitiveData && frc.Result is object result ?
+                                JsonSerializer.SerializeToNode(result, _jsonSerializerOptions.GetTypeInfo(result.GetType())) :
+                                null,
+                        }, OtelContext.Default.ToolEvent));
+                }
+            }
+            else
+            {
+                Log(new(1, message.Role == ChatRole.System ? OpenTelemetryConsts.GenAI.System.Message : OpenTelemetryConsts.GenAI.User.Message),
+                    JsonSerializer.Serialize(new()
+                    {
+                        Role = message.Role != ChatRole.System && message.Role != ChatRole.User && !string.IsNullOrWhiteSpace(message.Role.Value) ? message.Role.Value : null,
+                        Content = GetMessageContent(message),
+                    }, OtelContext.Default.SystemOrUserEvent));
+            }
+        }
+    }
+
+    private void LogChatCompletion(ChatCompletion completion)
+    {
+        if (!_logger.IsEnabled(EventLogLevel))
+        {
+            return;
+        }
+
+        EventId id = new(1, OpenTelemetryConsts.GenAI.Choice);
+        int choiceCount = completion.Choices.Count;
+        for (int choiceIndex = 0; choiceIndex < choiceCount; choiceIndex++)
+        {
+            Log(id, JsonSerializer.Serialize(new()
+            {
+                FinishReason = completion.FinishReason?.Value ?? "error",
+                Index = choiceIndex,
+                Message = CreateAssistantEvent(completion.Choices[choiceIndex]),
+            }, OtelContext.Default.ChoiceEvent));
+        }
+    }
+
+    private void Log(EventId id, [StringSyntax(StringSyntaxAttribute.Json)] string eventBodyJson)
+    {
+        // This is not the idiomatic way to log, but it's necessary for now in order to structure
+        // the data in a way that the OpenTelemetry collector can work with it. The event body
+        // can be very large and should not be logged as an attribute.
+
+        KeyValuePair<string, object?>[] tags =
+        [
+            new(OpenTelemetryConsts.Event.Name, id.Name),
+            new(OpenTelemetryConsts.GenAI.SystemName, _system),
+        ];
+
+        _logger.Log(EventLogLevel, id, tags, null, (_, __) => eventBodyJson);
+    }
+
+    private AssistantEvent CreateAssistantEvent(ChatMessage message)
+    {
+        var toolCalls = message.Contents.OfType<FunctionCallContent>().Select(fc => new ToolCall
+        {
+            Id = fc.CallId,
+            Function = new()
+            {
+                Name = fc.Name,
+                Arguments = EnableSensitiveData ?
+                    JsonSerializer.SerializeToNode(fc.Arguments, _jsonSerializerOptions.GetTypeInfo(typeof(IDictionary<string, object?>))) :
+                    null,
+            },
+        }).ToArray();
+
+        return new()
+        {
+            Content = GetMessageContent(message),
+            ToolCalls = toolCalls.Length > 0 ? toolCalls : null,
+        };
+    }
+
+    private string? GetMessageContent(ChatMessage message)
+    {
+        if (EnableSensitiveData)
+        {
+            // TODO: Include other content types once the genai specification details what's expected.
+            string content = string.Concat(message.Contents.OfType<TextContent>().Select(c => c.Text));
+            if (content.Length > 0)
+            {
+                return content;
             }
         }
 
-        ChatCompletion completion = new(messages)
-        {
-            CompletionId = id,
-            FinishReason = finishReason,
-            ModelId = modelId,
-            Usage = usage,
-        };
-
-        SetCompletionResponse(activity, requestModelId, completion, error: null, stopwatch);
+        return null;
     }
 
-    private void AddMetricTags(ref TagList tags, string? requestModelId, ChatCompletion? completions)
+    private sealed class SystemOrUserEvent
     {
-        tags.Add(OpenTelemetryConsts.GenAI.Operation.Name, "chat");
-
-        if (requestModelId is not null)
-        {
-            tags.Add(OpenTelemetryConsts.GenAI.Request.Model, requestModelId);
-        }
-
-        tags.Add(OpenTelemetryConsts.GenAI.System, _modelProvider);
-
-        if (_endpointAddress is string endpointAddress)
-        {
-            tags.Add(OpenTelemetryConsts.Server.Address, endpointAddress);
-            tags.Add(OpenTelemetryConsts.Server.Port, _endpointPort);
-        }
-
-        if (completions?.ModelId is string responseModel)
-        {
-            tags.Add(OpenTelemetryConsts.GenAI.Response.Model, responseModel);
-        }
+        public string? Role { get; set; }
+        public string? Content { get; set; }
     }
+
+    private sealed class AssistantEvent
+    {
+        public string? Content { get; set; }
+        public ToolCall[]? ToolCalls { get; set; }
+    }
+
+    private sealed class ToolEvent
+    {
+        public string? Id { get; set; }
+        public JsonNode? Content { get; set; }
+    }
+
+    private sealed class ChoiceEvent
+    {
+        public string? FinishReason { get; set; }
+        public int Index { get; set; }
+        public AssistantEvent? Message { get; set; }
+    }
+
+    private sealed class ToolCall
+    {
+        public string? Id { get; set; }
+        public string? Type { get; set; } = "function";
+        public ToolCallFunction? Function { get; set; }
+    }
+
+    private sealed class ToolCallFunction
+    {
+        public string? Name { get; set; }
+        public JsonNode? Arguments { get; set; }
+    }
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(SystemOrUserEvent))]
+    [JsonSerializable(typeof(AssistantEvent))]
+    [JsonSerializable(typeof(ToolEvent))]
+    [JsonSerializable(typeof(ChoiceEvent))]
+    [JsonSerializable(typeof(object))]
+    private sealed partial class OtelContext : JsonSerializerContext;
 }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClientBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/OpenTelemetryChatClientBuilderExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -17,15 +19,22 @@ public static class OpenTelemetryChatClientBuilderExtensions
     /// The specification is still experimental and subject to change; as such, the telemetry output by this client is also subject to change.
     /// </remarks>
     /// <param name="builder">The <see cref="ChatClientBuilder"/>.</param>
+    /// <param name="loggerFactory">An optional <see cref="ILoggerFactory"/> to use to create a logger for logging events.</param>
     /// <param name="sourceName">An optional source name that will be used on the telemetry data.</param>
     /// <param name="configure">An optional callback that can be used to configure the <see cref="OpenTelemetryChatClient"/> instance.</param>
     /// <returns>The <paramref name="builder"/>.</returns>
     public static ChatClientBuilder UseOpenTelemetry(
-        this ChatClientBuilder builder, string? sourceName = null, Action<OpenTelemetryChatClient>? configure = null) =>
-        Throw.IfNull(builder).Use(innerClient =>
+        this ChatClientBuilder builder,
+        ILoggerFactory? loggerFactory = null,
+        string? sourceName = null,
+        Action<OpenTelemetryChatClient>? configure = null) =>
+        Throw.IfNull(builder).Use((services, innerClient) =>
         {
-            var chatClient = new OpenTelemetryChatClient(innerClient, sourceName);
+            loggerFactory ??= services.GetService<ILoggerFactory>();
+
+            var chatClient = new OpenTelemetryChatClient(innerClient, loggerFactory?.CreateLogger(typeof(OpenTelemetryChatClient)), sourceName);
             configure?.Invoke(chatClient);
+
             return chatClient;
         });
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGenerator.cs
@@ -132,13 +132,13 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
                 if (_endpointAddress is not null)
                 {
                     _ = activity
-                        .SetTag(OpenTelemetryConsts.Server.Address, _endpointAddress)
-                        .SetTag(OpenTelemetryConsts.Server.Port, _endpointPort);
+                        .AddTag(OpenTelemetryConsts.Server.Address, _endpointAddress)
+                        .AddTag(OpenTelemetryConsts.Server.Port, _endpointPort);
                 }
 
                 if (_dimensions is int dimensions)
                 {
-                    _ = activity.SetTag(OpenTelemetryConsts.GenAI.Request.EmbeddingDimensions, dimensions);
+                    _ = activity.AddTag(OpenTelemetryConsts.GenAI.Request.EmbeddingDimensions, dimensions);
                 }
             }
         }
@@ -190,18 +190,18 @@ public sealed class OpenTelemetryEmbeddingGenerator<TInput, TEmbedding> : Delega
             if (error is not null)
             {
                 _ = activity
-                    .SetTag(OpenTelemetryConsts.Error.Type, error.GetType().FullName)
+                    .AddTag(OpenTelemetryConsts.Error.Type, error.GetType().FullName)
                     .SetStatus(ActivityStatusCode.Error, error.Message);
             }
 
             if (inputTokens.HasValue)
             {
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.InputTokens, inputTokens);
+                _ = activity.AddTag(OpenTelemetryConsts.GenAI.Response.InputTokens, inputTokens);
             }
 
             if (responseModelId is not null)
             {
-                _ = activity.SetTag(OpenTelemetryConsts.GenAI.Response.Model, responseModelId);
+                _ = activity.AddTag(OpenTelemetryConsts.GenAI.Response.Model, responseModelId);
             }
         }
     }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGeneratorBuilderExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/OpenTelemetryEmbeddingGeneratorBuilderExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -19,15 +21,24 @@ public static class OpenTelemetryEmbeddingGeneratorBuilderExtensions
     /// <typeparam name="TInput">The type of input used to produce embeddings.</typeparam>
     /// <typeparam name="TEmbedding">The type of embedding generated.</typeparam>
     /// <param name="builder">The <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/>.</param>
+    /// <param name="loggerFactory">An optional <see cref="ILoggerFactory"/> to use to create a logger for logging events.</param>
     /// <param name="sourceName">An optional source name that will be used on the telemetry data.</param>
     /// <param name="configure">An optional callback that can be used to configure the <see cref="OpenTelemetryEmbeddingGenerator{TInput, TEmbedding}"/> instance.</param>
     /// <returns>The <paramref name="builder"/>.</returns>
     public static EmbeddingGeneratorBuilder<TInput, TEmbedding> UseOpenTelemetry<TInput, TEmbedding>(
-        this EmbeddingGeneratorBuilder<TInput, TEmbedding> builder, string? sourceName = null, Action<OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>>? configure = null)
+        this EmbeddingGeneratorBuilder<TInput, TEmbedding> builder,
+        ILoggerFactory? loggerFactory = null,
+        string? sourceName = null,
+        Action<OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>>? configure = null)
         where TEmbedding : Embedding =>
-        Throw.IfNull(builder).Use(innerGenerator =>
+        Throw.IfNull(builder).Use((services, innerGenerator) =>
         {
-            var generator = new OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>(innerGenerator, sourceName);
+            loggerFactory ??= services.GetService<ILoggerFactory>();
+
+            var generator = new OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>(
+                innerGenerator,
+                loggerFactory?.CreateLogger(typeof(OpenTelemetryEmbeddingGenerator<TInput, TEmbedding>)),
+                sourceName);
             configure?.Invoke(generator);
             return generator;
         });

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
@@ -20,6 +20,7 @@
 
   <PropertyGroup>
     <InjectSharedEmptyCollections>true</InjectSharedEmptyCollections>
+    <InjectStringSyntaxAttributeOnLegacy>true</InjectStringSyntaxAttributeOnLegacy>
     <DisableMicrosoftExtensionsLoggingSourceGenerator>false</DisableMicrosoftExtensionsLoggingSourceGenerator>
   </PropertyGroup>
 

--- a/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/OpenTelemetryConsts.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Extensions.AI;
 
-#pragma warning disable S3218 // Inner class members should not shadow outer class "static" or type members
 #pragma warning disable CA1716 // Identifiers should not match keywords
 #pragma warning disable S4041 // Type names should not match namespaces
 
@@ -15,6 +14,11 @@ internal static class OpenTelemetryConsts
     public const string SecondsUnit = "s";
     public const string TokensUnit = "token";
 
+    public static class Event
+    {
+        public const string Name = "event.name";
+    }
+
     public static class Error
     {
         public const string Type = "error.type";
@@ -22,9 +26,16 @@ internal static class OpenTelemetryConsts
 
     public static class GenAI
     {
-        public const string Completion = "gen_ai.completion";
-        public const string Prompt = "gen_ai.prompt";
-        public const string System = "gen_ai.system";
+        public const string Choice = "gen_ai.choice";
+        public const string SystemName = "gen_ai.system";
+
+        public const string Chat = "chat";
+        public const string Embed = "embed";
+
+        public static class Assistant
+        {
+            public const string Message = "gen_ai.assistant.message";
+        }
 
         public static class Client
         {
@@ -43,12 +54,6 @@ internal static class OpenTelemetryConsts
             }
         }
 
-        public static class Content
-        {
-            public const string Completion = "gen_ai.content.completion";
-            public const string Prompt = "gen_ai.content.prompt";
-        }
-
         public static class Operation
         {
             public const string Name = "gen_ai.operation.name";
@@ -65,6 +70,8 @@ internal static class OpenTelemetryConsts
             public const string Temperature = "gen_ai.request.temperature";
             public const string TopK = "gen_ai.request.top_k";
             public const string TopP = "gen_ai.request.top_p";
+
+            public static string PerProvider(string providerName, string parameterName) => $"gen_ai.{providerName}.request.{parameterName}";
         }
 
         public static class Response
@@ -76,9 +83,24 @@ internal static class OpenTelemetryConsts
             public const string OutputTokens = "gen_ai.response.output_tokens";
         }
 
+        public static class System
+        {
+            public const string Message = "gen_ai.system.message";
+        }
+
         public static class Token
         {
             public const string Type = "gen_ai.token.type";
+        }
+
+        public static class Tool
+        {
+            public const string Message = "gen_ai.tool.message";
+        }
+
+        public static class User
+        {
+            public const string Message = "gen_ai.user.message";
         }
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
@@ -47,7 +47,7 @@ public class AzureAIInferenceChatClientTests
         ChatCompletionsClient client = new(endpoint, new AzureKeyCredential("key"));
 
         IChatClient chatClient = client.AsChatClient(model);
-        Assert.Equal("AzureAIInference", chatClient.Metadata.ProviderName);
+        Assert.Equal("az.ai.inference", chatClient.Metadata.ProviderName);
         Assert.Equal(endpoint, chatClient.Metadata.ProviderUri);
         Assert.Equal(model, chatClient.Metadata.ModelId);
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
@@ -111,7 +111,7 @@ public abstract class EmbeddingGeneratorIntegrationTests : IDisposable
             .Build();
 
         var embeddingGenerator = new EmbeddingGeneratorBuilder<string, Embedding<float>>()
-            .UseOpenTelemetry(sourceName)
+            .UseOpenTelemetry(sourceName: sourceName)
             .Use(CreateEmbeddingGenerator()!);
 
         _ = await embeddingGenerator.GenerateAsync("Hello, world!");

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -15,8 +17,12 @@ namespace Microsoft.Extensions.AI;
 
 public class OpenTelemetryChatClientTests
 {
-    [Fact]
-    public async Task ExpectedInformationLogged_NonStreaming_Async()
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ExpectedInformationLogged_Async(bool enableSensitiveData, bool streaming)
     {
         var sourceName = Guid.NewGuid().ToString();
         var activities = new List<Activity>();
@@ -25,13 +31,16 @@ public class OpenTelemetryChatClientTests
             .AddInMemoryExporter(activities)
             .Build();
 
+        var collector = new FakeLogCollector();
+        using ILoggerFactory loggerFactory = LoggerFactory.Create(b => b.AddProvider(new FakeLoggerProvider(collector)));
+
         using var innerClient = new TestChatClient
         {
             Metadata = new("testservice", new Uri("http://localhost:12345/something"), "amazingmodel"),
             CompleteAsyncCallback = async (messages, options, cancellationToken) =>
             {
                 await Task.Yield();
-                return new ChatCompletion([new ChatMessage(ChatRole.Assistant, "blue whale")])
+                return new ChatCompletion([new ChatMessage(ChatRole.Assistant, "The blue whale, I think.")])
                 {
                     CompletionId = "id123",
                     FinishReason = ChatFinishReason.Stop,
@@ -42,99 +51,31 @@ public class OpenTelemetryChatClientTests
                         TotalTokenCount = 42,
                     },
                 };
-            }
-        };
-
-        var chatClient = new ChatClientBuilder()
-            .UseOpenTelemetry(sourceName, instance =>
-            {
-                instance.EnableSensitiveData = true;
-                instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
-            })
-            .Use(innerClient);
-
-        await chatClient.CompleteAsync(
-            [new(ChatRole.User, "What's the biggest animal?")],
-            new ChatOptions
-            {
-                FrequencyPenalty = 3.0f,
-                MaxOutputTokens = 123,
-                ModelId = "replacementmodel",
-                TopP = 4.0f,
-                PresencePenalty = 5.0f,
-                ResponseFormat = ChatResponseFormat.Json,
-                Temperature = 6.0f,
-                StopSequences = ["hello", "world"],
-                AdditionalProperties = new() { ["top_k"] = 7.0f },
-            });
-
-        var activity = Assert.Single(activities);
-
-        Assert.NotNull(activity.Id);
-        Assert.NotEmpty(activity.Id);
-
-        Assert.Equal("http://localhost:12345/something", activity.GetTagItem("server.address"));
-        Assert.Equal(12345, (int)activity.GetTagItem("server.port")!);
-
-        Assert.Equal("chat.completions replacementmodel", activity.DisplayName);
-        Assert.Equal("testservice", activity.GetTagItem("gen_ai.system"));
-
-        Assert.Equal("replacementmodel", activity.GetTagItem("gen_ai.request.model"));
-        Assert.Equal(3.0f, activity.GetTagItem("gen_ai.request.frequency_penalty"));
-        Assert.Equal(4.0f, activity.GetTagItem("gen_ai.request.top_p"));
-        Assert.Equal(5.0f, activity.GetTagItem("gen_ai.request.presence_penalty"));
-        Assert.Equal(6.0f, activity.GetTagItem("gen_ai.request.temperature"));
-        Assert.Equal(7.0, activity.GetTagItem("gen_ai.request.top_k"));
-        Assert.Equal(123, activity.GetTagItem("gen_ai.request.max_tokens"));
-        Assert.Equal("""["hello", "world"]""", activity.GetTagItem("gen_ai.request.stop_sequences"));
-
-        Assert.Equal("id123", activity.GetTagItem("gen_ai.response.id"));
-        Assert.Equal("""["stop"]""", activity.GetTagItem("gen_ai.response.finish_reasons"));
-        Assert.Equal(10, activity.GetTagItem("gen_ai.response.input_tokens"));
-        Assert.Equal(20, activity.GetTagItem("gen_ai.response.output_tokens"));
-
-        Assert.Collection(activity.Events,
-            evt =>
-            {
-                Assert.Equal("gen_ai.content.prompt", evt.Name);
-                Assert.Equal("""[{"role": "user", "content": "What\u0027s the biggest animal?"}]""", evt.Tags.FirstOrDefault(t => t.Key == "gen_ai.prompt").Value);
             },
-            evt =>
-            {
-                Assert.Equal("gen_ai.content.completion", evt.Name);
-                Assert.Contains("whale", (string)evt.Tags.FirstOrDefault(t => t.Key == "gen_ai.completion").Value!);
-            });
-
-        Assert.True(activity.Duration.TotalMilliseconds > 0);
-    }
-
-    [Fact]
-    public async Task ExpectedInformationLogged_Streaming_Async()
-    {
-        var sourceName = Guid.NewGuid().ToString();
-        var activities = new List<Activity>();
-        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
-            .AddSource(sourceName)
-            .AddInMemoryExporter(activities)
-            .Build();
+            CompleteStreamingAsyncCallback = CallbackAsync,
+        };
 
         async static IAsyncEnumerable<StreamingChatCompletionUpdate> CallbackAsync(
             IList<ChatMessage> messages, ChatOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
+
+            foreach (string text in new[] { "The ", "blue ", "whale,", " ", "", "I", " think." })
+            {
+                await Task.Yield();
+                yield return new StreamingChatCompletionUpdate
+                {
+                    Role = ChatRole.Assistant,
+                    Text = text,
+                    CompletionId = "id123",
+                };
+            }
+
             yield return new StreamingChatCompletionUpdate
             {
-                Role = ChatRole.Assistant,
-                Text = "blue ",
-                CompletionId = "id123",
-            };
-            await Task.Yield();
-            yield return new StreamingChatCompletionUpdate
-            {
-                Role = ChatRole.Assistant,
-                Text = "whale",
                 FinishReason = ChatFinishReason.Stop,
             };
+
             yield return new StreamingChatCompletionUpdate
             {
                 Contents = [new UsageContent(new()
@@ -146,36 +87,47 @@ public class OpenTelemetryChatClientTests
             };
         }
 
-        using var innerClient = new TestChatClient
-        {
-            Metadata = new("testservice", new Uri("http://localhost:12345/something"), "amazingmodel"),
-            CompleteStreamingAsyncCallback = CallbackAsync,
-        };
-
         var chatClient = new ChatClientBuilder()
-            .UseOpenTelemetry(sourceName, instance =>
+            .UseOpenTelemetry(loggerFactory, sourceName, configure: instance =>
             {
-                instance.EnableSensitiveData = true;
+                instance.EnableSensitiveData = enableSensitiveData;
                 instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;
             })
             .Use(innerClient);
 
-        await foreach (var update in chatClient.CompleteStreamingAsync(
-            [new(ChatRole.User, "What's the biggest animal?")],
-            new ChatOptions
-            {
-                FrequencyPenalty = 3.0f,
-                MaxOutputTokens = 123,
-                ModelId = "replacementmodel",
-                TopP = 4.0f,
-                PresencePenalty = 5.0f,
-                ResponseFormat = ChatResponseFormat.Json,
-                Temperature = 6.0f,
-                StopSequences = ["hello", "world"],
-                AdditionalProperties = new() { ["top_k"] = 7.0 },
-            }))
+        List<ChatMessage> chatMessages =
+        [
+            new(ChatRole.System, "You are a close friend."),
+            new(ChatRole.User, "Hey!"),
+            new(ChatRole.Assistant, [new FunctionCallContent("12345", "GetPersonName")]),
+            new(ChatRole.Tool, [new FunctionResultContent("12345", "GetPersonName", "John")]),
+            new(ChatRole.Assistant, "Hey John, what's up?"),
+            new(ChatRole.User, "What's the biggest animal?")
+        ];
+
+        var options = new ChatOptions
         {
-            // Drain the stream.
+            FrequencyPenalty = 3.0f,
+            MaxOutputTokens = 123,
+            ModelId = "replacementmodel",
+            TopP = 4.0f,
+            TopK = 7,
+            PresencePenalty = 5.0f,
+            ResponseFormat = ChatResponseFormat.Json,
+            Temperature = 6.0f,
+            StopSequences = ["hello", "world"],
+        };
+
+        if (streaming)
+        {
+            await foreach (var update in chatClient.CompleteStreamingAsync(chatMessages, options))
+            {
+                await Task.Yield();
+            }
+        }
+        else
+        {
+            await chatClient.CompleteAsync(chatMessages, options);
         }
 
         var activity = Assert.Single(activities);
@@ -186,7 +138,7 @@ public class OpenTelemetryChatClientTests
         Assert.Equal("http://localhost:12345/something", activity.GetTagItem("server.address"));
         Assert.Equal(12345, (int)activity.GetTagItem("server.port")!);
 
-        Assert.Equal("chat.completions replacementmodel", activity.DisplayName);
+        Assert.Equal("chat replacementmodel", activity.DisplayName);
         Assert.Equal("testservice", activity.GetTagItem("gen_ai.system"));
 
         Assert.Equal("replacementmodel", activity.GetTagItem("gen_ai.request.model"));
@@ -194,7 +146,7 @@ public class OpenTelemetryChatClientTests
         Assert.Equal(4.0f, activity.GetTagItem("gen_ai.request.top_p"));
         Assert.Equal(5.0f, activity.GetTagItem("gen_ai.request.presence_penalty"));
         Assert.Equal(6.0f, activity.GetTagItem("gen_ai.request.temperature"));
-        Assert.Equal(7.0, activity.GetTagItem("gen_ai.request.top_k"));
+        Assert.Equal(7, activity.GetTagItem("gen_ai.request.top_k"));
         Assert.Equal(123, activity.GetTagItem("gen_ai.request.max_tokens"));
         Assert.Equal("""["hello", "world"]""", activity.GetTagItem("gen_ai.request.stop_sequences"));
 
@@ -203,18 +155,44 @@ public class OpenTelemetryChatClientTests
         Assert.Equal(10, activity.GetTagItem("gen_ai.response.input_tokens"));
         Assert.Equal(20, activity.GetTagItem("gen_ai.response.output_tokens"));
 
-        Assert.Collection(activity.Events,
-            evt =>
-            {
-                Assert.Equal("gen_ai.content.prompt", evt.Name);
-                Assert.Equal("""[{"role": "user", "content": "What\u0027s the biggest animal?"}]""", evt.Tags.FirstOrDefault(t => t.Key == "gen_ai.prompt").Value);
-            },
-            evt =>
-            {
-                Assert.Equal("gen_ai.content.completion", evt.Name);
-                Assert.Contains("whale", (string)evt.Tags.FirstOrDefault(t => t.Key == "gen_ai.completion").Value!);
-            });
-
         Assert.True(activity.Duration.TotalMilliseconds > 0);
+
+        var logs = collector.GetSnapshot();
+        if (enableSensitiveData)
+        {
+            Assert.Collection(logs,
+                log => Assert.Equal("""{"content":"You are a close friend."}""", log.Message),
+                log => Assert.Equal("""{"content":"Hey!"}""", log.Message),
+                log => Assert.Equal("""{"tool_calls":[{"id":"12345","type":"function","function":{"name":"GetPersonName"}}]}""", log.Message),
+                log => Assert.Equal("""{"id":"12345","content":"John"}""", log.Message),
+                log => Assert.Equal("""{"content":"Hey John, what\u0027s up?"}""", log.Message),
+                log => Assert.Equal("""{"content":"What\u0027s the biggest animal?"}""", log.Message),
+                log => Assert.Equal("""{"finish_reason":"stop","index":0,"message":{"content":"The blue whale, I think."}}""", log.Message));
+        }
+        else
+        {
+            Assert.Collection(logs,
+                log => Assert.Equal("""{}""", log.Message),
+                log => Assert.Equal("""{}""", log.Message),
+                log => Assert.Equal("""{"tool_calls":[{"id":"12345","type":"function","function":{"name":"GetPersonName"}}]}""", log.Message),
+                log => Assert.Equal("""{"id":"12345"}""", log.Message),
+                log => Assert.Equal("""{}""", log.Message),
+                log => Assert.Equal("""{}""", log.Message),
+                log => Assert.Equal("""{"finish_reason":"stop","index":0,"message":{}}""", log.Message));
+        }
+
+        Assert.Collection(logs,
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.system.message"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]),
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.user.message"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]),
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.assistant.message"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]),
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.tool.message"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]),
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.assistant.message"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]),
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.user.message"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]),
+            log => Assert.Equal(new KeyValuePair<string, string?>("event.name", "gen_ai.choice"), ((IList<KeyValuePair<string, string?>>)log.State!)[0]));
+
+        Assert.All(logs, log =>
+        {
+            Assert.Equal(new KeyValuePair<string, string?>("gen_ai.system", "testservice"), ((IList<KeyValuePair<string, string?>>)log.State!)[1]);
+        });
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Microsoft.Extensions.AI.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Microsoft.Extensions.AI.Tests.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.Diagnostics.Testing\Microsoft.Extensions.Diagnostics.Testing.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI.Abstractions\Microsoft.Extensions.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Microsoft.Extensions.AI\Microsoft.Extensions.AI.csproj" ProjectUnderTest="true" />
   </ItemGroup>


### PR DESCRIPTION
- Events are now expected to be emitted as body fields, and the newly-recommended way to achieve that is via ILogger. So UseOpenTelemetry now takes an optional logger that it uses for emitting such data.
- I restructured the implementation to reduce duplication.
- Added logging of response format and seed.
- Added ChatOptions.TopK, as it's one of the parameters considered special by the spec.
- Updated the Azure.AI.Inference provider name to match the convention and what the library itself uses
- Updated the OpenAI client to use openai regardless of the kind of the actual client being used, per spec and recommendation

Closes https://github.com/dotnet/extensions/issues/5523
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5532)