### PR TITLE
Add anonymous chat clients / embedding generators

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,6 +63,7 @@
     <SystemTextEncodingsWebVersion>9.0.0</SystemTextEncodingsWebVersion>
     <SystemNumericsTensorsVersion>9.0.0</SystemNumericsTensorsVersion>
     <SystemTextJsonVersion>9.0.0</SystemTextJsonVersion>
+    <SystemThreadingChannelsVersion>9.0.0</SystemThreadingChannelsVersion>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
     <MicrosoftAspNetCoreAppRefVersion>9.0.1</MicrosoftAspNetCoreAppRefVersion>
     <MicrosoftAspNetCoreAppRuntimewinx64Version>9.0.1</MicrosoftAspNetCoreAppRuntimewinx64Version>
@@ -112,6 +113,7 @@
     <SystemTextEncodingsWebLTSVersion>8.0.0</SystemTextEncodingsWebLTSVersion>
     <SystemNumericsTensorsLTSVersion>8.0.0</SystemNumericsTensorsLTSVersion>
     <SystemTextJsonLTSVersion>8.0.5</SystemTextJsonLTSVersion>
+    <SystemThreadingChannelsLTSVersion>8.0.0</SystemThreadingChannelsLTSVersion>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
     <MicrosoftAspNetCoreAppRefLTSVersion>8.0.11</MicrosoftAspNetCoreAppRefLTSVersion>
     <MicrosoftAspNetCoreAppRuntimewinx64LTSVersion>8.0.11</MicrosoftAspNetCoreAppRuntimewinx64LTSVersion>

--- a/eng/packages/General-LTS.props
+++ b/eng/packages/General-LTS.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonLTSVersion)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebLTSVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonLTSVersion)" />
+    <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsLTSVersion)" />
   </ItemGroup>
 
 </Project>

--- a/eng/packages/General-net9.props
+++ b/eng/packages/General-net9.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/AnonymousDelegatingChatClient.cs
@@ -1,0 +1,213 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Shared.Diagnostics;
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>A delegating chat client that wraps an inner client with implementations provided by delegates.</summary>
+public sealed class AnonymousDelegatingChatClient : DelegatingChatClient
+{
+    /// <summary>The delegate to use as the implementation of <see cref="CompleteAsync"/>.</summary>
+    private readonly Func<IList<ChatMessage>, ChatOptions?, IChatClient, CancellationToken, Task<ChatCompletion>>? _completeFunc;
+
+    /// <summary>The delegate to use as the implementation of <see cref="CompleteStreamingAsync"/>.</summary>
+    /// <remarks>
+    /// When non-<see langword="null"/>, this delegate is used as the implementation of <see cref="CompleteStreamingAsync"/> and
+    /// will be invoked with the same arguments as the method itself, along with a reference to the inner client.
+    /// When <see langword="null"/>, <see cref="CompleteStreamingAsync"/> will delegate directly to the inner client.
+    /// </remarks>
+    private readonly Func<IList<ChatMessage>, ChatOptions?, IChatClient, CancellationToken, IAsyncEnumerable<StreamingChatCompletionUpdate>>? _completeStreamingFunc;
+
+    /// <summary>The delegate to use as the implementation of both <see cref="CompleteAsync"/> and <see cref="CompleteStreamingAsync"/>.</summary>
+    private readonly CompleteSharedFunc? _sharedFunc;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnonymousDelegatingChatClient"/> class.
+    /// </summary>
+    /// <param name="innerClient">The inner client.</param>
+    /// <param name="sharedFunc">
+    /// A delegate that provides the implementation for both <see cref="CompleteAsync"/> and <see cref="CompleteStreamingAsync"/>.
+    /// In addition to the arguments for the operation, it's provided with a delegate to the inner client that should be
+    /// used to perform the operation on the inner client. It will handle both the non-streaming and streaming cases.
+    /// </param>
+    /// <remarks>
+    /// This overload may be used when the anonymous implementation needs to provide pre- and/or post-processing, but doesn't
+    /// need to interact with the results of the operation, which will come from the inner client.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="innerClient"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="sharedFunc"/> is <see langword="null"/>.</exception>
+    public AnonymousDelegatingChatClient(IChatClient innerClient, CompleteSharedFunc sharedFunc)
+        : base(innerClient)
+    {
+        _ = Throw.IfNull(sharedFunc);
+
+        _sharedFunc = sharedFunc;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnonymousDelegatingChatClient"/> class.
+    /// </summary>
+    /// <param name="innerClient">The inner client.</param>
+    /// <param name="completeFunc">
+    /// A delegate that provides the implementation for <see cref="CompleteAsync"/>. When <see langword="null"/>,
+    /// <paramref name="completeStreamingFunc"/> must be non-null, and the implementation of <see cref="CompleteAsync"/>
+    /// will use <paramref name="completeStreamingFunc"/> for the implementation.
+    /// </param>
+    /// <param name="completeStreamingFunc">
+    /// A delegate that provides the implementation for <see cref="CompleteStreamingAsync"/>. When <see langword="null"/>,
+    /// <paramref name="completeFunc"/> must be non-null, and the implementation of <see cref="CompleteStreamingAsync"/>
+    /// will use <paramref name="completeFunc"/> for the implementation.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="innerClient"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Both <paramref name="completeFunc"/> and <paramref name="completeStreamingFunc"/> are <see langword="null"/>.</exception>
+    public AnonymousDelegatingChatClient(
+        IChatClient innerClient,
+        Func<IList<ChatMessage>, ChatOptions?, IChatClient, CancellationToken, Task<ChatCompletion>>? completeFunc,
+        Func<IList<ChatMessage>, ChatOptions?, IChatClient, CancellationToken, IAsyncEnumerable<StreamingChatCompletionUpdate>>? completeStreamingFunc)
+        : base(innerClient)
+    {
+        ThrowIfBothDelegatesNull(completeFunc, completeStreamingFunc);
+
+        _completeFunc = completeFunc;
+        _completeStreamingFunc = completeStreamingFunc;
+    }
+
+    /// <inheritdoc/>
+    public override Task<ChatCompletion> CompleteAsync(
+        IList<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(chatMessages);
+
+        if (_sharedFunc is not null)
+        {
+            return CompleteViaSharedAsync(chatMessages, options, cancellationToken);
+
+            async Task<ChatCompletion> CompleteViaSharedAsync(IList<ChatMessage> chatMessages, ChatOptions? options, CancellationToken cancellationToken)
+            {
+                ChatCompletion? completion = null;
+                await _sharedFunc(chatMessages, options, async (chatMessages, options, cancellationToken) =>
+                {
+                    completion = await InnerClient.CompleteAsync(chatMessages, options, cancellationToken).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
+
+                if (completion is null)
+                {
+                    throw new InvalidOperationException("The wrapper completed successfully without producing a ChatCompletion.");
+                }
+
+                return completion;
+            }
+        }
+        else if (_completeFunc is not null)
+        {
+            return _completeFunc(chatMessages, options, InnerClient, cancellationToken);
+        }
+        else
+        {
+            Debug.Assert(_completeStreamingFunc is not null, "Expected non-null streaming delegate.");
+            return _completeStreamingFunc!(chatMessages, options, InnerClient, cancellationToken)
+                .ToChatCompletionAsync(coalesceContent: true, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override IAsyncEnumerable<StreamingChatCompletionUpdate> CompleteStreamingAsync(
+        IList<ChatMessage> chatMessages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(chatMessages);
+
+        if (_sharedFunc is not null)
+        {
+            var updates = Channel.CreateBounded<StreamingChatCompletionUpdate>(1);
+
+#pragma warning disable CA2016 // explicitly not forwarding the cancellation token, as we need to ensure the channel is always completed
+            _ = Task.Run(async () =>
+#pragma warning restore CA2016
+            {
+                Exception? error = null;
+                try
+                {
+                    await _sharedFunc(chatMessages, options, async (chatMessages, options, cancellationToken) =>
+                    {
+                        await foreach (var update in InnerClient.CompleteStreamingAsync(chatMessages, options, cancellationToken).ConfigureAwait(false))
+                        {
+                            await updates.Writer.WriteAsync(update, cancellationToken).ConfigureAwait(false);
+                        }
+                    }, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                    throw;
+                }
+                finally
+                {
+                    _ = updates.Writer.TryComplete(error);
+                }
+            });
+
+            return updates.Reader.ReadAllAsync(cancellationToken);
+        }
+        else if (_completeStreamingFunc is not null)
+        {
+            return _completeStreamingFunc(chatMessages, options, InnerClient, cancellationToken);
+        }
+        else
+        {
+            Debug.Assert(_completeFunc is not null, "Expected non-null non-streaming delegate.");
+            return CompleteStreamingAsyncViaCompleteAsync(_completeFunc!(chatMessages, options, InnerClient, cancellationToken));
+
+            static async IAsyncEnumerable<StreamingChatCompletionUpdate> CompleteStreamingAsyncViaCompleteAsync(Task<ChatCompletion> task)
+            {
+                ChatCompletion completion = await task.ConfigureAwait(false);
+                foreach (var update in completion.ToStreamingChatCompletionUpdates())
+                {
+                    yield return update;
+                }
+            }
+        }
+    }
+
+    /// <summary>Throws an exception if both of the specified delegates are null.</summary>
+    /// <exception cref="ArgumentNullException">Both <paramref name="completeFunc"/> and <paramref name="completeStreamingFunc"/> are <see langword="null"/>.</exception>
+    internal static void ThrowIfBothDelegatesNull(object? completeFunc, object? completeStreamingFunc)
+    {
+        if (completeFunc is null && completeStreamingFunc is null)
+        {
+            Throw.ArgumentNullException(nameof(completeFunc), $"At least one of the {nameof(completeFunc)} or {nameof(completeStreamingFunc)} delegates must be non-null.");
+        }
+    }
+
+    // Design note:
+    // The following delegate could juse use Func<...>, but it's defined as a custom delegate type
+    // in order to provide better discoverability / documentation / usability around its complicated
+    // signature with the nextAsync delegate parameter.
+
+    /// <summary>
+    /// Represents a method used to call <see cref="IChatClient.CompleteAsync"/> or <see cref="IChatClient.CompleteStreamingAsync"/>.
+    /// </summary>
+    /// <param name="chatMessages">The chat content to send.</param>
+    /// <param name="options">The chat options to configure the request.</param>
+    /// <param name="nextAsync">
+    /// A delegate that provides the implementation for the inner client's <see cref="IChatClient.CompleteAsync"/> or
+    /// <see cref="IChatClient.CompleteStreamingAsync"/>. It should be invoked to continue the pipeline. It accepts
+    /// the chat messages, options, and cancellation token, which are typically the same instances as provided to this method
+    /// but need not be.
+    /// </param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A <see cref="Task"/> that represents the completion of the operation.</returns>
+    public delegate Task CompleteSharedFunc(
+        IList<ChatMessage> chatMessages,
+        ChatOptions? options,
+        Func<IList<ChatMessage>, ChatOptions?, CancellationToken, Task> nextAsync,
+        CancellationToken cancellationToken);
+}

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilder.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilder.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -75,5 +77,63 @@ public sealed class ChatClientBuilder
 
         (_clientFactories ??= []).Add(clientFactory);
         return this;
+    }
+
+    /// <summary>
+    /// Adds to the chat client pipeline an anonymous delegating chat client based on a delegate that provides
+    /// an implementation for both <see cref="IChatClient.CompleteAsync"/> and <see cref="IChatClient.CompleteStreamingAsync"/>.
+    /// </summary>
+    /// <param name="sharedFunc">
+    /// A delegate that provides the implementation for both <see cref="IChatClient.CompleteAsync"/> and
+    /// <see cref="IChatClient.CompleteStreamingAsync"/>. In addition to the arguments for the operation, it's
+    /// provided with a delegate to the inner client that should be used to perform the operation on the inner client.
+    /// It will handle both the non-streaming and streaming cases.
+    /// </param>
+    /// <returns>The updated <see cref="ChatClientBuilder"/> instance.</returns>
+    /// <remarks>
+    /// This overload may be used when the anonymous implementation needs to provide pre- and/or post-processing, but doesn't
+    /// need to interact with the results of the operation, which will come from the inner client.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="sharedFunc"/> is <see langword="null"/>.</exception>
+    public ChatClientBuilder Use(AnonymousDelegatingChatClient.CompleteSharedFunc sharedFunc)
+    {
+        _ = Throw.IfNull(sharedFunc);
+
+        return Use((innerClient, _) => new AnonymousDelegatingChatClient(innerClient, sharedFunc));
+    }
+
+    /// <summary>
+    /// Adds to the chat client pipeline an anonymous delegating chat client based on a delegate that provides
+    /// an implementation for both <see cref="IChatClient.CompleteAsync"/> and <see cref="IChatClient.CompleteStreamingAsync"/>.
+    /// </summary>
+    /// <param name="completeFunc">
+    /// A delegate that provides the implementation for <see cref="IChatClient.CompleteAsync"/>. When <see langword="null"/>,
+    /// <paramref name="completeStreamingFunc"/> must be non-null, and the implementation of <see cref="IChatClient.CompleteAsync"/>
+    /// will use <paramref name="completeStreamingFunc"/> for the implementation.
+    /// </param>
+    /// <param name="completeStreamingFunc">
+    /// A delegate that provides the implementation for <see cref="IChatClient.CompleteStreamingAsync"/>. When <see langword="null"/>,
+    /// <paramref name="completeFunc"/> must be non-null, and the implementation of <see cref="IChatClient.CompleteStreamingAsync"/>
+    /// will use <paramref name="completeFunc"/> for the implementation.
+    /// </param>
+    /// <returns>The updated <see cref="ChatClientBuilder"/> instance.</returns>
+    /// <remarks>
+    /// One or both delegates may be provided. If both are provided, they will be used for their respective methods:
+    /// <paramref name="completeFunc"/> will provide the implementation of <see cref="IChatClient.CompleteAsync"/>, and
+    /// <paramref name="completeStreamingFunc"/> will provide the implementation of <see cref="IChatClient.CompleteStreamingAsync"/>.
+    /// If only one of the delegates is provided, it will be used for both methods. That means that if <paramref name="completeFunc"/>
+    /// is supplied without <paramref name="completeStreamingFunc"/>, the implementation of <see cref="IChatClient.CompleteStreamingAsync"/>
+    /// will employ limited streaming, as it will be operating on the batch output produced by <paramref name="completeFunc"/>. And if
+    /// <paramref name="completeStreamingFunc"/> is supplied without <paramref name="completeFunc"/>, the implementation of
+    /// <see cref="IChatClient.CompleteAsync"/> will be implemented by combining the updates from <paramref name="completeStreamingFunc"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Both <paramref name="completeFunc"/> and <paramref name="completeStreamingFunc"/> are <see langword="null"/>.</exception>
+    public ChatClientBuilder Use(
+        Func<IList<ChatMessage>, ChatOptions?, IChatClient, CancellationToken, Task<ChatCompletion>>? completeFunc,
+        Func<IList<ChatMessage>, ChatOptions?, IChatClient, CancellationToken, IAsyncEnumerable<StreamingChatCompletionUpdate>>? completeStreamingFunc)
+    {
+        AnonymousDelegatingChatClient.ThrowIfBothDelegatesNull(completeFunc, completeStreamingFunc);
+
+        return Use((innerClient, _) => new AnonymousDelegatingChatClient(innerClient, completeFunc, completeStreamingFunc));
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/AnonymousDelegatingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/AnonymousDelegatingEmbeddingGenerator.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>A delegating embedding generator that wraps an inner generator with implementations provided by delegates.</summary>
+/// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
+/// <typeparam name="TEmbedding">The type of embeddings to generate.</typeparam>
+public sealed class AnonymousDelegatingEmbeddingGenerator<TInput, TEmbedding> : DelegatingEmbeddingGenerator<TInput, TEmbedding>
+    where TEmbedding : Embedding
+{
+    /// <summary>The delegate to use as the implementation of <see cref="GenerateAsync"/>.</summary>
+    private readonly Func<IEnumerable<TInput>, EmbeddingGenerationOptions?, IEmbeddingGenerator<TInput, TEmbedding>, CancellationToken, Task<GeneratedEmbeddings<TEmbedding>>> _generateFunc;
+
+    /// <summary>Initializes a new instance of the <see cref="AnonymousDelegatingEmbeddingGenerator{TInput, TEmbedding}"/> class.</summary>
+    /// <param name="innerGenerator">The inner generator.</param>
+    /// <param name="generateFunc">A delegate that provides the implementation for <see cref="GenerateAsync"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="innerGenerator"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="generateFunc"/> is <see langword="null"/>.</exception>
+    public AnonymousDelegatingEmbeddingGenerator(
+        IEmbeddingGenerator<TInput, TEmbedding> innerGenerator,
+        Func<IEnumerable<TInput>, EmbeddingGenerationOptions?, IEmbeddingGenerator<TInput, TEmbedding>, CancellationToken, Task<GeneratedEmbeddings<TEmbedding>>> generateFunc)
+        : base(innerGenerator)
+    {
+        _ = Throw.IfNull(generateFunc);
+
+        _generateFunc = generateFunc;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<GeneratedEmbeddings<TEmbedding>> GenerateAsync(
+        IEnumerable<TInput> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(values);
+
+        return await _generateFunc(values, options, InnerGenerator, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI/Microsoft.Extensions.AI.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/UseDelegateChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/UseDelegateChatClientTests.cs
@@ -1,0 +1,255 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class UseDelegateChatClientTests
+{
+    [Fact]
+    public void InvalidArgs_Throws()
+    {
+        using var client = new TestChatClient();
+        ChatClientBuilder builder = new(client);
+
+        Assert.Throws<ArgumentNullException>("sharedFunc", () =>
+            builder.Use((AnonymousDelegatingChatClient.CompleteSharedFunc)null!));
+
+        Assert.Throws<ArgumentNullException>("completeFunc", () => builder.Use(null!, null!));
+
+        Assert.Throws<ArgumentNullException>("innerClient", () => new AnonymousDelegatingChatClient(null!, delegate { return Task.CompletedTask; }));
+        Assert.Throws<ArgumentNullException>("sharedFunc", () => new AnonymousDelegatingChatClient(client, null!));
+
+        Assert.Throws<ArgumentNullException>("innerClient", () => new AnonymousDelegatingChatClient(null!, null!, null!));
+        Assert.Throws<ArgumentNullException>("completeFunc", () => new AnonymousDelegatingChatClient(client, null!, null!));
+    }
+
+    [Fact]
+    public async Task Shared_ContextPropagated()
+    {
+        IList<ChatMessage> expectedMessages = [];
+        ChatOptions expectedOptions = new();
+        using CancellationTokenSource expectedCts = new();
+
+        AsyncLocal<int> asyncLocal = new();
+
+        using IChatClient innerClient = new TestChatClient
+        {
+            CompleteAsyncCallback = (chatMessages, options, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return Task.FromResult(new ChatCompletion(new ChatMessage(ChatRole.Assistant, "hello")));
+            },
+
+            CompleteStreamingAsyncCallback = (chatMessages, options, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return YieldUpdates(new StreamingChatCompletionUpdate { Text = "world" });
+            },
+        };
+
+        using IChatClient client = new ChatClientBuilder(innerClient)
+            .Use(async (chatMessages, options, next, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                asyncLocal.Value = 42;
+                await next(chatMessages, options, cancellationToken);
+            })
+            .Build();
+
+        Assert.Equal(0, asyncLocal.Value);
+        ChatCompletion completion = await client.CompleteAsync(expectedMessages, expectedOptions, expectedCts.Token);
+        Assert.Equal("hello", completion.Message.Text);
+
+        Assert.Equal(0, asyncLocal.Value);
+        completion = await client.CompleteStreamingAsync(expectedMessages, expectedOptions, expectedCts.Token).ToChatCompletionAsync();
+        Assert.Equal("world", completion.Message.Text);
+    }
+
+    [Fact]
+    public async Task CompleteFunc_ContextPropagated()
+    {
+        IList<ChatMessage> expectedMessages = [];
+        ChatOptions expectedOptions = new();
+        using CancellationTokenSource expectedCts = new();
+        AsyncLocal<int> asyncLocal = new();
+
+        using IChatClient innerClient = new TestChatClient
+        {
+            CompleteAsyncCallback = (chatMessages, options, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return Task.FromResult(new ChatCompletion(new ChatMessage(ChatRole.Assistant, "hello")));
+            },
+        };
+
+        using IChatClient client = new ChatClientBuilder(innerClient)
+            .Use(async (chatMessages, options, innerClient, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                asyncLocal.Value = 42;
+                var cc = await innerClient.CompleteAsync(chatMessages, options, cancellationToken);
+                cc.Choices[0].Text += " world";
+                return cc;
+            }, null)
+            .Build();
+
+        Assert.Equal(0, asyncLocal.Value);
+
+        ChatCompletion completion = await client.CompleteAsync(expectedMessages, expectedOptions, expectedCts.Token);
+        Assert.Equal("hello world", completion.Message.Text);
+
+        completion = await client.CompleteStreamingAsync(expectedMessages, expectedOptions, expectedCts.Token).ToChatCompletionAsync();
+        Assert.Equal("hello world", completion.Message.Text);
+    }
+
+    [Fact]
+    public async Task CompleteStreamingFunc_ContextPropagated()
+    {
+        IList<ChatMessage> expectedMessages = [];
+        ChatOptions expectedOptions = new();
+        using CancellationTokenSource expectedCts = new();
+        AsyncLocal<int> asyncLocal = new();
+
+        using IChatClient innerClient = new TestChatClient
+        {
+            CompleteStreamingAsyncCallback = (chatMessages, options, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return YieldUpdates(new StreamingChatCompletionUpdate { Text = "hello" });
+            },
+        };
+
+        using IChatClient client = new ChatClientBuilder(innerClient)
+            .Use(null, (chatMessages, options, innerClient, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                asyncLocal.Value = 42;
+                return Impl(chatMessages, options, innerClient, cancellationToken);
+
+                static async IAsyncEnumerable<StreamingChatCompletionUpdate> Impl(
+                    IList<ChatMessage> chatMessages, ChatOptions? options, IChatClient innerClient, [EnumeratorCancellation] CancellationToken cancellationToken)
+                {
+                    await foreach (var update in innerClient.CompleteStreamingAsync(chatMessages, options, cancellationToken))
+                    {
+                        yield return update;
+                    }
+
+                    yield return new() { Text = " world" };
+                }
+            })
+            .Build();
+
+        Assert.Equal(0, asyncLocal.Value);
+
+        ChatCompletion completion = await client.CompleteAsync(expectedMessages, expectedOptions, expectedCts.Token);
+        Assert.Equal("hello world", completion.Message.Text);
+
+        completion = await client.CompleteStreamingAsync(expectedMessages, expectedOptions, expectedCts.Token).ToChatCompletionAsync();
+        Assert.Equal("hello world", completion.Message.Text);
+    }
+
+    [Fact]
+    public async Task BothCompleteAndCompleteStreamingFuncs_ContextPropagated()
+    {
+        IList<ChatMessage> expectedMessages = [];
+        ChatOptions expectedOptions = new();
+        using CancellationTokenSource expectedCts = new();
+        AsyncLocal<int> asyncLocal = new();
+
+        using IChatClient innerClient = new TestChatClient
+        {
+            CompleteAsyncCallback = (chatMessages, options, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return Task.FromResult(new ChatCompletion(new ChatMessage(ChatRole.Assistant, "non-streaming hello")));
+            },
+
+            CompleteStreamingAsyncCallback = (chatMessages, options, cancellationToken) =>
+            {
+                Assert.Same(expectedMessages, chatMessages);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return YieldUpdates(new StreamingChatCompletionUpdate { Text = "streaming hello" });
+            },
+        };
+
+        using IChatClient client = new ChatClientBuilder(innerClient)
+            .Use(
+                async (chatMessages, options, innerClient, cancellationToken) =>
+                {
+                    Assert.Same(expectedMessages, chatMessages);
+                    Assert.Same(expectedOptions, options);
+                    Assert.Equal(expectedCts.Token, cancellationToken);
+                    asyncLocal.Value = 42;
+                    var cc = await innerClient.CompleteAsync(chatMessages, options, cancellationToken);
+                    cc.Choices[0].Text += " world (non-streaming)";
+                    return cc;
+                },
+                (chatMessages, options, innerClient, cancellationToken) =>
+                {
+                    Assert.Same(expectedMessages, chatMessages);
+                    Assert.Same(expectedOptions, options);
+                    Assert.Equal(expectedCts.Token, cancellationToken);
+                    asyncLocal.Value = 42;
+                    return Impl(chatMessages, options, innerClient, cancellationToken);
+
+                    static async IAsyncEnumerable<StreamingChatCompletionUpdate> Impl(
+                        IList<ChatMessage> chatMessages, ChatOptions? options, IChatClient innerClient, [EnumeratorCancellation] CancellationToken cancellationToken)
+                    {
+                        await foreach (var update in innerClient.CompleteStreamingAsync(chatMessages, options, cancellationToken))
+                        {
+                            yield return update;
+                        }
+
+                        yield return new() { Text = " world (streaming)" };
+                    }
+                })
+            .Build();
+
+        Assert.Equal(0, asyncLocal.Value);
+
+        ChatCompletion completion = await client.CompleteAsync(expectedMessages, expectedOptions, expectedCts.Token);
+        Assert.Equal("non-streaming hello world (non-streaming)", completion.Message.Text);
+
+        completion = await client.CompleteStreamingAsync(expectedMessages, expectedOptions, expectedCts.Token).ToChatCompletionAsync();
+        Assert.Equal("streaming hello world (streaming)", completion.Message.Text);
+    }
+
+    private static async IAsyncEnumerable<StreamingChatCompletionUpdate> YieldUpdates(params StreamingChatCompletionUpdate[] updates)
+    {
+        foreach (var update in updates)
+        {
+            await Task.Yield();
+            yield return update;
+        }
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/UseDelegateEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/UseDelegateEmbeddingGeneratorTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class UseDelegateEmbeddingGeneratorTests
+{
+    [Fact]
+    public void InvalidArgs_Throws()
+    {
+        using var generator = new TestEmbeddingGenerator();
+        EmbeddingGeneratorBuilder<string, Embedding<float>> builder = new(generator);
+
+        Assert.Throws<ArgumentNullException>("generateFunc", () =>
+            builder.Use((Func<IEnumerable<string>, EmbeddingGenerationOptions?, IEmbeddingGenerator<string, Embedding<float>>, CancellationToken, Task<GeneratedEmbeddings<Embedding<float>>>>)null!));
+
+        Assert.Throws<ArgumentNullException>("innerGenerator", () =>
+            new AnonymousDelegatingEmbeddingGenerator<string, Embedding<float>>(
+                null!, (values, options, innerGenerator, cancellationToken) => Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(Array.Empty<Embedding<float>>()))));
+
+        Assert.Throws<ArgumentNullException>("generateFunc", () =>
+            new AnonymousDelegatingEmbeddingGenerator<string, Embedding<float>>(generator, null!));
+    }
+
+    [Fact]
+    public async Task GenerateFunc_ContextPropagated()
+    {
+        GeneratedEmbeddings<Embedding<float>> expectedEmbeddings = new();
+        IList<string> expectedValues = ["hello"];
+        EmbeddingGenerationOptions expectedOptions = new();
+        using CancellationTokenSource expectedCts = new();
+        AsyncLocal<int> asyncLocal = new();
+
+        using IEmbeddingGenerator<string, Embedding<float>> innerGenerator = new TestEmbeddingGenerator
+        {
+            GenerateAsyncCallback = (values, options, cancellationToken) =>
+            {
+                Assert.Same(expectedValues, values);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                Assert.Equal(42, asyncLocal.Value);
+                return Task.FromResult(expectedEmbeddings);
+            },
+        };
+
+        using IEmbeddingGenerator<string, Embedding<float>> generator = new EmbeddingGeneratorBuilder<string, Embedding<float>>(innerGenerator)
+            .Use(async (values, options, innerGenerator, cancellationToken) =>
+            {
+                Assert.Same(expectedValues, values);
+                Assert.Same(expectedOptions, options);
+                Assert.Equal(expectedCts.Token, cancellationToken);
+                asyncLocal.Value = 42;
+                var e = await innerGenerator.GenerateAsync(values, options, cancellationToken);
+                e.Add(new Embedding<float>(default));
+                return e;
+            })
+            .Build();
+
+        Assert.Equal(0, asyncLocal.Value);
+
+        GeneratedEmbeddings<Embedding<float>> actual = await generator.GenerateAsync(expectedValues, expectedOptions, expectedCts.Token);
+        Assert.Same(expectedEmbeddings, actual);
+        Assert.Single(actual);
+    }
+}


### PR DESCRIPTION
Provides an `AnonymousChatClient`/`EmbeddingGenerator` and corresponding `UseAnonymous` methods, that enable adding simple middleware functionality without needing to derive a custom type from `DelegatingChatHandler`. For example, a client that wants to add a message before delegating and remove it after can just do:
```C#
.UseAnonymous(async (args, next) =>
{
    ChatMessage m = new(ChatRole.User, "Always respond in Italian");
    args.ChatMessages.Add(m);
    try { await next(args.ChatMessages, args.Options, args.CancellationToken); }
    finally { args.ChatMessages.Remove(m); }
})
```
With that overload, the same delegate is used for both non-streaming and streaming, with the batch or streaming results forwarded to the consumer, such that this delegate doesn't get a chance to mutate or augment the results. If such mutation is desired, another overload exists that allows for the non-streaming and streaming to be provided using their own dedicated delegates. If just one of the delegates is provided, than the other mode is implemented in terms of it.
```C#
.UseAnonymous(async args =>
{
    ChatMessage m = new(ChatRole.User, "Always respond in Italian");
    args.ChatMessages.Add(m);
    try
    {
        ChatCompletion completion = await args.InnerClient.CompleteAsync(args.ChatMessages, args.Options, args.CancellationToken);
        foreach (ChatMessage choice in completion.Choices)
        {
            choice.Text += "Caio!";
        }
        return completion;
    }
    finally { args.ChatMessages.Remove(m); }
})
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5650)