### PR TITLE
Cache current process object to avoid performance hit

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Interop/ProcessInfo.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Interop/ProcessInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -41,7 +42,6 @@ internal sealed class ProcessInfo : IProcessInfo
 
     public ulong GetCurrentProcessMemoryUsage()
     {
-        using Process process = Process.GetCurrentProcess();
-        return (ulong)process.WorkingSet64;
+        return (ulong)Environment.WorkingSet;
     }
 }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -109,8 +109,7 @@ internal sealed class WindowsSnapshotProvider : ISnapshotProvider
 
     internal static long GetMemoryUsageInBytes()
     {
-        using var process = Process.GetCurrentProcess();
-        return process.WorkingSet64;
+        return Environment.WorkingSet;
     }
 
     internal static ulong GetTotalMemoryInBytes()

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/ProcessInfoTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/ProcessInfoTests.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Test;
 /// </summary>
 /// <remarks>These tests are added for coverage reasons, but the code doesn't have
 /// the necessary environment predictability to really test it.</remarks>
-[OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "Windows specific.")]
 public sealed class ProcessInfoTests
 {
     [ConditionalFact]

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/ProcessInfoTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/ProcessInfoTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
+using Microsoft.TestUtilities;
+using Xunit;
+
+namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Test;
+
+/// <summary>
+/// Process Info Interop Tests.
+/// </summary>
+/// <remarks>These tests are added for coverage reasons, but the code doesn't have
+/// the necessary environment predictability to really test it.</remarks>
+[OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "Windows specific.")]
+public sealed class ProcessInfoTests
+{
+    [ConditionalFact]
+    public void GetCurrentProcessMemoryUsage()
+    {
+        var workingSet64 = new ProcessInfo().GetCurrentProcessMemoryUsage();
+        Assert.True(workingSet64 > 0);
+    }
+}


### PR DESCRIPTION
`GetCurrentProcessMemoryUsage` will be called by `src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs` from `GetSnapshot` method, which will be triggered every 1 second by default. And also this will be called by `_ = meter.CreateObservableGauge(name: ResourceUtilizationInstruments.ProcessMemoryUtilization, observeValue: () => MemoryPercentage(() => _processInfo.GetCurrentProcessMemoryUsage()));` with default interval: 5 seconds.

![image](https://github.com/user-attachments/assets/29de7e30-2359-4c3b-b7d3-1f0b7324b5ed)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5597)
 
 Related issue: https://github.com/dotnet/extensions/issues/5588
 
 Refer to another similar fix in Otel: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2286