### PR TITLE
Add string constructor to OllamaEmbeddingGenerator

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaEmbeddingGenerator.cs
@@ -28,6 +28,18 @@ public sealed class OllamaEmbeddingGenerator : IEmbeddingGenerator<string, Embed
     /// Either this parameter or <see cref="ChatOptions.ModelId"/> must provide a valid model id.
     /// </param>
     /// <param name="httpClient">An <see cref="HttpClient"/> instance to use for HTTP operations.</param>
+    public OllamaEmbeddingGenerator(string endpoint, string? modelId = null, HttpClient? httpClient = null)
+        : this(new Uri(Throw.IfNull(endpoint)), modelId, httpClient)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="OllamaEmbeddingGenerator"/> class.</summary>
+    /// <param name="endpoint">The endpoint URI where Ollama is hosted.</param>
+    /// <param name="modelId">
+    /// The id of the model to use. This may also be overridden per request via <see cref="ChatOptions.ModelId"/>.
+    /// Either this parameter or <see cref="ChatOptions.ModelId"/> must provide a valid model id.
+    /// </param>
+    /// <param name="httpClient">An <see cref="HttpClient"/> instance to use for HTTP operations.</param>
     public OllamaEmbeddingGenerator(Uri endpoint, string? modelId = null, HttpClient? httpClient = null)
     {
         _ = Throw.IfNull(endpoint);
@@ -59,7 +71,8 @@ public sealed class OllamaEmbeddingGenerator : IEmbeddingGenerator<string, Embed
     }
 
     /// <inheritdoc />
-    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+        IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
     {
         _ = Throw.IfNull(values);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaEmbeddingGeneratorTests.cs
@@ -17,14 +17,14 @@ public class OllamaEmbeddingGeneratorTests
     [Fact]
     public void Ctor_InvalidArgs_Throws()
     {
-        Assert.Throws<ArgumentNullException>("endpoint", () => new OllamaEmbeddingGenerator(null!));
-        Assert.Throws<ArgumentException>("modelId", () => new OllamaEmbeddingGenerator(new("http://localhost"), "   "));
+        Assert.Throws<ArgumentNullException>("endpoint", () => new OllamaEmbeddingGenerator((string)null!));
+        Assert.Throws<ArgumentException>("modelId", () => new OllamaEmbeddingGenerator(new Uri("http://localhost"), "   "));
     }
 
     [Fact]
     public void GetService_SuccessfullyReturnsUnderlyingClient()
     {
-        using OllamaEmbeddingGenerator generator = new(new("http://localhost"));
+        using OllamaEmbeddingGenerator generator = new("http://localhost");
 
         Assert.Same(generator, generator.GetService<OllamaEmbeddingGenerator>());
         Assert.Same(generator, generator.GetService<IEmbeddingGenerator<string, Embedding<float>>>());
@@ -76,7 +76,7 @@ public class OllamaEmbeddingGeneratorTests
 
         using VerbatimHttpHandler handler = new(Input, Output);
         using HttpClient httpClient = new(handler);
-        using IEmbeddingGenerator<string, Embedding<float>> generator = new OllamaEmbeddingGenerator(new("http://localhost:11434"), "all-minilm", httpClient);
+        using IEmbeddingGenerator<string, Embedding<float>> generator = new OllamaEmbeddingGenerator("http://localhost:11434", "all-minilm", httpClient);
 
         var response = await generator.GenerateAsync([
             "hello, world!",


### PR DESCRIPTION
We'd previously added one to OllamaChatClient but neglected to add one here.

Separated out of https://github.com/dotnet/extensions/pull/5558