### PR TITLE
Ensure non-streaming usage data from function calling is in history

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -252,6 +252,13 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                     }
                 }
 
+                // If the original chat completion included usage data,
+                // add that into the message so it's available in the history.
+                if (KeepFunctionCallingMessages && response.Usage is { } usage)
+                {
+                    response.Message.Contents = [.. response.Message.Contents, new UsageContent(usage)];
+                }
+
                 // Add the responses from the function calls into the history.
                 var modeAndMessages = await ProcessFunctionCallsAsync(chatMessages, options, functionCallContents, iteration, cancellationToken).ConfigureAwait(false);
                 if (modeAndMessages.MessagesAdded is not null)


### PR DESCRIPTION
It's already yielded during streaming, but it's not being surfaced for non-streaming. Do so by manufacturing a new UsageContent for the UsageDetails and adding that to the response message that's added to the history.

Fixes https://github.com/dotnet/extensions/issues/5668
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5676)