### PR TITLE
Update the meter names of NetworkMetrics to match other meters in ResourceMonitoring

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Network/LinuxNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Network/LinuxNetworkMetrics.cs
@@ -19,7 +19,7 @@ internal sealed class LinuxNetworkMetrics
         // We don't dispose the meter because IMeterFactory handles that
         // Is's a false-positive, see: https://github.com/dotnet/roslyn-analyzers/issues/6912
         // Related documentation: https://github.com/dotnet/docs/pull/37170.
-        var meter = meterFactory.Create(nameof(ResourceMonitoring));
+        var meter = meterFactory.Create(ResourceUtilizationInstruments.MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         KeyValuePair<string, object?> tcpTag = new("network.transport", "tcp");

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Network/WindowsNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Network/WindowsNetworkMetrics.cs
@@ -19,7 +19,7 @@ internal sealed class WindowsNetworkMetrics
         // We don't dispose the meter because IMeterFactory handles that
         // Is's a false-positive, see: https://github.com/dotnet/roslyn-analyzers/issues/6912.
         // Related documentation: https://github.com/dotnet/docs/pull/37170
-        var meter = meterFactory.Create(nameof(ResourceMonitoring));
+        var meter = meterFactory.Create(ResourceUtilizationInstruments.MeterName);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         KeyValuePair<string, object?> tcpTag = new("network.transport", "tcp");

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxNetworkMetricsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxNetworkMetricsTests.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Network;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
+using Microsoft.TestUtilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test;
+
+[OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX, SkipReason = "Linux specific tests")]
+public class LinuxNetworkMetricsTests
+{
+    [Fact]
+    public void Creates_Meter_With_Correct_Name()
+    {
+        using var meterFactory = new TestMeterFactory();
+        var tcpStateInfoProviderMock = new Mock<ITcpStateInfoProvider>();
+        _ = new LinuxNetworkMetrics(meterFactory, tcpStateInfoProviderMock.Object);
+
+        Meter meter = meterFactory.Meters.Single();
+        Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsNetworkMetricsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsNetworkMetricsTests.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Network;
+using Microsoft.TestUtilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Test;
+
+[OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "Windows specific.")]
+public class WindowsNetworkMetricsTests
+{
+    [ConditionalFact]
+    public void Creates_Meter_With_Correct_Name()
+    {
+        using var meterFactory = new TestMeterFactory();
+        var tcpStateInfoProviderMock = new Mock<ITcpStateInfoProvider>();
+        _ = new WindowsNetworkMetrics(meterFactory, tcpStateInfoProviderMock.Object);
+
+        Meter meter = meterFactory.Meters.Single();
+        Assert.Equal(ResourceUtilizationInstruments.MeterName, meter.Name);
+    }
+}


### PR DESCRIPTION
Fixes #5537.

Changes the meter name in `WindowsNetworkMetrics.cs` to `Microsoft.Extensions.Diagnostics.ResourceMonitoring` to match the meter name in `WindowsContainerSnapshotProvider.cs`.

And the Linux one as well.

Related to #5403 and #5404.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5541)