### PR TITLE
Improve FakeTimeProvider documentation, remove redundant tests

### DIFF
--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/README.md
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/README.md
@@ -33,31 +33,109 @@ public void Advance(TimeSpan delta)
 public void SetLocalTimeZone(TimeZoneInfo localTimeZone)
 ```
 
-These can be used as follows:
+### ExpiryCache with TimeProvider
+
+The example below demonstrates the `ExpiryCache` class and how it can be tested using `FakeTimeProvider` in `ExpiryCacheTests`. 
+
+The `TimeProvider` abstraction is injected into the `ExpiryCache` class, allowing the cache to rely on `GetUtcNow()` to determine whether cache entries should be evicted based on the current time. This abstraction provides flexibility by enabling different time-related behaviors in test environments.
+
+By using `FakeTimeProvider` in testing, we can simulate the passage of time with methods like `Advance()` and `SetUtcNow()`. This makes it possible to emulate the system's time in a controlled and predictable way during tests, ensuring that cache eviction works as expected.
 
 ```csharp
-var timeProvider = new FakeTimeProvider();
-var myComponent = new MyComponent(timeProvider);
-timeProvider.Advance(TimeSpan.FromSeconds(5));
-myComponent.CheckState();
+public class ExpiryCache<TKey, TValue>
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<TKey, CacheItem> _cache = new();
+    private readonly TimeSpan _expirationDuration;
+
+    public ExpiryCache(TimeProvider timeProvider, TimeSpan expirationDuration)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _expirationDuration = expirationDuration;
+    }
+
+    public void Add(TKey key, TValue value)
+    {
+        var expirationTime = _timeProvider.GetUtcNow() + _expirationDuration;
+        var cacheItem = new CacheItem(value, expirationTime);
+
+        _cache[key] = cacheItem;
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        value = default;
+        if (_cache.TryGetValue(key, out var cacheItem))
+        {
+            if (cacheItem.ExpirationTime > _timeProvider.GetUtcNow())
+            {
+                value = cacheItem.Value;
+                return true;
+            }
+
+            // Remove expired item
+            _cache.TryRemove(key, out _);
+        }
+        return false;
+    }
+
+    private class CacheItem
+    {
+        public TValue Value { get; }
+        public DateTimeOffset ExpirationTime { get; }
+
+        public CacheItem(TValue value, DateTimeOffset expirationTime)
+        {
+            Value = value;
+            ExpirationTime = expirationTime;
+        }
+    }
+}
+
+using Microsoft.Extensions.Time.Testing;
+
+public class ExpiryCacheTests
+{
+    [Fact]
+    public void ExpiryCache_ShouldRemoveExpiredItems()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var cache = new ExpiryCache<string, string>(timeProvider, TimeSpan.FromSeconds(3));
+
+        cache.Add("key1", "value1");
+
+        // Simulate time passing
+        timeProvider.SetUtcNow(timeProvider.GetUtcNow() + TimeSpan.FromSeconds(2));
+
+        // The item should still be in the cache
+        bool found = cache.TryGetValue("key1", out var value);
+        Assert.True(found);
+        Assert.Equal("value1", value);
+
+        // Simulate further time passing to be after expiration time
+        timeProvider.SetUtcNow(timeProvider.GetUtcNow() + TimeSpan.FromSeconds(2));
+
+        // The item should now be expired
+        found = cache.TryGetValue("key1", out value);
+        Assert.False(found);
+    }
+}
 ```
 
 ## SynchronizationContext in xUnit Tests
 
 ### xUnit v2
 
-Some testing libraries such as xUnit v2 provide custom `SynchronizationContext` for running tests. xUnit v2, for instance, provides `AsyncTestSyncContext` that allows to properly manage asynchronous operations withing the test execution. However, it brings an issue when we test asynchronous code that uses `ConfigureAwait(false)` in combination with class like `FakeTimeProvider`. In such cases, the xUnit context may lose track of the continuation, causing the test to become unresponsive, whether the test itself is asynchronous or not.
+Some testing libraries such as xUnit v2 provide custom `SynchronizationContext` for running tests. xUnit v2, for instance, provides `AsyncTestSyncContext` that allows to properly manage asynchronous operations within the test execution. However, it brings an issue when we test asynchronous code that uses `ConfigureAwait(false)` in combination with class like `FakeTimeProvider`. In such cases, the xUnit context may lose track of the continuation, causing the test to become unresponsive, whether the test itself is asynchronous or not.
 
 To prevent this issue, remove the xUnit context for tests dependent on `FakeTimeProvider` by setting the synchronization context to `null`:
-```
+```csharp
 SynchronizationContext.SetSynchronizationContext(null)
 ```
 
-The `Advance` method is used to simulate the passage of time. Below is an example how to create a test for a code that uses `ConfigureAwait(false)` that ensures that the continuation of the awaited task (i.e., the code that comes after the await statement) works correctly.
+The `Advance` method is used to simulate the passage of time. Below is an example how to create a test for a code that uses `ConfigureAwait(false)` that ensures that the continuation of the awaited task (i.e., the code that comes after the await statement) works correctly. For a more realistic example, consider the following test using Polly:
 
-For a more realistic example, consider the following test using Polly:
-
-```cs
+```csharp
 using Polly;
 using Polly.Retry;
 
@@ -129,7 +207,7 @@ public class SomeServiceTests
 
 ### xUnit v3 
 
-`AsyncTestSyncContext` has been removed more [here](https://xunit.net/docs/getting-started/v3/migration) so described issue is no longer a problem.
+`AsyncTestSyncContext` has been removed, more info [here](https://xunit.net/docs/getting-started/v3/migration), so above issue is no longer a problem.
 
 ## Feedback & Contributing
 

--- a/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/README.md
+++ b/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/README.md
@@ -33,7 +33,7 @@ public void Advance(TimeSpan delta)
 public void SetLocalTimeZone(TimeZoneInfo localTimeZone)
 ```
 
-### ExpiryCache with TimeProvider
+### `ExpiryCache` with `TimeProvider`
 
 The example below demonstrates the `ExpiryCache` class and how it can be tested using `FakeTimeProvider` in `ExpiryCacheTests`. 
 
@@ -65,7 +65,7 @@ public class ExpiryCache<TKey, TValue>
     public bool TryGetValue(TKey key, out TValue value)
     {
         value = default;
-        if (_cache.TryGetValue(key, out var cacheItem))
+        if (_cache.TryGetValue(key, out TValue cacheItem))
         {
             if (cacheItem.ExpirationTime > _timeProvider.GetUtcNow())
             {
@@ -108,7 +108,7 @@ public class ExpiryCacheTests
         timeProvider.SetUtcNow(timeProvider.GetUtcNow() + TimeSpan.FromSeconds(2));
 
         // The item should still be in the cache
-        bool found = cache.TryGetValue("key1", out var value);
+        bool found = cache.TryGetValue("key1", out string value);
         Assert.True(found);
         Assert.Equal("value1", value);
 
@@ -122,7 +122,7 @@ public class ExpiryCacheTests
 }
 ```
 
-## SynchronizationContext in xUnit Tests
+## `SynchronizationContext` in xUnit Tests
 
 ### xUnit v2
 

--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/FakeTimeProviderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Time.Testing.Test;
 public class FakeTimeProviderTests
 {
     [Fact]
-    public void DefaultCtor()
+    public void Constructor_DefaultInitialization_SetsExpectedValues()
     {
         var timeProvider = new FakeTimeProvider();
 
@@ -41,7 +41,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void RichCtor()
+    public void Constructor_InitializesWithCustomDateTimeOffset_AdvancesCorrectly()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2001, 2, 3, 4, 5, 6, TimeSpan.Zero));
 
@@ -78,7 +78,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void LocalTimeZoneIsUtc()
+    public void LocalTimeZone_Default_IsUtc()
     {
         var timeProvider = new FakeTimeProvider();
         var localTimeZone = timeProvider.LocalTimeZone;
@@ -87,7 +87,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void SetLocalTimeZoneWorks()
+    public void SetLocalTimeZone_CustomTimeZone_SetsNewTimeZone()
     {
         var timeProvider = new FakeTimeProvider();
 
@@ -100,7 +100,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void GetTimestampSyncWithUtcNow()
+    public void SetUtcNow_Forward_AdvancesByProperAmount()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2001, 2, 3, 4, 5, 6, TimeSpan.Zero));
 
@@ -124,7 +124,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void AdvanceGoesForward()
+    public void Advance_Forward_AdvancesByProperAmount()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2001, 2, 3, 4, 5, 6, TimeSpan.Zero));
 
@@ -148,16 +148,23 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void TimeCannotGoBackwards()
+    public void Advance_Backwards_ThrowsArgumentOutOfRangeException()
     {
         var timeProvider = new FakeTimeProvider();
 
         Assert.Throws<ArgumentOutOfRangeException>(() => timeProvider.Advance(TimeSpan.FromTicks(-1)));
+    }
+
+    [Fact]
+    public void SetUtcNow_Backwards_ThrowsArgumentOutOfRangeException()
+    {
+        var timeProvider = new FakeTimeProvider();
+
         Assert.Throws<ArgumentOutOfRangeException>(() => timeProvider.SetUtcNow(timeProvider.GetUtcNow() - TimeSpan.FromTicks(1)));
     }
 
     [Fact]
-    public void AdjustTimeForwardWorks()
+    public void TimerCallback_AdjustTimeForward_Works()
     {
         var tp = new FakeTimeProvider();
 
@@ -184,7 +191,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void AdjustTimeBackwardWorks()
+    public void TimerCallback_AdjustTimeBackwards_Works()
     {
         var tp = new FakeTimeProvider();
 
@@ -211,7 +218,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void ToStr()
+    public void ToString_SetDateTimeOffset_ReturnsProperFormat()
     {
         var dto = new DateTimeOffset(new DateTime(2022, 1, 2, 3, 4, 5, 6), TimeSpan.Zero);
 
@@ -222,7 +229,7 @@ public class FakeTimeProviderTests
     private readonly TimeSpan _infiniteTimeout = TimeSpan.FromMilliseconds(-1);
 
     [Fact]
-    public async Task Delay_Zero()
+    public async Task Delay_ZeroDelay_CompletesSuccessfully()
     {
         var timeProvider = new FakeTimeProvider();
         var t = timeProvider.Delay(TimeSpan.Zero, CancellationToken.None);
@@ -232,7 +239,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public async Task Delay_Timeout()
+    public async Task Delay_Awaited_CompletesSuccessfully()
     {
         var timeProvider = new FakeTimeProvider();
 
@@ -246,7 +253,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public async Task Delay_Cancelled()
+    public async Task Delay_TokenCancelled_ThrowsTaskCanceledException()
     {
         var timeProvider = new FakeTimeProvider();
 
@@ -262,7 +269,22 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public async Task CreateSource()
+    public async Task Delay_WhenTimeAdvanced_CompletesWithoutCancellation()
+    {
+        var fakeTimeProvider = new FakeTimeProvider();
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000));
+
+        var task = fakeTimeProvider.Delay(TimeSpan.FromMilliseconds(10000), cancellationTokenSource.Token);
+
+        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(10000));
+
+        await task;
+
+        Assert.False(cancellationTokenSource.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Advance_CancelledToken_ThrowsTaskCanceledException()
     {
         var timeProvider = new FakeTimeProvider();
 
@@ -272,9 +294,8 @@ public class FakeTimeProviderTests
         await Assert.ThrowsAsync<TaskCanceledException>(() => timeProvider.Delay(TimeSpan.FromTicks(1), cts.Token));
     }
 
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
     [Fact]
-    public async Task WaitAsync()
+    public async Task WaitAsync_NegativeTimeout_Throws()
     {
         var timeProvider = new FakeTimeProvider();
         var source = new TaskCompletionSource<bool>();
@@ -285,6 +306,14 @@ public class FakeTimeProviderTests
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => source.Task.WaitAsync(TimeSpan.FromTicks(-1), timeProvider, CancellationToken.None));
 #endif
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => source.Task.WaitAsync(TimeSpan.FromMilliseconds(-2), timeProvider, CancellationToken.None));
+    }
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+    [Fact]
+    public async Task WaitAsync_ValidTimeout_CompletesSuccessfully()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var source = new TaskCompletionSource<bool>();
 
         var t = source.Task.WaitAsync(TimeSpan.FromSeconds(100000), timeProvider, CancellationToken.None);
         while (!t.IsCompleted)
@@ -301,12 +330,12 @@ public class FakeTimeProviderTests
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
     [Fact]
-    public async Task WaitAsync_InfiniteTimeout()
+    public async Task WaitAsync_InfiniteTimeout_CompletesSuccessfully()
     {
         var timeProvider = new FakeTimeProvider();
         var source = new TaskCompletionSource<bool>();
 
-        var t = source.Task.WaitAsync(_infiniteTimeout, timeProvider, CancellationToken.None);
+        var t = source.Task.WaitAsync(TimeSpan.FromMilliseconds(-1), timeProvider, CancellationToken.None);
         while (!t.IsCompleted)
         {
             timeProvider.Advance(TimeSpan.FromMilliseconds(1));
@@ -320,7 +349,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public async Task WaitAsync_Timeout()
+    public async Task WaitAsync_Timeout_ResultsInFaultedTask()
     {
         var timeProvider = new FakeTimeProvider();
         var source = new TaskCompletionSource<bool>();
@@ -338,7 +367,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public async Task WaitAsync_Cancel()
+    public async Task WaitAsync_CancelledToken_ThrowsTaskCanceledException()
     {
         var timeProvider = new FakeTimeProvider();
         var source = new TaskCompletionSource<bool>();
@@ -353,7 +382,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void AutoAdvance()
+    public void GetUtcNow_AutoAdvanceSpecified_AutoAdvancesBySpecifiedAmount()
     {
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow)
         {
@@ -370,7 +399,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void ToString_AutoAdvance_off()
+    public void ToString_NoAutoAdvanceSpecified_DoesNotAutoAdvance()
     {
         var timeProvider = new FakeTimeProvider();
 
@@ -380,7 +409,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void ToString_AutoAdvance_on()
+    public void ToString_AutoAdvanceSpecified_AutoAdvancesBySpecifiedAmount()
     {
         var timeProvider = new FakeTimeProvider
         {
@@ -394,7 +423,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void AdvanceTimeInCallback()
+    public void Advance_TimeInCallback_PreventsInfiniteLoop()
     {
         var oneSecond = TimeSpan.FromSeconds(1);
         var timeProvider = new FakeTimeProvider();
@@ -411,7 +440,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void ShouldResetGateUnderLock_PreventingContextSwitching_AffectionOnTimerCallback()
+    public void GetUtcNow_ResetGateUnderLock_PreventsContextSwitchingIssuesWithTimerCallback()
     {
         // Arrange
         var provider = new FakeTimeProvider { AutoAdvanceAmount = TimeSpan.FromSeconds(2) };
@@ -438,7 +467,7 @@ public class FakeTimeProviderTests
     }
 
     [Fact]
-    public void SimulateRetryPolicy()
+    public void Advance_PollyRetryWithConfigureAwaitFalse_ProcessesCorrectly()
     {
         // Arrange
         SynchronizationContext.SetSynchronizationContext(null);
@@ -468,7 +497,7 @@ public class FakeTimeProviderTests
                 }
                 catch (InvalidOperationException)
                 {
-                    // ConfigureAwait(true) is required to ensure that tasks continue on the captured context
+                    // ConfigureAwait(false) is required to validate test properly
                     await provider.Delay(TimeSpan.FromSeconds(delay)).ConfigureAwait(false);
                 }
             }

--- a/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/TimerTests.cs
+++ b/test/Libraries/Microsoft.Extensions.TimeProvider.Testing.Tests/TimerTests.cs
@@ -18,7 +18,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void TimerNonPeriodicPeriodZero()
+    public void CreateTimer_PeriodZero_FiresOnceAndDoesNotRepeat()
     {
         var counter = 0;
         var timeProvider = new FakeTimeProvider();
@@ -40,7 +40,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void TimerNonPeriodicPeriodInfinite()
+    public void CreateTimer_PeriodInfinite_FiresOnceAndDoesNotRepeat()
     {
         var counter = 0;
         var timeProvider = new FakeTimeProvider();
@@ -62,7 +62,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void TimerStartsImmediately()
+    public void CreateTimer_ImmediateStart_FiresOnceAndDoesNotRepeat()
     {
         var counter = 0;
         var timeProvider = new FakeTimeProvider();
@@ -84,7 +84,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void NoDueTime_TimerDoesntStart()
+    public void CreateTimer_InfiniteTimeSpan_DoesNotFire()
     {
         var counter = 0;
         var timeProvider = new FakeTimeProvider();
@@ -106,7 +106,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void TimerTriggersPeriodically()
+    public void CreateTimer_PeriodicTrigger_FiresAtSpecifiedIntervals()
     {
         var counter = 0;
         var timeProvider = new FakeTimeProvider();
@@ -133,37 +133,7 @@ public class TimerTests
     }
 
     [Fact]
-    public async Task TaskDelayWithFakeTimeProviderAdvanced()
-    {
-        var fakeTimeProvider = new FakeTimeProvider();
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000));
-
-        var task = fakeTimeProvider.Delay(TimeSpan.FromMilliseconds(10000), cancellationTokenSource.Token);
-
-        fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(10000));
-
-        await task;
-
-        Assert.False(cancellationTokenSource.Token.IsCancellationRequested);
-    }
-
-    [Fact]
-    public async Task TaskDelayWithFakeTimeProviderStopped()
-    {
-        var fakeTimeProvider = new FakeTimeProvider();
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-
-        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
-        {
-            await fakeTimeProvider.Delay(
-                TimeSpan.FromMilliseconds(10000),
-                cancellationTokenSource.Token)
-            .ConfigureAwait(false);
-        });
-    }
-
-    [Fact]
-    public void TimerChangeDueTimeOutOfRangeThrows()
+    public void Change_WhenDueTimeIsOutOfRange_ThrowsArgumentOutOfRangeException()
     {
         using var t = new Timer(new FakeTimeProvider(), new TimerCallback(EmptyTimerTarget), null);
         _ = t.Change(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1));
@@ -175,7 +145,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void TimerChangePeriodOutOfRangeThrows()
+    public void Change_WhenPeriodIsOutOfRange_ThrowsArgumentOutOfRangeException()
     {
         using var t = new Timer(new FakeTimeProvider(), new TimerCallback(EmptyTimerTarget), null);
         _ = t.Change(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1));
@@ -187,7 +157,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void Timer_Change_AfterDispose_Test()
+    public void Change_WhenCalledAfterDispose_ReturnsFalse()
     {
         var t = new Timer(new FakeTimeProvider(), new TimerCallback(EmptyTimerTarget), null);
         _ = t.Change(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1));
@@ -198,7 +168,7 @@ public class TimerTests
     }
 
     [Fact]
-    public async Task Timer_Change_AfterDisposeAsync_Test()
+    public async Task Change_WhenCalledAfterDisposeAsync_ReturnsFalse()
     {
         var t = new Timer(new FakeTimeProvider(), new TimerCallback(EmptyTimerTarget), null);
         _ = t.Change(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1));
@@ -209,7 +179,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void WaiterRemovedAfterDispose()
+    public void CreateTimer_WhenDisposed_RemovesWaiterFromQueue()
     {
         var timer1Counter = 0;
         var timer2Counter = 0;
@@ -242,7 +212,7 @@ public class TimerTests
 
 #if RELEASE // In Release only since this might not work if the timer reference being tracked by the debugger
     [Fact(Skip = "Flaky on .NET Framework")]
-    public void WaiterRemovedWhenCollectedWithoutDispose()
+    public void CreateTimer_WhenCollectedWithoutDispose_RemovesWaiterFromQueue()
     {
         var timer1Counter = 0;
         var timer2Counter = 0;
@@ -276,7 +246,7 @@ public class TimerTests
 #endif
 
     [Fact]
-    public void UtcNowUpdatedBeforeTimerCallback()
+    public void CreateTimer_WhenUtcNowUpdatedBeforeCallback_UpdatesCallbackTime()
     {
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
         var callbackTime = DateTimeOffset.MinValue;
@@ -298,7 +268,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void LongPausesTriggerMultipleCallbacks()
+    public void CreateTimer_WhenLongPauses_TriggersMultipleCallbacks()
     {
         var callbackTimes = new List<DateTimeOffset>();
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
@@ -323,7 +293,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void MultipleTimersCallbackInvokedInScheduledOrder()
+    public void CreateMultipleTimers_WhenAdvanced_InvokesCallbacksInScheduledOrder()
     {
         var callbacks = new List<(int timerId, TimeSpan callbackTime)>();
         var timeProvider = new FakeTimeProvider();
@@ -352,7 +322,7 @@ public class TimerTests
     }
 
     [Fact]
-    public void OutOfOrderWakeTimes()
+    public void CreateMultipleTimers_WhenAdvanced_TriggersCallbacksInOrder()
     {
         const int MaxDueTime = 10;
         const int TotalTimers = 128;


### PR DESCRIPTION
Improve `FakeTimeProvider` documentation, remove redundant tests, refactor tests methods.

I updated test method names as well to make them more readable, so that the code can also serve as nice documentation and reference to the users.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5683)