### PR TITLE
Add missing [JsonIgnore] on ChatCompletion.Message

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatCompletion.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatCompletion.cs
@@ -42,6 +42,7 @@ public class ChatCompletion
     /// If there are multiple choices, this property returns the first choice.
     /// If <see cref="Choices"/> is empty, this will throw. Use <see cref="Choices"/> to access all choices directly."/>.
     /// </remarks>
+    [JsonIgnore]
     public ChatMessage Message
     {
         get


### PR DESCRIPTION
This property is an accelerator into Choices. It's already serialized as part of Choices and shouldn't be duplicated.