### PR TITLE
Remove duplicate GetCacheKey methods

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
@@ -92,7 +92,10 @@ public class DistributedCachingChatClient : CachingChatClient
         await _storage.SetAsync(key, newJson, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <inheritdoc />
+    /// <summary>Computes a cache key for the specified values.</summary>
+    /// <param name="values">The values to inform the key.</param>
+    /// <returns>The computed key.</returns>
+    /// <remarks>The <paramref name="values"/> are serialized to JSON using <see cref="JsonSerializerOptions"/> in order to compute the key.</remarks>
     protected override string GetCacheKey(params ReadOnlySpan<object?> values)
     {
         _jsonSerializerOptions.MakeReadOnly();

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/DistributedCachingChatClient.cs
@@ -20,12 +20,6 @@ namespace Microsoft.Extensions.AI;
 /// </remarks>
 public class DistributedCachingChatClient : CachingChatClient
 {
-    /// <summary>A boxed <see langword="true"/> value.</summary>
-    private static readonly object _boxedTrue = true;
-
-    /// <summary>A boxed <see langword="false"/> value.</summary>
-    private static readonly object _boxedFalse = false;
-
     /// <summary>The <see cref="IDistributedCache"/> instance that will be used as the backing store for the cache.</summary>
     private readonly IDistributedCache _storage;
 
@@ -99,14 +93,7 @@ public class DistributedCachingChatClient : CachingChatClient
     }
 
     /// <inheritdoc />
-    protected override string GetCacheKey(bool streaming, IList<ChatMessage> chatMessages, ChatOptions? options) =>
-        GetCacheKey([streaming ? _boxedTrue : _boxedFalse, chatMessages, options]);
-
-    /// <summary>Gets a cache key based on the supplied values.</summary>
-    /// <param name="values">The values to inform the key.</param>
-    /// <returns>The computed key.</returns>
-    /// <remarks>This provides the default implementation for <see cref="GetCacheKey(bool, IList{ChatMessage}, ChatOptions?)"/>.</remarks>
-    protected string GetCacheKey(ReadOnlySpan<object?> values)
+    protected override string GetCacheKey(params ReadOnlySpan<object?> values)
     {
         _jsonSerializerOptions.MakeReadOnly();
         return CachingHelpers.GetCacheKey(values, _jsonSerializerOptions);

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/CachingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/CachingEmbeddingGenerator.cs
@@ -106,13 +106,10 @@ public abstract class CachingEmbeddingGenerator<TInput, TEmbedding> : Delegating
         return results;
     }
 
-    /// <summary>
-    /// Computes a cache key for the specified call parameters.
-    /// </summary>
-    /// <param name="value">The <typeparamref name="TInput"/> for which an embedding is being requested.</param>
-    /// <param name="options">The options to configure the request.</param>
-    /// <returns>A string that will be used as a cache key.</returns>
-    protected abstract string GetCacheKey(TInput value, EmbeddingGenerationOptions? options);
+    /// <summary>Computes a cache key for the specified values.</summary>
+    /// <param name="values">The values to inform the key.</param>
+    /// <returns>The computed key.</returns>
+    protected abstract string GetCacheKey(params ReadOnlySpan<object?> values);
 
     /// <summary>Returns a previously cached <see cref="Embedding{TEmbedding}"/>, if available.</summary>
     /// <param name="key">The cache key.</param>

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/DistributedCachingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/DistributedCachingEmbeddingGenerator.cs
@@ -75,14 +75,7 @@ public class DistributedCachingEmbeddingGenerator<TInput, TEmbedding> : CachingE
     }
 
     /// <inheritdoc />
-    protected override string GetCacheKey(TInput value, EmbeddingGenerationOptions? options) =>
-        GetCacheKey([value, options]);
-
-    /// <summary>Gets a cache key based on the supplied values.</summary>
-    /// <param name="values">The values to inform the key.</param>
-    /// <returns>The computed key.</returns>
-    /// <remarks>This provides the default implementation for <see cref="GetCacheKey(TInput, EmbeddingGenerationOptions?)"/>.</remarks>
-    protected string GetCacheKey(ReadOnlySpan<object?> values)
+    protected override string GetCacheKey(params ReadOnlySpan<object?> values)
     {
         _jsonSerializerOptions.MakeReadOnly();
         return CachingHelpers.GetCacheKey(values, _jsonSerializerOptions);

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/DistributedCachingEmbeddingGenerator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/DistributedCachingEmbeddingGenerator.cs
@@ -74,7 +74,10 @@ public class DistributedCachingEmbeddingGenerator<TInput, TEmbedding> : CachingE
         await _storage.SetAsync(key, newJson, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <inheritdoc />
+    /// <summary>Computes a cache key for the specified values.</summary>
+    /// <param name="values">The values to inform the key.</param>
+    /// <returns>The computed key.</returns>
+    /// <remarks>The <paramref name="values"/> are serialized to JSON using <see cref="JsonSerializerOptions"/> in order to compute the key.</remarks>
     protected override string GetCacheKey(params ReadOnlySpan<object?> values)
     {
         _jsonSerializerOptions.MakeReadOnly();

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
@@ -815,10 +815,18 @@ public class DistributedCachingChatClientTest
     private sealed class CachingChatClientWithCustomKey(IChatClient innerClient, IDistributedCache storage)
         : DistributedCachingChatClient(innerClient, storage)
     {
-        protected override string GetCacheKey(bool streaming, IList<ChatMessage> chatMessages, ChatOptions? options)
+        protected override string GetCacheKey(params ReadOnlySpan<object?> values)
         {
-            var baseKey = base.GetCacheKey(streaming, chatMessages, options);
-            return baseKey + options?.AdditionalProperties?["someKey"]?.ToString();
+            var baseKey = base.GetCacheKey(values);
+            foreach (var value in values)
+            {
+                if (value is ChatOptions options)
+                {
+                    return baseKey + options.AdditionalProperties?["someKey"]?.ToString();
+                }
+            }
+
+            return baseKey;
         }
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/DistributedCachingEmbeddingGeneratorTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/DistributedCachingEmbeddingGeneratorTest.cs
@@ -350,7 +350,18 @@ public class DistributedCachingEmbeddingGeneratorTest
     private sealed class CachingEmbeddingGeneratorWithCustomKey(IEmbeddingGenerator<string, Embedding<float>> innerGenerator, IDistributedCache storage)
         : DistributedCachingEmbeddingGenerator<string, Embedding<float>>(innerGenerator, storage)
     {
-        protected override string GetCacheKey(string value, EmbeddingGenerationOptions? options) =>
-            base.GetCacheKey(value, options) + options?.AdditionalProperties?["someKey"]?.ToString();
+        protected override string GetCacheKey(params ReadOnlySpan<object?> values)
+        {
+            var baseKey = base.GetCacheKey(values);
+            foreach (var value in values)
+            {
+                if (value is EmbeddingGenerationOptions options)
+                {
+                    return baseKey + options.AdditionalProperties?["someKey"]?.ToString();
+                }
+            }
+
+            return baseKey;
+        }
     }
 }


### PR DESCRIPTION
Consolidate to only the `ReadOnlySpan<object>`-based method.

@shyamnamboodiripad, does this address your concerns (https://github.com/dotnet/extensions/pull/5641#discussion_r1844931054)?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5651)