### PR TITLE
For AI integration tests, use config including user secrets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\eng\packages\General.props" />
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\eng\packages\General.props" />
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+  </ItemGroup>
 </Project>

--- a/eng/packages/TestOnly.props
+++ b/eng/packages/TestOnly.props
@@ -10,6 +10,8 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.2.3" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24378.1" />
     <PackageVersion Include="Moq.AutoMock" Version="3.1.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />

--- a/src/Libraries/Microsoft.Extensions.AI/README.md
+++ b/src/Libraries/Microsoft.Extensions.AI/README.md
@@ -69,6 +69,8 @@ Your account must have models matching these names.
 
 ### Configuring Azure AI Inference tests
 
+Run commands like the following. The settings will be saved in your user profile.
+
 ```
 cd test/Libraries/Microsoft.Extensions.AI.Integration.Tests
 dotnet user-secrets set AzureAIInference:Endpoint https://YOUR_DEPLOYMENT.azure.com/

--- a/src/Libraries/Microsoft.Extensions.AI/README.md
+++ b/src/Libraries/Microsoft.Extensions.AI/README.md
@@ -25,3 +25,59 @@ Please refer to the [README](https://www.nuget.org/packages/Microsoft.Extensions
 ## Feedback & Contributing
 
 We welcome feedback and contributions in [our GitHub repo](https://github.com/dotnet/extensions).
+
+## Running the integration tests
+
+If you're working on this repo and want to run the integration tests, e.g., those in `Microsoft.Extensions.AI.OpenAI.Tests`, you must first set endpoints and keys. You can either set these as environment variables or - better - using .NET's user secrets feature as shown below.
+
+### Configuring OpenAI tests (OpenAI)
+
+Run commands like the following. The settings will be saved in your user profile.
+
+```
+cd test/Libraries/Microsoft.Extensions.AI.Integration.Tests
+dotnet user-secrets set OpenAI:Mode OpenAI
+dotnet user-secrets set OpenAI:Key abcdefghijkl
+```
+
+Optionally also run the following. The values shown here are the defaults if you don't specify otherwise:
+
+```
+dotnet user-secrets set OpenAI:ChatModel gpt-4o-mini
+dotnet user-secrets set OpenAI:EmbeddingModel text-embedding-3-small
+```
+
+### Configuring OpenAI tests (Azure OpenAI)
+
+Run commands like the following. The settings will be saved in your user profile.
+
+```
+cd test/Libraries/Microsoft.Extensions.AI.Integration.Tests
+dotnet user-secrets set OpenAI:Mode AzureOpenAI
+dotnet user-secrets set OpenAI:Endpoint https://YOUR_DEPLOYMENT.openai.azure.com/
+dotnet user-secrets set OpenAI:Key abcdefghijkl
+```
+
+Optionally also run the following. The values shown here are the defaults if you don't specify otherwise:
+
+```
+dotnet user-secrets set OpenAI:ChatModel gpt-4o-mini
+dotnet user-secrets set OpenAI:EmbeddingModel text-embedding-3-small
+```
+
+Your account must have models matching these names.
+
+### Configuring Azure AI Inference tests
+
+```
+cd test/Libraries/Microsoft.Extensions.AI.Integration.Tests
+dotnet user-secrets set AzureAIInference:Endpoint https://YOUR_DEPLOYMENT.azure.com/
+dotnet user-secrets set AzureAIInference:Key abcdefghijkl
+```
+
+Optionally also run the following. The values shown here are the defaults if you don't specify otherwise:
+
+```
+dotnet user-secrets set AzureAIInference:ChatModel gpt-4o-mini
+dotnet user-secrets set AzureAIInference:EmbeddingModel text-embedding-3-small
+```

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientIntegrationTests.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.Extensions.AI;
 
 public class AzureAIInferenceChatClientIntegrationTests : ChatClientIntegrationTests
 {
     protected override IChatClient? CreateChatClient() =>
         IntegrationTestHelpers.GetChatCompletionsClient()
-            ?.AsChatClient(Environment.GetEnvironmentVariable("AZURE_AI_INFERENCE_CHAT_MODEL") ?? "gpt-4o-mini");
+            ?.AsChatClient(TestRunnerConfiguration.Instance["AzureAIInference:ChatModel"] ?? "gpt-4o-mini");
 }

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceEmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceEmbeddingGeneratorIntegrationTests.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.Extensions.AI;
 
 public class AzureAIInferenceEmbeddingGeneratorIntegrationTests : EmbeddingGeneratorIntegrationTests
 {
     protected override IEmbeddingGenerator<string, Embedding<float>>? CreateEmbeddingGenerator() =>
         IntegrationTestHelpers.GetEmbeddingsClient()
-        ?.AsEmbeddingGenerator(Environment.GetEnvironmentVariable("OPENAI_EMBEDDING_MODEL") ?? "text-embedding-3-small");
+        ?.AsEmbeddingGenerator(TestRunnerConfiguration.Instance["AzureAIInference:EmbeddingModel"] ?? "text-embedding-3-small");
 }

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/IntegrationTestHelpers.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/IntegrationTestHelpers.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Extensions.AI;
 internal static class IntegrationTestHelpers
 {
     private static readonly string? _apiKey =
-        Environment.GetEnvironmentVariable("AZURE_AI_INFERENCE_APIKEY") ??
-        Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        TestRunnerConfiguration.Instance["AzureAIInference:Key"] ??
+        TestRunnerConfiguration.Instance["OpenAI:Key"];
 
     private static readonly string _endpoint =
-        Environment.GetEnvironmentVariable("AZURE_AI_INFERENCE_ENDPOINT") ??
+        TestRunnerConfiguration.Instance["AzureAIInference:Endpoint"] ??
         "https://api.openai.com/v1";
 
     /// <summary>Gets an <see cref="ChatCompletionsClient"/> to use for testing, or null if the associated tests should be disabled.</summary>

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/Microsoft.Extensions.AI.Integration.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/Microsoft.Extensions.AI.Integration.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.AI</RootNamespace>
     <Description>Opt-in integration tests for Microsoft.Extensions.AI.</Description>
+    <UserSecretsId>2ddf3914-75d2-4677-96e8-2e583ca87838</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/Microsoft.Extensions.AI.Integration.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/Microsoft.Extensions.AI.Integration.Tests.csproj
@@ -25,6 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.ML.Tokenizers" />

--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/TestRunnerConfiguration.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/TestRunnerConfiguration.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.AI;
+
+public static class TestRunnerConfiguration
+{
+    public static IConfiguration Instance { get; } = new ConfigurationBuilder()
+        .AddUserSecrets<TypeInThisAssembly>()
+        .AddEnvironmentVariables()
+        .Build();
+
+    private class TypeInThisAssembly;
+}

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/IntegrationTestHelpers.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/IntegrationTestHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ClientModel;
 using Azure.AI.OpenAI;
+using Microsoft.Extensions.Configuration;
 using OpenAI;
 
 namespace Microsoft.Extensions.AI;
@@ -14,14 +15,15 @@ internal static class IntegrationTestHelpers
     /// <summary>Gets an <see cref="OpenAIClient"/> to use for testing, or null if the associated tests should be disabled.</summary>
     public static OpenAIClient? GetOpenAIClient()
     {
-        string? apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        var configuration = TestRunnerConfiguration.Instance;
+        string? apiKey = configuration["OpenAI:Key"];
 
         if (apiKey is not null)
         {
-            if (string.Equals(Environment.GetEnvironmentVariable("OPENAI_MODE"), "AzureOpenAI", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(configuration["OpenAI:Mode"], "AzureOpenAI", StringComparison.OrdinalIgnoreCase))
             {
-                var endpoint = Environment.GetEnvironmentVariable("OPENAI_ENDPOINT")
-                    ?? throw new InvalidOperationException("To use AzureOpenAI, set a value for OPENAI_ENDPOINT");
+                var endpoint = configuration["OpenAI:Endpoint"]
+                    ?? throw new InvalidOperationException("To use AzureOpenAI, set a value for OpenAI:Endpoint");
                 return new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey));
             }
             else

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientIntegrationTests.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.Extensions.AI;
 
 public class OpenAIChatClientIntegrationTests : ChatClientIntegrationTests
 {
     protected override IChatClient? CreateChatClient() =>
         IntegrationTestHelpers.GetOpenAIClient()
-        ?.AsChatClient(Environment.GetEnvironmentVariable("OPENAI_CHAT_MODEL") ?? "gpt-4o-mini");
+        ?.AsChatClient(TestRunnerConfiguration.Instance["OpenAI:ChatModel"] ?? "gpt-4o-mini");
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIEmbeddingGeneratorIntegrationTests.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
 namespace Microsoft.Extensions.AI;
 
 public class OpenAIEmbeddingGeneratorIntegrationTests : EmbeddingGeneratorIntegrationTests
 {
     protected override IEmbeddingGenerator<string, Embedding<float>>? CreateEmbeddingGenerator() =>
         IntegrationTestHelpers.GetOpenAIClient()
-        ?.AsEmbeddingGenerator(Environment.GetEnvironmentVariable("OPENAI_EMBEDDING_MODEL") ?? "text-embedding-3-small");
+        ?.AsEmbeddingGenerator(TestRunnerConfiguration.Instance["OpenAI:EmbeddingModel"] ?? "text-embedding-3-small");
 }

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIRealtimeIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIRealtimeIntegrationTests.cs
@@ -102,7 +102,7 @@ public class OpenAIRealtimeIntegrationTests
 
     private static RealtimeConversationClient? CreateConversationClient()
     {
-        var realtimeModel = Environment.GetEnvironmentVariable("OPENAI_REALTIME_MODEL");
+        var realtimeModel = TestRunnerConfiguration.Instance["OpenAI:RealtimeModel"];
         if (string.IsNullOrEmpty(realtimeModel))
         {
             return null;


### PR DESCRIPTION
I was getting tired of having to remember to set environment variables and restart VS whenever I wanted to run the integration tests. We were also a bit out of line with our recommendations in using `GetEnvironmentVariable` directly instead of going through the `IConfiguration` abstraction which allows for multiple configuration sources.

With this change, you can set your config just once using `dotnet user-secrets` and it will be stored in your user profile in a way that's scoped to this repo. Instructions added to readme file.

Alternatively you can continue using environment variables (though the names have changed to match .NET config naming conventions).