### PR TITLE
HybridCache: don't log cancellation as failure event

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/HybridCacheEventSource.cs
+++ b/src/Libraries/Microsoft.Extensions.Caching.Hybrid/Internal/HybridCacheEventSource.cs
@@ -25,6 +25,8 @@ internal sealed class HybridCacheEventSource : EventSource
     internal const int EventIdLocalCacheWrite = 10;
     internal const int EventIdDistributedCacheWrite = 11;
     internal const int EventIdStampedeJoin = 12;
+    internal const int EventIdUnderlyingDataQueryCanceled = 13;
+    internal const int EventIdDistributedCacheCanceled = 14;
 
     // fast local counters
     private long _totalLocalCacheHit;
@@ -117,6 +119,14 @@ internal sealed class HybridCacheEventSource : EventSource
         WriteEvent(EventIdDistributedCacheFailed);
     }
 
+    [Event(EventIdDistributedCacheCanceled, Level = EventLevel.Verbose)]
+    public void DistributedCacheCanceled()
+    {
+        DebugAssertEnabled();
+        _ = Interlocked.Decrement(ref _currentDistributedFetch);
+        WriteEvent(EventIdDistributedCacheCanceled);
+    }
+
     [Event(EventIdUnderlyingDataQueryStart, Level = EventLevel.Verbose)]
     public void UnderlyingDataQueryStart()
     {
@@ -141,6 +151,14 @@ internal sealed class HybridCacheEventSource : EventSource
         DebugAssertEnabled();
         _ = Interlocked.Decrement(ref _currentUnderlyingDataQuery);
         WriteEvent(EventIdUnderlyingDataQueryFailed);
+    }
+
+    [Event(EventIdUnderlyingDataQueryCanceled, Level = EventLevel.Verbose)]
+    public void UnderlyingDataQueryCanceled()
+    {
+        DebugAssertEnabled();
+        _ = Interlocked.Decrement(ref _currentUnderlyingDataQuery);
+        WriteEvent(EventIdUnderlyingDataQueryCanceled);
     }
 
     [Event(EventIdLocalCacheWrite, Level = EventLevel.Verbose)]

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/HybridCacheEventSourceTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/HybridCacheEventSourceTests.cs
@@ -100,6 +100,19 @@ public class HybridCacheEventSourceTests(ITestOutputHelper log, TestEventListene
     }
 
     [SkippableFact]
+    public async Task DistributedCacheCanceled()
+    {
+        AssertEnabled();
+
+        listener.Reset().Source.DistributedCacheGet();
+        listener.Reset(resetCounters: false).Source.DistributedCacheCanceled();
+        listener.AssertSingleEvent(HybridCacheEventSource.EventIdDistributedCacheCanceled, "DistributedCacheCanceled", EventLevel.Verbose);
+
+        await AssertCountersAsync();
+        listener.AssertRemainingCountersZero();
+    }
+
+    [SkippableFact]
     public async Task UnderlyingDataQueryStart()
     {
         AssertEnabled();
@@ -135,6 +148,20 @@ public class HybridCacheEventSourceTests(ITestOutputHelper log, TestEventListene
         listener.Reset().Source.UnderlyingDataQueryStart();
         listener.Reset(resetCounters: false).Source.UnderlyingDataQueryFailed();
         listener.AssertSingleEvent(HybridCacheEventSource.EventIdUnderlyingDataQueryFailed, "UnderlyingDataQueryFailed", EventLevel.Error);
+
+        await AssertCountersAsync();
+        listener.AssertCounter("total-data-query", "Total Data Queries", 1);
+        listener.AssertRemainingCountersZero();
+    }
+
+    [SkippableFact]
+    public async Task UnderlyingDataQueryCanceled()
+    {
+        AssertEnabled();
+
+        listener.Reset().Source.UnderlyingDataQueryStart();
+        listener.Reset(resetCounters: false).Source.UnderlyingDataQueryCanceled();
+        listener.AssertSingleEvent(HybridCacheEventSource.EventIdUnderlyingDataQueryCanceled, "UnderlyingDataQueryCanceled", EventLevel.Verbose);
 
         await AssertCountersAsync();
         listener.AssertCounter("total-data-query", "Total Data Queries", 1);

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/TestEventListener.cs
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/TestEventListener.cs
@@ -50,7 +50,7 @@ public sealed class TestEventListener : EventListener
             {
                 ["EventCounterIntervalSec"] = EventCounterIntervalSec.ToString("G", CultureInfo.InvariantCulture),
             };
-            EnableEvents(Source, EventLevel.Verbose, EventKeywords.All, args);
+            EnableEvents(Source, EventLevel.LogAlways, EventKeywords.All, args);
         }
 
         base.OnEventSourceCreated(eventSource);


### PR DESCRIPTION
Follow up PR feedback from https://github.com/dotnet/extensions/pull/5467

If the operation is cancelled, do not report as a failure; we still need to decrement the counters, and there is a new corresponding event (at level "verbose" rather than "error")

Note: intentionally doesn't demand that `OperationCanceledException.Token` is correctly set, as that can be a little brittle; if we see an `OperationCanceledException` *and* `SharedToken` is marked as cancelled: that's good enough to assume that the two things are related, at least enough for logging purposes.

/cc @BrennanConroy 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5601)