### PR TITLE
Remove unnecessary ctors from FunctionResultContent

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/FunctionResultContent.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Contents/FunctionResultContent.cs
@@ -34,40 +34,6 @@ public sealed class FunctionResultContent : AIContent
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="FunctionResultContent"/> class.
-    /// </summary>
-    /// <param name="callId">The function call ID for which this is the result.</param>
-    /// <param name="name">The function name that produced the result.</param>
-    /// <param name="result">
-    /// This may be <see langword="null"/> if the function returned <see langword="null"/>, if the function was void-returning
-    /// and thus had no result, or if the function call failed. Typically, however, in order to provide meaningfully representative
-    /// information to an AI service, a human-readable representation of those conditions should be supplied.
-    /// </param>
-    /// <param name="exception">Any exception that occurred when invoking the function.</param>
-    public FunctionResultContent(string callId, string name, object? result, Exception? exception)
-    {
-        CallId = Throw.IfNull(callId);
-        Name = Throw.IfNull(name);
-        Result = result;
-        Exception = exception;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="FunctionResultContent"/> class.
-    /// </summary>
-    /// <param name="functionCall">The function call for which this is the result.</param>
-    /// <param name="result">
-    /// This may be <see langword="null"/> if the function returned <see langword="null"/>, if the function was void-returning
-    /// and thus had no result, or if the function call failed. Typically, however, in order to provide meaningfully representative
-    /// information to an AI service, a human-readable representation of those conditions should be supplied.
-    /// </param>
-    /// <param name="exception">Any exception that occurred when invoking the function.</param>
-    public FunctionResultContent(FunctionCallContent functionCall, object? result, Exception? exception = null)
-        : this(Throw.IfNull(functionCall).CallId, functionCall.Name, result, exception)
-    {
-    }
-
-    /// <summary>
     /// Gets or sets the ID of the function call for which this is the result.
     /// </summary>
     /// <remarks>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -552,7 +552,7 @@ public class FunctionInvokingChatClient : DelegatingChatClient
                 functionResult = message;
             }
 
-            return new FunctionResultContent(result.CallContent.CallId, result.CallContent.Name, functionResult, result.Exception);
+            return new FunctionResultContent(result.CallContent.CallId, result.CallContent.Name, functionResult) { Exception = result.Exception };
         }
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatMessageTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatMessageTests.cs
@@ -128,7 +128,7 @@ public class ChatMessageTests
             new FunctionCallContent("callId1", "fc1"),
             new TextContent("text-1"),
             new TextContent("text-2"),
-            new FunctionResultContent(new FunctionCallContent("callId1", "fc2"), "result"),
+            new FunctionResultContent("callId1", "fc2", "result"),
         ]);
 
         TextContent textContent = Assert.IsType<TextContent>(message.Contents[3]);
@@ -291,7 +291,7 @@ public class ChatMessageTests
                 AdditionalProperties = new() { ["metadata-key-6"] = "metadata-value-6" }
             },
             new FunctionCallContent("function-id", "plugin-name-function-name", new Dictionary<string, object?> { ["parameter"] = "argument" }),
-            new FunctionResultContent(new FunctionCallContent("function-id", "plugin-name-function-name"), "function-result"),
+            new FunctionResultContent("function-id", "plugin-name-function-name", "function-result"),
         ];
 
         // Act

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/StreamingChatCompletionUpdateTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/StreamingChatCompletionUpdateTests.cs
@@ -96,7 +96,7 @@ public class StreamingChatCompletionUpdateTests
                 new FunctionCallContent("callId1", "fc1"),
                 new TextContent("text-1"),
                 new TextContent("text-2"),
-                new FunctionResultContent(new FunctionCallContent("callId1", "fc2"), "result"),
+                new FunctionResultContent("callId1", "fc2", "result"),
             ],
         };
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionResultContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/FunctionResultContentTests.cs
@@ -25,30 +25,14 @@ public class FunctionResultContentTests
     [Fact]
     public void Constructor_String_PropsRoundtrip()
     {
-        Exception e = new();
-
-        FunctionResultContent c = new("id", "name", "result", e);
+        FunctionResultContent c = new("id", "name", "result");
         Assert.Null(c.RawRepresentation);
         Assert.Null(c.ModelId);
         Assert.Null(c.AdditionalProperties);
         Assert.Equal("name", c.Name);
         Assert.Equal("id", c.CallId);
         Assert.Equal("result", c.Result);
-        Assert.Same(e, c.Exception);
-    }
-
-    [Fact]
-    public void Constructor_FunctionCallContent_PropsRoundtrip()
-    {
-        Exception e = new();
-
-        FunctionResultContent c = new(new FunctionCallContent("id", "name"), "result", e);
-        Assert.Null(c.RawRepresentation);
-        Assert.Null(c.ModelId);
-        Assert.Null(c.AdditionalProperties);
-        Assert.Equal("id", c.CallId);
-        Assert.Equal("result", c.Result);
-        Assert.Same(e, c.Exception);
+        Assert.Null(c.Exception);
     }
 
     [Fact]
@@ -88,7 +72,7 @@ public class FunctionResultContentTests
     public void ItShouldBeSerializableAndDeserializable()
     {
         // Arrange
-        var sut = new FunctionResultContent(new FunctionCallContent("id", "p1-f1"), "result");
+        var sut = new FunctionResultContent("id", "p1-f1", "result");
 
         // Act
         var json = JsonSerializer.Serialize(sut, TestJsonSerializerContext.Default.Options);
@@ -106,7 +90,7 @@ public class FunctionResultContentTests
     public void ItShouldBeSerializableAndDeserializableWithException()
     {
         // Arrange
-        var sut = new FunctionResultContent("callId1", "functionName", null, new InvalidOperationException("hello"));
+        var sut = new FunctionResultContent("callId1", "functionName", null) { Exception = new InvalidOperationException("hello") };
 
         // Act
         var json = JsonSerializer.Serialize(sut, TestJsonSerializerContext.Default.Options);


### PR DESCRIPTION
This should be merged at around the same time as https://github.com/dotnet/extensions/pull/5535, to batch up breaks to the API abstractions layer.
cc: @SteveSandersonMS, @eiriktsarpalis 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5536)