### PR TITLE
Add AsBuilder extensions for IChatClient and IEmbeddingGenerator

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilderChatClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilderChatClientExtensions.cs
@@ -16,7 +16,7 @@ public static class ChatClientBuilderChatClientExtensions
     /// This method is equivalent to using the <see cref="ChatClientBuilder"/> constructor directly,
     /// specifying <paramref name="innerClient"/> as the inner client.
     /// </remarks>
-    public static ChatClientBuilder ToBuilder(this IChatClient innerClient)
+    public static ChatClientBuilder AsBuilder(this IChatClient innerClient)
     {
         _ = Throw.IfNull(innerClient);
 

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilderChatClientExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientBuilderChatClientExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides extension methods for working with <see cref="IChatClient"/> in the context of <see cref="ChatClientBuilder"/>.</summary>
+public static class ChatClientBuilderChatClientExtensions
+{
+    /// <summary>Creates a new <see cref="ChatClientBuilder"/> using <paramref name="innerClient"/> as its inner client.</summary>
+    /// <param name="innerClient">The client to use as the inner client.</param>
+    /// <returns>The new <see cref="ChatClientBuilder"/> instance.</returns>
+    /// <remarks>
+    /// This method is equivalent to using the <see cref="ChatClientBuilder"/> constructor directly,
+    /// specifying <paramref name="innerClient"/> as the inner client.
+    /// </remarks>
+    public static ChatClientBuilder ToBuilder(this IChatClient innerClient)
+    {
+        _ = Throw.IfNull(innerClient);
+
+        return new ChatClientBuilder(innerClient);
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides extension methods for working with <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>
+/// in the context of <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/>.</summary>
+public static class EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions
+{
+    /// <summary>
+    /// Creates a new <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/> using
+    /// <paramref name="innerGenerator"/> as its inner generator.
+    /// </summary>
+    /// <typeparam name="TInput">The type from which embeddings will be generated.</typeparam>
+    /// <typeparam name="TEmbedding">The type of embeddings to generate.</typeparam>
+    /// <param name="innerGenerator">The generator to use as the inner generator.</param>
+    /// <returns>The new <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/> instance.</returns>
+    /// <remarks>
+    /// This method is equivalent to using the <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/>
+    /// constructor directly, specifying <paramref name="innerGenerator"/> as the inner generator.
+    /// </remarks>
+    public static EmbeddingGeneratorBuilder<TInput, TEmbedding> ToBuilder<TInput, TEmbedding>(
+        this IEmbeddingGenerator<TInput, TEmbedding> innerGenerator)
+        where TEmbedding : Embedding
+    {
+        _ = Throw.IfNull(innerGenerator);
+
+        return new EmbeddingGeneratorBuilder<TInput, TEmbedding>(innerGenerator);
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Embeddings/EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions.cs
@@ -22,7 +22,7 @@ public static class EmbeddingGeneratorBuilderEmbeddingGeneratorExtensions
     /// This method is equivalent to using the <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/>
     /// constructor directly, specifying <paramref name="innerGenerator"/> as the inner generator.
     /// </remarks>
-    public static EmbeddingGeneratorBuilder<TInput, TEmbedding> ToBuilder<TInput, TEmbedding>(
+    public static EmbeddingGeneratorBuilder<TInput, TEmbedding> AsBuilder<TInput, TEmbedding>(
         this IEmbeddingGenerator<TInput, TEmbedding> innerGenerator)
         where TEmbedding : Embedding
     {

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
@@ -78,7 +78,7 @@ public class AzureAIInferenceChatClientTests
         Assert.Same(client, chatClient.GetService<ChatCompletionsClient>());
 
         using IChatClient pipeline = chatClient
-            .ToBuilder()
+            .AsBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
@@ -77,7 +77,8 @@ public class AzureAIInferenceChatClientTests
 
         Assert.Same(client, chatClient.GetService<ChatCompletionsClient>());
 
-        using IChatClient pipeline = new ChatClientBuilder(chatClient)
+        using IChatClient pipeline = chatClient
+            .ToBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceEmbeddingGeneratorTests.cs
@@ -64,7 +64,7 @@ public class AzureAIInferenceEmbeddingGeneratorTests
         Assert.Same(client, embeddingGenerator.GetService<EmbeddingsClient>());
 
         using IEmbeddingGenerator<string, Embedding<float>> pipeline = embeddingGenerator
-            .ToBuilder()
+            .AsBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceEmbeddingGeneratorTests.cs
@@ -63,7 +63,8 @@ public class AzureAIInferenceEmbeddingGeneratorTests
         Assert.Same(embeddingGenerator, embeddingGenerator.GetService<IEmbeddingGenerator<string, Embedding<float>>>());
         Assert.Same(client, embeddingGenerator.GetService<EmbeddingsClient>());
 
-        using IEmbeddingGenerator<string, Embedding<float>> pipeline = new EmbeddingGeneratorBuilder<string, Embedding<float>>(embeddingGenerator)
+        using IEmbeddingGenerator<string, Embedding<float>> pipeline = embeddingGenerator
+            .ToBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -377,7 +377,8 @@ public abstract class ChatClientIntegrationTests : IDisposable
         }, "GetTemperature");
 
         // First call executes the function and calls the LLM
-        using var chatClient = new ChatClientBuilder(CreateChatClient()!)
+        using var chatClient = CreateChatClient()!
+            .ToBuilder()
             .ConfigureOptions(options => options.Tools = [getTemperature])
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .UseFunctionInvocation()
@@ -415,7 +416,8 @@ public abstract class ChatClientIntegrationTests : IDisposable
         }, "GetTemperature");
 
         // First call executes the function and calls the LLM
-        using var chatClient = new ChatClientBuilder(CreateChatClient()!)
+        using var chatClient = CreateChatClient()!
+            .ToBuilder()
             .ConfigureOptions(options => options.Tools = [getTemperature])
             .UseFunctionInvocation()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
@@ -454,7 +456,8 @@ public abstract class ChatClientIntegrationTests : IDisposable
         }, "GetTemperature");
 
         // First call executes the function and calls the LLM
-        using var chatClient = new ChatClientBuilder(CreateChatClient()!)
+        using var chatClient = CreateChatClient()!
+            .ToBuilder()
             .ConfigureOptions(options => options.Tools = [getTemperature])
             .UseFunctionInvocation()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
@@ -573,7 +576,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .AddInMemoryExporter(activities)
             .Build();
 
-        var chatClient = new ChatClientBuilder(CreateChatClient()!)
+        var chatClient = CreateChatClient()!.ToBuilder()
             .UseOpenTelemetry(sourceName: sourceName)
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -378,7 +378,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
 
         // First call executes the function and calls the LLM
         using var chatClient = CreateChatClient()!
-            .ToBuilder()
+            .AsBuilder()
             .ConfigureOptions(options => options.Tools = [getTemperature])
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .UseFunctionInvocation()
@@ -417,7 +417,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
 
         // First call executes the function and calls the LLM
         using var chatClient = CreateChatClient()!
-            .ToBuilder()
+            .AsBuilder()
             .ConfigureOptions(options => options.Tools = [getTemperature])
             .UseFunctionInvocation()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
@@ -457,7 +457,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
 
         // First call executes the function and calls the LLM
         using var chatClient = CreateChatClient()!
-            .ToBuilder()
+            .AsBuilder()
             .ConfigureOptions(options => options.Tools = [getTemperature])
             .UseFunctionInvocation()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
@@ -576,7 +576,7 @@ public abstract class ChatClientIntegrationTests : IDisposable
             .AddInMemoryExporter(activities)
             .Build();
 
-        var chatClient = CreateChatClient()!.ToBuilder()
+        var chatClient = CreateChatClient()!.AsBuilder()
             .UseOpenTelemetry(sourceName: sourceName)
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
@@ -81,7 +81,8 @@ public abstract class EmbeddingGeneratorIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        using var generator = new EmbeddingGeneratorBuilder<string, Embedding<float>>(CreateEmbeddingGenerator()!)
+        using var generator = CreateEmbeddingGenerator()!
+            .ToBuilder()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .UseCallCounting()
             .Build();
@@ -110,7 +111,8 @@ public abstract class EmbeddingGeneratorIntegrationTests : IDisposable
             .AddInMemoryExporter(activities)
             .Build();
 
-        var embeddingGenerator = new EmbeddingGeneratorBuilder<string, Embedding<float>>(CreateEmbeddingGenerator()!)
+        var embeddingGenerator = CreateEmbeddingGenerator()!
+            .ToBuilder()
             .UseOpenTelemetry(sourceName: sourceName)
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/EmbeddingGeneratorIntegrationTests.cs
@@ -82,7 +82,7 @@ public abstract class EmbeddingGeneratorIntegrationTests : IDisposable
         SkipIfNotEnabled();
 
         using var generator = CreateEmbeddingGenerator()!
-            .ToBuilder()
+            .AsBuilder()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .UseCallCounting()
             .Build();
@@ -112,7 +112,7 @@ public abstract class EmbeddingGeneratorIntegrationTests : IDisposable
             .Build();
 
         var embeddingGenerator = CreateEmbeddingGenerator()!
-            .ToBuilder()
+            .AsBuilder()
             .UseOpenTelemetry(sourceName: sourceName)
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ReducingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ReducingChatClientTests.cs
@@ -38,7 +38,7 @@ public class ReducingChatClientTests
         };
 
         using var client = innerClient
-            .ToBuilder()
+            .AsBuilder()
             .UseChatReducer(new TokenCountingChatReducer(_gpt4oTokenizer, 40))
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ReducingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ReducingChatClientTests.cs
@@ -37,7 +37,8 @@ public class ReducingChatClientTests
             }
         };
 
-        using var client = new ChatClientBuilder(innerClient)
+        using var client = innerClient
+            .ToBuilder()
             .UseChatReducer(new TokenCountingChatReducer(_gpt4oTokenizer, 40))
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientIntegrationTests.cs
@@ -38,7 +38,7 @@ public class OllamaChatClientIntegrationTests : ChatClientIntegrationTests
         SkipIfNotEnabled();
 
         using var chatClient = CreateChatClient()!
-            .ToBuilder()
+            .AsBuilder()
             .UseFunctionInvocation()
             .UsePromptBasedFunctionCalling()
             .Use(innerClient => new AssertNoToolsDefinedChatClient(innerClient))
@@ -63,7 +63,7 @@ public class OllamaChatClientIntegrationTests : ChatClientIntegrationTests
         SkipIfNotEnabled();
 
         using var chatClient = CreateChatClient()!
-            .ToBuilder()
+            .AsBuilder()
             .UseFunctionInvocation()
             .UsePromptBasedFunctionCalling()
             .Use(innerClient => new AssertNoToolsDefinedChatClient(innerClient))

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientIntegrationTests.cs
@@ -37,7 +37,8 @@ public class OllamaChatClientIntegrationTests : ChatClientIntegrationTests
     {
         SkipIfNotEnabled();
 
-        using var chatClient = new ChatClientBuilder(CreateChatClient()!)
+        using var chatClient = CreateChatClient()!
+            .ToBuilder()
             .UseFunctionInvocation()
             .UsePromptBasedFunctionCalling()
             .Use(innerClient => new AssertNoToolsDefinedChatClient(innerClient))
@@ -61,7 +62,8 @@ public class OllamaChatClientIntegrationTests : ChatClientIntegrationTests
     {
         SkipIfNotEnabled();
 
-        using var chatClient = new ChatClientBuilder(CreateChatClient()!)
+        using var chatClient = CreateChatClient()!
+            .ToBuilder()
             .UseFunctionInvocation()
             .UsePromptBasedFunctionCalling()
             .Use(innerClient => new AssertNoToolsDefinedChatClient(innerClient))

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
@@ -48,7 +48,8 @@ public class OllamaChatClientTests
         Assert.Same(client, client.GetService<OllamaChatClient>());
         Assert.Same(client, client.GetService<IChatClient>());
 
-        using IChatClient pipeline = new ChatClientBuilder(client)
+        using IChatClient pipeline = client
+            .ToBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
@@ -49,7 +49,7 @@ public class OllamaChatClientTests
         Assert.Same(client, client.GetService<IChatClient>());
 
         using IChatClient pipeline = client
-            .ToBuilder()
+            .AsBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaEmbeddingGeneratorTests.cs
@@ -29,7 +29,8 @@ public class OllamaEmbeddingGeneratorTests
         Assert.Same(generator, generator.GetService<OllamaEmbeddingGenerator>());
         Assert.Same(generator, generator.GetService<IEmbeddingGenerator<string, Embedding<float>>>());
 
-        using IEmbeddingGenerator<string, Embedding<float>> pipeline = new EmbeddingGeneratorBuilder<string, Embedding<float>>(generator)
+        using IEmbeddingGenerator<string, Embedding<float>> pipeline = generator
+            .ToBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaEmbeddingGeneratorTests.cs
@@ -30,7 +30,7 @@ public class OllamaEmbeddingGeneratorTests
         Assert.Same(generator, generator.GetService<IEmbeddingGenerator<string, Embedding<float>>>());
 
         using IEmbeddingGenerator<string, Embedding<float>> pipeline = generator
-            .ToBuilder()
+            .AsBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -96,7 +96,7 @@ public class OpenAIChatClientTests
         Assert.NotNull(chatClient.GetService<ChatClient>());
 
         using IChatClient pipeline = chatClient
-            .ToBuilder()
+            .AsBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
@@ -121,7 +121,7 @@ public class OpenAIChatClientTests
         Assert.Same(openAIClient, chatClient.GetService<ChatClient>());
 
         using IChatClient pipeline = chatClient
-            .ToBuilder()
+            .AsBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -95,7 +95,8 @@ public class OpenAIChatClientTests
 
         Assert.NotNull(chatClient.GetService<ChatClient>());
 
-        using IChatClient pipeline = new ChatClientBuilder(chatClient)
+        using IChatClient pipeline = chatClient
+            .ToBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
@@ -119,7 +120,8 @@ public class OpenAIChatClientTests
         Assert.Same(chatClient, chatClient.GetService<IChatClient>());
         Assert.Same(openAIClient, chatClient.GetService<ChatClient>());
 
-        using IChatClient pipeline = new ChatClientBuilder(chatClient)
+        using IChatClient pipeline = chatClient
+            .ToBuilder()
             .UseFunctionInvocation()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorTests.cs
@@ -79,7 +79,7 @@ public class OpenAIEmbeddingGeneratorTests
         Assert.NotNull(embeddingGenerator.GetService<EmbeddingClient>());
 
         using IEmbeddingGenerator<string, Embedding<float>> pipeline = embeddingGenerator
-            .ToBuilder()
+            .AsBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();
@@ -102,7 +102,7 @@ public class OpenAIEmbeddingGeneratorTests
         Assert.Same(openAIClient, embeddingGenerator.GetService<EmbeddingClient>());
 
         using IEmbeddingGenerator<string, Embedding<float>> pipeline = embeddingGenerator
-            .ToBuilder()
+            .AsBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorTests.cs
@@ -78,7 +78,8 @@ public class OpenAIEmbeddingGeneratorTests
 
         Assert.NotNull(embeddingGenerator.GetService<EmbeddingClient>());
 
-        using IEmbeddingGenerator<string, Embedding<float>> pipeline = new EmbeddingGeneratorBuilder<string, Embedding<float>>(embeddingGenerator)
+        using IEmbeddingGenerator<string, Embedding<float>> pipeline = embeddingGenerator
+            .ToBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();
@@ -100,7 +101,8 @@ public class OpenAIEmbeddingGeneratorTests
         Assert.Same(embeddingGenerator, embeddingGenerator.GetService<IEmbeddingGenerator<string, Embedding<float>>>());
         Assert.Same(openAIClient, embeddingGenerator.GetService<EmbeddingClient>());
 
-        using IEmbeddingGenerator<string, Embedding<float>> pipeline = new EmbeddingGeneratorBuilder<string, Embedding<float>>(embeddingGenerator)
+        using IEmbeddingGenerator<string, Embedding<float>> pipeline = embeddingGenerator
+            .ToBuilder()
             .UseOpenTelemetry()
             .UseDistributedCache(new MemoryDistributedCache(Options.Options.Create(new MemoryDistributedCacheOptions())))
             .Build();

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
@@ -58,7 +58,8 @@ public class ChatClientBuilderTest
     [Fact]
     public void DoesNotAcceptNullInnerService()
     {
-        Assert.Throws<ArgumentNullException>(() => new ChatClientBuilder((IChatClient)null!));
+        Assert.Throws<ArgumentNullException>("innerClient", () => new ChatClientBuilder((IChatClient)null!));
+        Assert.Throws<ArgumentNullException>("innerClient", () => ((IChatClient)null!).ToBuilder());
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientBuilderTest.cs
@@ -59,7 +59,7 @@ public class ChatClientBuilderTest
     public void DoesNotAcceptNullInnerService()
     {
         Assert.Throws<ArgumentNullException>("innerClient", () => new ChatClientBuilder((IChatClient)null!));
-        Assert.Throws<ArgumentNullException>("innerClient", () => ((IChatClient)null!).ToBuilder());
+        Assert.Throws<ArgumentNullException>("innerClient", () => ((IChatClient)null!).AsBuilder());
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ConfigureOptionsChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ConfigureOptionsChatClientTests.cs
@@ -23,7 +23,7 @@ public class ConfigureOptionsChatClientTests
     public void ConfigureOptions_InvalidArgs_Throws()
     {
         using var innerClient = new TestChatClient();
-        var builder = innerClient.ToBuilder();
+        var builder = innerClient.AsBuilder();
         Assert.Throws<ArgumentNullException>("configure", () => builder.ConfigureOptions(null!));
     }
 
@@ -56,7 +56,7 @@ public class ConfigureOptionsChatClientTests
         };
 
         using var client = innerClient
-            .ToBuilder()
+            .AsBuilder()
             .ConfigureOptions(options =>
             {
                 Assert.NotSame(providedOptions, options);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ConfigureOptionsChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ConfigureOptionsChatClientTests.cs
@@ -23,7 +23,7 @@ public class ConfigureOptionsChatClientTests
     public void ConfigureOptions_InvalidArgs_Throws()
     {
         using var innerClient = new TestChatClient();
-        var builder = new ChatClientBuilder(innerClient);
+        var builder = innerClient.ToBuilder();
         Assert.Throws<ArgumentNullException>("configure", () => builder.ConfigureOptions(null!));
     }
 
@@ -55,7 +55,8 @@ public class ConfigureOptionsChatClientTests
             },
         };
 
-        using var client = new ChatClientBuilder(innerClient)
+        using var client = innerClient
+            .ToBuilder()
             .ConfigureOptions(options =>
             {
                 Assert.NotSame(providedOptions, options);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
@@ -682,7 +682,7 @@ public class DistributedCachingChatClientTest
             }
         };
         using var outer = testClient
-            .ToBuilder()
+            .AsBuilder()
             .UseDistributedCache(configure: options =>
             {
                 options.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
@@ -681,7 +681,8 @@ public class DistributedCachingChatClientTest
                     new(ChatRole.Assistant, [new TextContent("Hey")])]));
             }
         };
-        using var outer = new ChatClientBuilder(testClient)
+        using var outer = testClient
+            .ToBuilder()
             .UseDistributedCache(configure: options =>
             {
                 options.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -295,7 +295,7 @@ public class FunctionInvokingChatClientTests
             }
         };
 
-        IChatClient service = innerClient.ToBuilder().UseFunctionInvocation().Build();
+        IChatClient service = innerClient.AsBuilder().UseFunctionInvocation().Build();
 
         List<ChatMessage> chat = [new ChatMessage(ChatRole.User, "hello")];
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -415,7 +415,7 @@ public class FunctionInvokingChatClientTests
             }
         };
 
-        IChatClient service = configurePipeline(innerClient.ToBuilder()).Build();
+        IChatClient service = configurePipeline(innerClient.AsBuilder()).Build();
 
         var result = await service.CompleteAsync(chat, options, cts.Token);
         chat.Add(result.Message);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -295,7 +295,7 @@ public class FunctionInvokingChatClientTests
             }
         };
 
-        IChatClient service = new ChatClientBuilder(innerClient).UseFunctionInvocation().Build();
+        IChatClient service = innerClient.ToBuilder().UseFunctionInvocation().Build();
 
         List<ChatMessage> chat = [new ChatMessage(ChatRole.User, "hello")];
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -415,7 +415,7 @@ public class FunctionInvokingChatClientTests
             }
         };
 
-        IChatClient service = configurePipeline(new ChatClientBuilder(innerClient)).Build();
+        IChatClient service = configurePipeline(innerClient.ToBuilder()).Build();
 
         var result = await service.CompleteAsync(chat, options, cts.Token);
         chat.Add(result.Message);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/LoggingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/LoggingChatClientTests.cs
@@ -41,7 +41,7 @@ public class LoggingChatClientTests
         };
 
         using IChatClient client = innerClient
-            .ToBuilder()
+            .AsBuilder()
             .UseLogging()
             .Build(services);
 
@@ -88,7 +88,7 @@ public class LoggingChatClientTests
         }
 
         using IChatClient client = innerClient
-            .ToBuilder()
+            .AsBuilder()
             .UseLogging(logger)
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/LoggingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/LoggingChatClientTests.cs
@@ -40,7 +40,8 @@ public class LoggingChatClientTests
             },
         };
 
-        using IChatClient client = new ChatClientBuilder(innerClient)
+        using IChatClient client = innerClient
+            .ToBuilder()
             .UseLogging()
             .Build(services);
 
@@ -86,7 +87,8 @@ public class LoggingChatClientTests
             yield return new StreamingChatCompletionUpdate { Role = ChatRole.Assistant, Text = "whale" };
         }
 
-        using IChatClient client = new ChatClientBuilder(innerClient)
+        using IChatClient client = innerClient
+            .ToBuilder()
             .UseLogging(logger)
             .Build();
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -87,7 +87,7 @@ public class OpenTelemetryChatClientTests
         }
 
         var chatClient = innerClient
-            .ToBuilder()
+            .AsBuilder()
             .UseOpenTelemetry(loggerFactory, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = enableSensitiveData;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/OpenTelemetryChatClientTests.cs
@@ -86,7 +86,8 @@ public class OpenTelemetryChatClientTests
             };
         }
 
-        var chatClient = new ChatClientBuilder(innerClient)
+        var chatClient = innerClient
+            .ToBuilder()
             .UseOpenTelemetry(loggerFactory, sourceName, configure: instance =>
             {
                 instance.EnableSensitiveData = enableSensitiveData;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/ConfigureOptionsEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/ConfigureOptionsEmbeddingGeneratorTests.cs
@@ -21,7 +21,7 @@ public class ConfigureOptionsEmbeddingGeneratorTests
     public void ConfigureOptions_InvalidArgs_Throws()
     {
         using var innerGenerator = new TestEmbeddingGenerator();
-        var builder = new EmbeddingGeneratorBuilder<string, Embedding<float>>(innerGenerator);
+        var builder = innerGenerator.ToBuilder();
         Assert.Throws<ArgumentNullException>("configure", () => builder.ConfigureOptions(null!));
     }
 
@@ -45,7 +45,8 @@ public class ConfigureOptionsEmbeddingGeneratorTests
             }
         };
 
-        using var generator = new EmbeddingGeneratorBuilder<string, Embedding<float>>(innerGenerator)
+        using var generator = innerGenerator
+            .ToBuilder()
             .ConfigureOptions(options =>
             {
                 Assert.NotSame(providedOptions, options);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/ConfigureOptionsEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/ConfigureOptionsEmbeddingGeneratorTests.cs
@@ -21,7 +21,7 @@ public class ConfigureOptionsEmbeddingGeneratorTests
     public void ConfigureOptions_InvalidArgs_Throws()
     {
         using var innerGenerator = new TestEmbeddingGenerator();
-        var builder = innerGenerator.ToBuilder();
+        var builder = innerGenerator.AsBuilder();
         Assert.Throws<ArgumentNullException>("configure", () => builder.ConfigureOptions(null!));
     }
 
@@ -46,7 +46,7 @@ public class ConfigureOptionsEmbeddingGeneratorTests
         };
 
         using var generator = innerGenerator
-            .ToBuilder()
+            .AsBuilder()
             .ConfigureOptions(options =>
             {
                 Assert.NotSame(providedOptions, options);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/DistributedCachingEmbeddingGeneratorTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/DistributedCachingEmbeddingGeneratorTest.cs
@@ -321,7 +321,8 @@ public class DistributedCachingEmbeddingGeneratorTest
                 return Task.FromResult<GeneratedEmbeddings<Embedding<float>>>([_expectedEmbedding]);
             },
         };
-        using var outer = new EmbeddingGeneratorBuilder<string, Embedding<float>>(testGenerator)
+        using var outer = testGenerator
+            .ToBuilder()
             .UseDistributedCache(configure: instance =>
             {
                 instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/DistributedCachingEmbeddingGeneratorTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/DistributedCachingEmbeddingGeneratorTest.cs
@@ -322,7 +322,7 @@ public class DistributedCachingEmbeddingGeneratorTest
             },
         };
         using var outer = testGenerator
-            .ToBuilder()
+            .AsBuilder()
             .UseDistributedCache(configure: instance =>
             {
                 instance.JsonSerializerOptions = TestJsonSerializerContext.Default.Options;

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
@@ -36,7 +36,7 @@ public class EmbeddingGeneratorBuilderTests
     {
         // Arrange
         using var expectedInnerGenerator = new TestEmbeddingGenerator();
-        var builder = expectedInnerGenerator.ToBuilder();
+        var builder = expectedInnerGenerator.AsBuilder();
 
         builder.Use(next => new InnerServiceCapturingEmbeddingGenerator("First", next));
         builder.Use(next => new InnerServiceCapturingEmbeddingGenerator("Second", next));
@@ -58,7 +58,7 @@ public class EmbeddingGeneratorBuilderTests
     public void DoesNotAcceptNullInnerService()
     {
         Assert.Throws<ArgumentNullException>("innerGenerator", () => new EmbeddingGeneratorBuilder<string, Embedding<float>>((IEmbeddingGenerator<string, Embedding<float>>)null!));
-        Assert.Throws<ArgumentNullException>("innerGenerator", () => ((IEmbeddingGenerator<string, Embedding<float>>)null!).ToBuilder());
+        Assert.Throws<ArgumentNullException>("innerGenerator", () => ((IEmbeddingGenerator<string, Embedding<float>>)null!).AsBuilder());
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class EmbeddingGeneratorBuilderTests
     public void DoesNotAllowFactoriesToReturnNull()
     {
         using var innerGenerator = new TestEmbeddingGenerator();
-        var builder = innerGenerator.ToBuilder();
+        var builder = innerGenerator.AsBuilder();
         builder.Use(_ => null!);
         var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
         Assert.Contains("entry at index 0", ex.Message);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/EmbeddingGeneratorBuilderTests.cs
@@ -36,7 +36,7 @@ public class EmbeddingGeneratorBuilderTests
     {
         // Arrange
         using var expectedInnerGenerator = new TestEmbeddingGenerator();
-        var builder = new EmbeddingGeneratorBuilder<string, Embedding<float>>(expectedInnerGenerator);
+        var builder = expectedInnerGenerator.ToBuilder();
 
         builder.Use(next => new InnerServiceCapturingEmbeddingGenerator("First", next));
         builder.Use(next => new InnerServiceCapturingEmbeddingGenerator("Second", next));
@@ -57,7 +57,8 @@ public class EmbeddingGeneratorBuilderTests
     [Fact]
     public void DoesNotAcceptNullInnerService()
     {
-        Assert.Throws<ArgumentNullException>(() => new EmbeddingGeneratorBuilder<string, Embedding<float>>((IEmbeddingGenerator<string, Embedding<float>>)null!));
+        Assert.Throws<ArgumentNullException>("innerGenerator", () => new EmbeddingGeneratorBuilder<string, Embedding<float>>((IEmbeddingGenerator<string, Embedding<float>>)null!));
+        Assert.Throws<ArgumentNullException>("innerGenerator", () => ((IEmbeddingGenerator<string, Embedding<float>>)null!).ToBuilder());
     }
 
     [Fact]
@@ -70,7 +71,7 @@ public class EmbeddingGeneratorBuilderTests
     public void DoesNotAllowFactoriesToReturnNull()
     {
         using var innerGenerator = new TestEmbeddingGenerator();
-        var builder = new EmbeddingGeneratorBuilder<string, Embedding<float>>(innerGenerator);
+        var builder = innerGenerator.ToBuilder();
         builder.Use(_ => null!);
         var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
         Assert.Contains("entry at index 0", ex.Message);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/LoggingEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/LoggingEmbeddingGeneratorTests.cs
@@ -40,7 +40,7 @@ public class LoggingEmbeddingGeneratorTests
         };
 
         using IEmbeddingGenerator<string, Embedding<float>> generator = innerGenerator
-            .ToBuilder()
+            .AsBuilder()
             .UseLogging()
             .Build(services);
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/LoggingEmbeddingGeneratorTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Embeddings/LoggingEmbeddingGeneratorTests.cs
@@ -39,7 +39,8 @@ public class LoggingEmbeddingGeneratorTests
             },
         };
 
-        using IEmbeddingGenerator<string, Embedding<float>> generator = new EmbeddingGeneratorBuilder<string, Embedding<float>>(innerGenerator)
+        using IEmbeddingGenerator<string, Embedding<float>> generator = innerGenerator
+            .ToBuilder()
             .UseLogging()
             .Build(services);
 


### PR DESCRIPTION
Enables a fluent style of construction of a pipeline from a client/generator, and not having to specify the generic type parameters for the embedding generator builder.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5652)