### PR TITLE
Expose a schema transformer on AIJsonSchemaCreateOptions.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.csproj
@@ -25,6 +25,7 @@
     <InjectSharedEmptyCollections>true</InjectSharedEmptyCollections>
     <InjectStringHashOnLegacy>true</InjectStringHashOnLegacy>
     <InjectStringSyntaxAttributeOnLegacy>true</InjectStringSyntaxAttributeOnLegacy>
+    <InjectRequiredMemberOnLegacy>true</InjectRequiredMemberOnLegacy>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateContext.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Schema;
+using System.Text.Json.Serialization.Metadata;
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Defines the context in which a JSON schema within a type graph is being generated.
+/// </summary>
+public readonly struct AIJsonSchemaCreateContext
+{
+    private readonly JsonSchemaExporterContext _exporterContext;
+
+    internal AIJsonSchemaCreateContext(JsonSchemaExporterContext exporterContext)
+    {
+        _exporterContext = exporterContext;
+    }
+
+    /// <summary>
+    /// Gets the path to the schema document currently being generated.
+    /// </summary>
+    public ReadOnlySpan<string> Path => _exporterContext.Path;
+
+    /// <summary>
+    /// Gets the <see cref="JsonTypeInfo"/> for the type being processed.
+    /// </summary>
+    public JsonTypeInfo TypeInfo => _exporterContext.TypeInfo;
+
+    /// <summary>
+    /// Gets the type info for the polymorphic base type if generated as a derived type.
+    /// </summary>
+    public JsonTypeInfo? BaseTypeInfo => _exporterContext.BaseTypeInfo;
+
+    /// <summary>
+    /// Gets the <see cref="JsonPropertyInfo"/> if the schema is being generated for a property.
+    /// </summary>
+    public JsonPropertyInfo? PropertyInfo => _exporterContext.PropertyInfo;
+
+    /// <summary>
+    /// Gets the declaring type of the property or parameter being processed.
+    /// </summary>
+    public Type? DeclaringType =>
+#if NET9_0_OR_GREATER
+        _exporterContext.PropertyInfo?.DeclaringType;
+#else
+        _exporterContext.DeclaringType;
+#endif
+
+    /// <summary>
+    /// Gets the <see cref="ICustomAttributeProvider"/> corresponding to the property or field being processed.
+    /// </summary>
+    public ICustomAttributeProvider? PropertyAttributeProvider =>
+#if NET9_0_OR_GREATER
+        _exporterContext.PropertyInfo?.AttributeProvider;
+#else
+        _exporterContext.PropertyAttributeProvider;
+#endif
+
+    /// <summary>
+    /// Gets the <see cref="System.Reflection.ICustomAttributeProvider"/> of the
+    /// constructor parameter associated with the accompanying <see cref="PropertyInfo"/>.
+    /// </summary>
+    public ICustomAttributeProvider? ParameterAttributeProvider =>
+#if NET9_0_OR_GREATER
+        _exporterContext.PropertyInfo?.AssociatedParameter?.AttributeProvider;
+#else
+        _exporterContext.ParameterInfo;
+#endif
+
+    /// <summary>
+    /// Retrieves a custom attribute of a specified type that is applied to the specified schema node context.
+    /// </summary>
+    /// <typeparam name="TAttribute">The type of attribute to search for.</typeparam>
+    /// <param name="inherit">If <see langword="true"/>, specifies to also search the ancestors of the context members for custom attributes.</param>
+    /// <returns>The first occurrence of <typeparamref name="TAttribute"/> if found, or <see langword="null"/> otherwise.</returns>
+    /// <remarks>
+    /// This helper method resolves attributes from context locations in the following order:
+    /// <list type="number">
+    /// <item>Attributes specified on the property of the context, if specified.</item>
+    /// <item>Attributes specified on the constructor parameter of the context, if specified.</item>
+    /// <item>Attributes specified on the type of the context.</item>
+    /// </list>
+    /// </remarks>
+    public TAttribute? GetCustomAttribute<TAttribute>(bool inherit = false)
+        where TAttribute : Attribute
+    {
+        return GetCustomAttr(PropertyAttributeProvider) ??
+            GetCustomAttr(ParameterAttributeProvider) ??
+            GetCustomAttr(TypeInfo.Type);
+
+        TAttribute? GetCustomAttr(ICustomAttributeProvider? provider) =>
+            (TAttribute?)provider?.GetCustomAttributes(typeof(TAttribute), inherit).FirstOrDefault();
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateContext.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateContext.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Extensions.AI;
 /// <summary>
 /// Defines the context in which a JSON schema within a type graph is being generated.
 /// </summary>
+/// <remarks>
+/// This struct is being passed to the user-provided <see cref="AIJsonSchemaCreateOptions.TransformSchemaNode"/> 
+/// callback by the <see cref="AIJsonUtilities.CreateJsonSchema"/> method and cannot be instantiated directly.
+/// </remarks>
 public readonly struct AIJsonSchemaCreateContext
 {
     private readonly JsonSchemaExporterContext _exporterContext;

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -40,20 +40,4 @@ public sealed class AIJsonSchemaCreateOptions
     /// Gets a value indicating whether to mark all properties as required in the schema.
     /// </summary>
     public bool RequireAllProperties { get; init; } = true;
-
-    /// <summary>
-    /// Gets a value indicating whether to filter keywords that are disallowed by certain AI vendors.
-    /// </summary>
-    /// <remarks>
-    /// Filters a number of non-essential schema keywords that are not yet supported by some AI vendors.
-    /// These include:
-    /// <list type="bullet">
-    /// <item>The "minLength", "maxLength", "pattern", and "format" keywords.</item>
-    /// <item>The "minimum", "maximum", and "multipleOf" keywords.</item>
-    /// <item>The "patternProperties", "unevaluatedProperties", "propertyNames", "minProperties", and "maxProperties" keywords.</item>
-    /// <item>The "unevaluatedItems", "contains", "minContains", "maxContains", "minItems", "maxItems", and "uniqueItems" keywords.</item>
-    /// </list>
-    /// See also https://platform.openai.com/docs/guides/structured-outputs#some-type-specific-keywords-are-not-yet-supported.
-    /// </remarks>
-    public bool FilterDisallowedKeywords { get; init; } = true;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonSchemaCreateOptions.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Text.Json.Nodes;
+
 namespace Microsoft.Extensions.AI;
 
 /// <summary>
@@ -12,6 +15,11 @@ public sealed class AIJsonSchemaCreateOptions
     /// Gets the default options instance.
     /// </summary>
     public static AIJsonSchemaCreateOptions Default { get; } = new AIJsonSchemaCreateOptions();
+
+    /// <summary>
+    /// Gets a callback that is invoked for every schema that is generated within the type graph.
+    /// </summary>
+    public Func<AIJsonSchemaCreateContext, JsonNode, JsonNode>? TransformSchemaNode { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether to include the type keyword in inferred schemas for .NET enums.

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -162,7 +162,7 @@ public static partial class AIJsonUtilities
         options.MakeReadOnly();
         ConcurrentDictionary<SchemaGenerationKey, JsonElement> cache = _schemaCaches.GetOrCreateValue(options);
 
-        if (cache.Count >= CacheSoftLimit || key.TransformSchemaNode is not null)
+        if (key.TransformSchemaNode is not null || cache.Count >= CacheSoftLimit)
         {
             return GetJsonSchemaCore(options, key);
         }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -154,7 +154,7 @@ public static partial class AIJsonUtilities
         options.MakeReadOnly();
         ConcurrentDictionary<SchemaGenerationKey, JsonElement> cache = _schemaCaches.GetOrCreateValue(options);
 
-        if (cache.Count >= CacheSoftLimit)
+        if (cache.Count >= CacheSoftLimit || key.TransformSchemaNode is not null)
         {
             return GetJsonSchemaCore(options, key);
         }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -289,12 +289,9 @@ public static partial class AIJsonUtilities
                 }
 
                 // Filter potentially disallowed keywords.
-                if (key.FilterDisallowedKeywords)
+                foreach (string keyword in _schemaKeywordsDisallowedByAIVendors)
                 {
-                    foreach (string keyword in _schemaKeywordsDisallowedByAIVendors)
-                    {
-                        _ = objSchema.Remove(keyword);
-                    }
+                    _ = objSchema.Remove(keyword);
                 }
 
                 // Some consumers of the JSON schema, including Ollama as of v0.3.13, don't understand
@@ -456,7 +453,6 @@ public static partial class AIJsonUtilities
             DisallowAdditionalProperties = options.DisallowAdditionalProperties;
             IncludeTypeInEnumSchemas = options.IncludeTypeInEnumSchemas;
             RequireAllProperties = options.RequireAllProperties;
-            FilterDisallowedKeywords = options.FilterDisallowedKeywords;
             TransformSchemaNode = options.TransformSchemaNode;
         }
 
@@ -469,7 +465,6 @@ public static partial class AIJsonUtilities
         public bool DisallowAdditionalProperties { get; }
         public bool IncludeTypeInEnumSchemas { get; }
         public bool RequireAllProperties { get; }
-        public bool FilterDisallowedKeywords { get; }
         public Func<AIJsonSchemaCreateContext, JsonNode, JsonNode>? TransformSchemaNode { get; }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -94,6 +94,10 @@ public static partial class AIJsonUtilities
     /// <param name="serializerOptions">The options used to extract the schema from the specified type.</param>
     /// <param name="inferenceOptions">The options controlling schema inference.</param>
     /// <returns>A JSON schema document encoded as a <see cref="JsonElement"/>.</returns>
+    /// <remarks>
+    /// Uses a cache keyed on the <paramref name="serializerOptions"/> to store schema result,
+    /// unless a <see cref="AIJsonSchemaCreateOptions.TransformSchemaNode" /> delegate has been specified.
+    /// </remarks>
     public static JsonElement CreateParameterJsonSchema(
         Type? type,
         string parameterName,
@@ -127,6 +131,10 @@ public static partial class AIJsonUtilities
     /// <param name="serializerOptions">The options used to extract the schema from the specified type.</param>
     /// <param name="inferenceOptions">The options controlling schema inference.</param>
     /// <returns>A <see cref="JsonElement"/> representing the schema.</returns>
+    /// <remarks>
+    /// Uses a cache keyed on the <paramref name="serializerOptions"/> to store schema result,
+    /// unless a <see cref="AIJsonSchemaCreateOptions.TransformSchemaNode" /> delegate has been specified.
+    /// </remarks>
     public static JsonElement CreateJsonSchema(
         Type? type,
         string? description = null,

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Utilities/AIJsonUtilitiesTests.cs
@@ -45,7 +45,6 @@ public static class AIJsonUtilitiesTests
         Assert.True(options.DisallowAdditionalProperties);
         Assert.False(options.IncludeSchemaKeyword);
         Assert.True(options.RequireAllProperties);
-        Assert.True(options.FilterDisallowedKeywords);
         Assert.Null(options.TransformSchemaNode);
     }
 
@@ -194,46 +193,6 @@ public static class AIJsonUtilitiesTests
             """).RootElement;
 
         JsonElement actual = AIJsonUtilities.CreateJsonSchema(typeof(PocoWithTypesWithOpenAIUnsupportedKeywords), serializerOptions: JsonSerializerOptions.Default);
-
-        Assert.True(JsonElement.DeepEquals(expected, actual));
-    }
-
-    [Fact]
-    public static void CreateJsonSchema_FilterDisallowedKeywords_Disabled()
-    {
-        JsonElement expected = JsonDocument.Parse("""
-            {
-                "type": "object",
-                "properties": {
-                    "Date": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "TimeSpan": {
-                        "$comment": "Represents a System.TimeSpan value.",
-                        "type": "string",
-                        "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$"
-                    },
-                    "Char" : {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 1
-                    }
-                },
-                "required": ["Date","TimeSpan","Char"],
-                "additionalProperties": false
-            }
-            """).RootElement;
-
-        AIJsonSchemaCreateOptions inferenceOptions = new()
-        {
-            FilterDisallowedKeywords = false
-        };
-
-        JsonElement actual = AIJsonUtilities.CreateJsonSchema(
-            typeof(PocoWithTypesWithOpenAIUnsupportedKeywords),
-            serializerOptions: JsonSerializerOptions.Default,
-            inferenceOptions: inferenceOptions);
 
         Assert.True(JsonElement.DeepEquals(expected, actual));
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/Functions/AIFunctionFactoryTest.cs
@@ -191,7 +191,6 @@ public class AIFunctionFactoryTest
 
         Assert.NotNull(schemaOptions);
         Assert.True(schemaOptions.IncludeTypeInEnumSchemas);
-        Assert.True(schemaOptions.FilterDisallowedKeywords);
         Assert.True(schemaOptions.RequireAllProperties);
         Assert.True(schemaOptions.DisallowAdditionalProperties);
     }


### PR DESCRIPTION
With https://github.com/eiriktsarpalis/stj-schema-mapper being migrated to M.E.AI and archived, `AIJsonUtilities` has become the de facto standard API for exporting JSON schemas that's available in both .NET 8 and .NET 9. Partner teams that have been relying on `stj-schema-mapper` source copies will soon need to start using `AIJsonUtilities` instead. 

In order to make this functionality more useful from a customizability perspective, this PR exposes the schema transformer functionality on `AIJsonSchemaCreateOptions`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5677)