### PR TITLE
Support aggregating usage data, and do so in FunctionInvokingChatClient

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/AdditionalUsageValues.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/AdditionalUsageValues.cs
@@ -1,0 +1,226 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// A key-value store for usage values. Values may be of the following types:
+/// <see cref="int"/>, <see cref="long"/>, <see cref="float"/>, <see cref="double"/>, <see cref="decimal"/>.
+/// </summary>
+public class AdditionalUsageValues : IEnumerable<KeyValuePair<string, object>>
+{
+    private readonly Dictionary<string, Entry> _dictionary = new();
+
+    /// <summary>
+    /// Gets a value matching the specified key.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The corresponding dictionary entry.</returns>
+    public object? this[string key] => _dictionary[key].AsObject();
+
+    /// <summary>Gets the keys in the collection.</summary>
+    public IEnumerable<string> Keys => _dictionary.Keys;
+
+    /// <summary>Gets the number of items in the collection.</summary>
+    public int Count => _dictionary.Count;
+
+    /// <summary>
+    /// Returns an enumerator that enumerates through the collection.
+    /// </summary>
+    /// <returns>The enumerator.</returns>
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+    {
+        foreach (var entry in _dictionary)
+        {
+            yield return new KeyValuePair<string, object>(entry.Key, entry.Value.AsObject());
+        }
+    }
+
+    /// <summary>
+    /// Returns an enumerator that enumerates through the collection.
+    /// </summary>
+    /// <returns>The enumerator.</returns>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        foreach (var entry in _dictionary)
+        {
+            yield return new KeyValuePair<string, object>(entry.Key, entry.Value.AsObject());
+        }
+    }
+
+    /// <summary>Removes the specified entry.</summary>
+    /// <param name="key">The key.</param>
+    public void Remove(string key)
+        => _dictionary.Remove(key);
+
+    /// <summary>Gets the specified value as a <see cref="int"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The value.</returns>
+    public int GetInt32(string key) => _dictionary[key].AsInt();
+
+    /// <summary>Gets the specified value as a <see cref="long"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The value.</returns>
+    public long GetInt64(string key) => _dictionary[key].AsLong();
+
+    /// <summary>Gets the specified value as a <see cref="float"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The value.</returns>
+    public float GetSingle(string key) => _dictionary[key].AsFloat();
+
+    /// <summary>Gets the specified value as a <see cref="double"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The value.</returns>
+    public double GetDouble(string key) => _dictionary[key].AsDouble();
+
+    /// <summary>Gets the specified value as a <see cref="decimal"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <returns>The value.</returns>
+    public decimal GetDecimal(string key) => _dictionary[key].AsDecimal();
+
+    /// <summary>Adds or overwrites an entry with the specified <paramref name="key"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    public void Set(string key, int value) => _dictionary[key] = new Entry(value);
+
+    /// <summary>Adds or overwrites an entry with the specified <paramref name="key"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    public void Set(string key, long value) => _dictionary[key] = new Entry(value);
+
+    /// <summary>Adds or overwrites an entry with the specified <paramref name="key"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    public void Set(string key, float value) => _dictionary[key] = new Entry(value);
+
+    /// <summary>Adds or overwrites an entry with the specified <paramref name="key"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    public void Set(string key, double value) => _dictionary[key] = new Entry(value);
+
+    /// <summary>Adds or overwrites an entry with the specified <paramref name="key"/>.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The value.</param>
+    public void Set(string key, decimal value) => _dictionary[key] = new Entry(value);
+
+    /// <summary>Increases an existing entry stored with the specified <paramref name="key"/>, or creates a new entry.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="amountToAdd">The amount by which to increment the entry. If no stored value already exists, a new one is created with this value.</param>
+    public void Add(string key, int amountToAdd) =>
+        _dictionary[key] = _dictionary.TryGetValue(key, out var existingValue) ? existingValue.Add(amountToAdd) : new(amountToAdd);
+
+    /// <summary>Increases an existing entry stored with the specified <paramref name="key"/>, or creates a new entry.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="amountToAdd">The amount by which to increment the entry. If no stored value already exists, a new one is created with this value.</param>
+    public void Add(string key, long amountToAdd) =>
+        _dictionary[key] = _dictionary.TryGetValue(key, out var existingValue) ? existingValue.Add(amountToAdd) : new(amountToAdd);
+
+    /// <summary>Increases an existing entry stored with the specified <paramref name="key"/>, or creates a new entry.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="amountToAdd">The amount by which to increment the entry. If no stored value already exists, a new one is created with this value.</param>
+    public void Add(string key, float amountToAdd) =>
+        _dictionary[key] = _dictionary.TryGetValue(key, out var existingValue) ? existingValue.Add(amountToAdd) : new(amountToAdd);
+
+    /// <summary>Increases an existing entry stored with the specified <paramref name="key"/>, or creates a new entry.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="amountToAdd">The amount by which to increment the entry. If no stored value already exists, a new one is created with this value.</param>
+    public void Add(string key, double amountToAdd) =>
+        _dictionary[key] = _dictionary.TryGetValue(key, out var existingValue) ? existingValue.Add(amountToAdd) : new(amountToAdd);
+
+    /// <summary>Increases an existing entry stored with the specified <paramref name="key"/>, or creates a new entry.</summary>
+    /// <param name="key">The key.</param>
+    /// <param name="amountToAdd">The amount by which to increment the entry. If no stored value already exists, a new one is created with this value.</param>
+    public void Add(string key, decimal amountToAdd) =>
+        _dictionary[key] = _dictionary.TryGetValue(key, out var existingValue) ? existingValue.Add(amountToAdd) : new(amountToAdd);
+
+    [StructLayout(LayoutKind.Explicit)]
+    private readonly struct Entry
+    {
+        [FieldOffset(0)]
+        public readonly EntryType Type;
+
+        [FieldOffset(4)]
+        public readonly int IntValue;
+
+        [FieldOffset(4)]
+        public readonly long LongValue;
+
+        [FieldOffset(4)]
+        public readonly float FloatValue;
+
+        [FieldOffset(4)]
+        public readonly double DoubleValue;
+
+        [FieldOffset(4)]
+        public readonly decimal DecimalValue;
+
+        public Entry(int value)
+        {
+            Type = EntryType.Int;
+            IntValue = value;
+        }
+
+        public Entry(long value)
+        {
+            Type = EntryType.Long;
+            LongValue = value;
+        }
+
+        public Entry(float value)
+        {
+            Type = EntryType.Float;
+            FloatValue = value;
+        }
+
+        public Entry(double value)
+        {
+            Type = EntryType.Double;
+            DoubleValue = value;
+        }
+
+        public Entry(decimal value)
+        {
+            Type = EntryType.Decimal;
+            DecimalValue = value;
+        }
+
+        public object AsObject() => Type switch
+        {
+            EntryType.Int => IntValue,
+            EntryType.Long => LongValue,
+            EntryType.Float => FloatValue,
+            EntryType.Double => DoubleValue,
+            EntryType.Decimal => DecimalValue,
+            _ => throw new InvalidOperationException("Unknown entry type.")
+        };
+
+        // In the common case we'll be reading the correct type. In the uncommon case we'll do a boxed conversion to keep things simple,
+        // otherwise there are 25 conversion cases to write out.
+        public int AsInt() => Type == EntryType.Int ? IntValue : Convert.ToInt32(AsObject(), CultureInfo.InvariantCulture);
+        public long AsLong() => Type == EntryType.Long ? LongValue : Convert.ToInt64(AsObject(), CultureInfo.InvariantCulture);
+        public float AsFloat() => Type == EntryType.Float ? FloatValue : Convert.ToSingle(AsObject(), CultureInfo.InvariantCulture);
+        public double AsDouble() => Type == EntryType.Double ? DoubleValue : Convert.ToDouble(AsObject(), CultureInfo.InvariantCulture);
+        public decimal AsDecimal() => Type == EntryType.Decimal ? DecimalValue : Convert.ToDecimal(AsObject(), CultureInfo.InvariantCulture);
+
+        public Entry Add(int value) => new Entry(AsInt() + value);
+        public Entry Add(long value) => new Entry(AsLong() + value);
+        public Entry Add(float value) => new Entry(AsFloat() + value);
+        public Entry Add(double value) => new Entry(AsDouble() + value);
+        public Entry Add(decimal value) => new Entry(AsDecimal() + value);
+    }
+
+    private enum EntryType
+    {
+        Int,
+        Long,
+        Float,
+        Double,
+        Decimal
+    }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/UsageDetails.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/UsageDetails.cs
@@ -28,9 +28,9 @@ public class UsageDetails
     public void Add(UsageDetails usage)
     {
         _ = Throw.IfNull(usage);
-        InputTokenCount += usage.InputTokenCount;
-        OutputTokenCount += usage.OutputTokenCount;
-        TotalTokenCount += usage.TotalTokenCount;
+        InputTokenCount = NullableSum(InputTokenCount, usage.InputTokenCount);
+        OutputTokenCount = NullableSum(OutputTokenCount, usage.OutputTokenCount);
+        TotalTokenCount = NullableSum(TotalTokenCount, usage.TotalTokenCount);
 
         if (usage.AdditionalValues is not null)
         {
@@ -73,4 +73,6 @@ public class UsageDetails
             return string.Join(", ", parts);
         }
     }
+
+    private static int? NullableSum(int? a, int? b) => (a.HasValue || b.HasValue) ? (a ?? 0) + (b ?? 0) : null;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/UsageDetails.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/UsageDetails.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
 
@@ -21,6 +23,21 @@ public class UsageDetails
 
     /// <summary>Gets or sets additional usage values.</summary>
     public AdditionalUsageValues? AdditionalValues { get; set; }
+
+    /// <summary>Adds usage data from another <see cref="UsageDetails"/> into this instance.</summary>
+    public void Add(UsageDetails usage)
+    {
+        _ = Throw.IfNull(usage);
+        InputTokenCount += usage.InputTokenCount;
+        OutputTokenCount += usage.OutputTokenCount;
+        TotalTokenCount += usage.TotalTokenCount;
+
+        if (usage.AdditionalValues is not null)
+        {
+            AdditionalValues ??= new();
+            AdditionalValues.AddFrom(usage.AdditionalValues);
+        }
+    }
 
     /// <summary>Gets a string representing this instance to display in the debugger.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/UsageDetails.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/UsageDetails.cs
@@ -19,8 +19,8 @@ public class UsageDetails
     /// <summary>Gets or sets the total number of tokens used to produce the response.</summary>
     public int? TotalTokenCount { get; set; }
 
-    /// <summary>Gets or sets additional properties for the usage details.</summary>
-    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+    /// <summary>Gets or sets additional usage values.</summary>
+    public AdditionalUsageValues? AdditionalValues { get; set; }
 
     /// <summary>Gets a string representing this instance to display in the debugger.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -45,9 +45,9 @@ public class UsageDetails
                 parts.Add($"{nameof(TotalTokenCount)} = {total}");
             }
 
-            if (AdditionalProperties is { } additionalProperties)
+            if (AdditionalValues is { } additionalValues)
             {
-                foreach (var entry in additionalProperties)
+                foreach (var entry in additionalValues)
                 {
                     parts.Add($"{entry.Key} = {entry.Value}");
                 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Extensions.AI;
 /// <summary>Represents an <see cref="IChatClient"/> for an OpenAI <see cref="OpenAIClient"/> or <see cref="OpenAI.Chat.ChatClient"/>.</summary>
 public sealed class OpenAIChatClient : IChatClient
 {
+    private const string OutputTokenDetailsReasoningTokenCountKey = $"{nameof(ChatTokenUsage.OutputTokenDetails)}.{nameof(ChatOutputTokenUsageDetails.ReasoningTokenCount)}";
+
     private static readonly JsonElement _defaultParameterSchema = JsonDocument.Parse("{}").RootElement;
 
     /// <summary>Default OpenAI endpoint.</summary>
@@ -168,7 +170,10 @@ public sealed class OpenAIChatClient : IChatClient
 
             if (tokenUsage.OutputTokenDetails is ChatOutputTokenUsageDetails details)
             {
-                completion.Usage.AdditionalProperties = new() { [nameof(details.ReasoningTokenCount)] = details.ReasoningTokenCount };
+                completion.Usage.AdditionalValues = new()
+                {
+                    { OutputTokenDetailsReasoningTokenCountKey, details.ReasoningTokenCount },
+                };
             }
         }
 
@@ -299,9 +304,9 @@ public sealed class OpenAIChatClient : IChatClient
 
                 if (tokenUsage.OutputTokenDetails is ChatOutputTokenUsageDetails details)
                 {
-                    (usageDetails.AdditionalProperties = [])[nameof(tokenUsage.OutputTokenDetails)] = new Dictionary<string, object?>
+                    usageDetails.AdditionalValues = new()
                     {
-                        [nameof(details.ReasoningTokenCount)] = details.ReasoningTokenCount,
+                        { OutputTokenDetailsReasoningTokenCountKey, details.ReasoningTokenCount },
                     };
                 }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/UsageContentTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/Contents/UsageContentTests.cs
@@ -26,7 +26,7 @@ public class UsageContentTests
         Assert.Null(c.Details.InputTokenCount);
         Assert.Null(c.Details.OutputTokenCount);
         Assert.Null(c.Details.TotalTokenCount);
-        Assert.Null(c.Details.AdditionalProperties);
+        Assert.Null(c.Details.AdditionalValues);
     }
 
     [Fact]

--- a/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.OpenAI.Tests/OpenAIChatClientTests.cs
@@ -199,7 +199,7 @@ public class OpenAIChatClientTests
         Assert.Equal(8, response.Usage.InputTokenCount);
         Assert.Equal(9, response.Usage.OutputTokenCount);
         Assert.Equal(17, response.Usage.TotalTokenCount);
-        Assert.NotNull(response.Usage.AdditionalProperties);
+        Assert.NotNull(response.Usage.AdditionalValues);
 
         Assert.NotNull(response.AdditionalProperties);
         Assert.Equal("fp_f85bea6784", response.AdditionalProperties[nameof(OpenAI.Chat.ChatCompletion.SystemFingerprint)]);
@@ -275,8 +275,11 @@ public class OpenAIChatClientTests
         Assert.Equal(8, usage.Details.InputTokenCount);
         Assert.Equal(9, usage.Details.OutputTokenCount);
         Assert.Equal(17, usage.Details.TotalTokenCount);
-        Assert.NotNull(usage.Details.AdditionalProperties);
-        Assert.Equal(new Dictionary<string, object> { [nameof(ChatOutputTokenUsageDetails.ReasoningTokenCount)] = 0 }, usage.Details.AdditionalProperties[nameof(ChatTokenUsage.OutputTokenDetails)]);
+
+        var additionalUsageValues = usage.Details.AdditionalValues;
+        Assert.NotNull(additionalUsageValues);
+        Assert.Equal(1, additionalUsageValues.Count);
+        Assert.Equal(0, additionalUsageValues[$"{nameof(ChatTokenUsage.OutputTokenDetails)}.{nameof(ChatOutputTokenUsageDetails.ReasoningTokenCount)}"]);
     }
 
     [Fact]
@@ -380,7 +383,7 @@ public class OpenAIChatClientTests
         Assert.Equal(42, response.Usage.InputTokenCount);
         Assert.Equal(15, response.Usage.OutputTokenCount);
         Assert.Equal(57, response.Usage.TotalTokenCount);
-        Assert.NotNull(response.Usage.AdditionalProperties);
+        Assert.NotNull(response.Usage.AdditionalValues);
 
         Assert.NotNull(response.AdditionalProperties);
         Assert.Equal("fp_f85bea6784", response.AdditionalProperties[nameof(OpenAI.Chat.ChatCompletion.SystemFingerprint)]);
@@ -472,7 +475,7 @@ public class OpenAIChatClientTests
         Assert.Equal(42, response.Usage.InputTokenCount);
         Assert.Equal(15, response.Usage.OutputTokenCount);
         Assert.Equal(57, response.Usage.TotalTokenCount);
-        Assert.NotNull(response.Usage.AdditionalProperties);
+        Assert.NotNull(response.Usage.AdditionalValues);
 
         Assert.NotNull(response.AdditionalProperties);
         Assert.Equal("fp_f85bea6784", response.AdditionalProperties[nameof(OpenAI.Chat.ChatCompletion.SystemFingerprint)]);
@@ -565,7 +568,7 @@ public class OpenAIChatClientTests
         Assert.Equal(42, response.Usage.InputTokenCount);
         Assert.Equal(15, response.Usage.OutputTokenCount);
         Assert.Equal(57, response.Usage.TotalTokenCount);
-        Assert.NotNull(response.Usage.AdditionalProperties);
+        Assert.NotNull(response.Usage.AdditionalValues);
 
         Assert.NotNull(response.AdditionalProperties);
         Assert.Equal("fp_f85bea6784", response.AdditionalProperties[nameof(OpenAI.Chat.ChatCompletion.SystemFingerprint)]);
@@ -782,8 +785,11 @@ public class OpenAIChatClientTests
         Assert.Equal(61, usage.Details.InputTokenCount);
         Assert.Equal(16, usage.Details.OutputTokenCount);
         Assert.Equal(77, usage.Details.TotalTokenCount);
-        Assert.NotNull(usage.Details.AdditionalProperties);
-        Assert.Equal(new Dictionary<string, object> { [nameof(ChatOutputTokenUsageDetails.ReasoningTokenCount)] = 0 }, usage.Details.AdditionalProperties[nameof(ChatTokenUsage.OutputTokenDetails)]);
+
+        var additionalUsageValues = usage.Details.AdditionalValues;
+        Assert.NotNull(additionalUsageValues);
+        Assert.Equal(1, additionalUsageValues.Count);
+        Assert.Equal(0, additionalUsageValues[$"{nameof(ChatTokenUsage.OutputTokenDetails)}.{nameof(ChatOutputTokenUsageDetails.ReasoningTokenCount)}"]);
     }
 
     [Fact]
@@ -916,7 +922,7 @@ public class OpenAIChatClientTests
         Assert.Equal(42, response.Usage.InputTokenCount);
         Assert.Equal(15, response.Usage.OutputTokenCount);
         Assert.Equal(57, response.Usage.TotalTokenCount);
-        Assert.NotNull(response.Usage.AdditionalProperties);
+        Assert.NotNull(response.Usage.AdditionalValues);
 
         Assert.NotNull(response.AdditionalProperties);
         Assert.Equal("fp_f85bea6784", response.AdditionalProperties[nameof(OpenAI.Chat.ChatCompletion.SystemFingerprint)]);

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/DistributedCachingChatClientTest.cs
@@ -61,6 +61,14 @@ public class DistributedCachingChatClientTest
                 InputTokenCount = 123,
                 OutputTokenCount = 456,
                 TotalTokenCount = 99999,
+                AdditionalValues = new()
+                {
+                    { "intVal", 1 },
+                    { "longVal", 2L },
+                    { "floatVal", 3.4f },
+                    { "doubleVal", 5.6 },
+                    { "decimalVal", 6.7m },
+                }
             },
             CreatedAt = DateTimeOffset.UtcNow,
             ModelId = "someModel",
@@ -732,6 +740,7 @@ public class DistributedCachingChatClientTest
         Assert.Equal(expected.Usage?.InputTokenCount, actual.Usage?.InputTokenCount);
         Assert.Equal(expected.Usage?.OutputTokenCount, actual.Usage?.OutputTokenCount);
         Assert.Equal(expected.Usage?.TotalTokenCount, actual.Usage?.TotalTokenCount);
+        AssertUsageValuesEqual(expected.Usage?.AdditionalValues, actual.Usage?.AdditionalValues);
         Assert.Equal(expected.CreatedAt, actual.CreatedAt);
         Assert.Equal(expected.ModelId, actual.ModelId);
         Assert.Equal(
@@ -764,6 +773,19 @@ public class DistributedCachingChatClientTest
                         JsonSerializer.Serialize(expectedFcc.Arguments, TestJsonSerializerContext.Default.Options),
                         JsonSerializer.Serialize(actualFcc.Arguments, TestJsonSerializerContext.Default.Options));
                 }
+            }
+        }
+    }
+
+    private static void AssertUsageValuesEqual(AdditionalUsageValues? a, AdditionalUsageValues? b)
+    {
+        Assert.Equal(a is null, b is null);
+        if (a is not null)
+        {
+            Assert.Equal(a.Count, b!.Count);
+            foreach (var key in a.Keys)
+            {
+                Assert.Equal(a[key], b[key]);
             }
         }
     }

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -508,7 +508,6 @@ public class FunctionInvokingChatClientTests
         using CancellationTokenSource cts = new();
         List<ChatMessage> chat = [plan[0]];
         var expectedTotalTokenCounts = 0;
-        var rng = new Random();
 
         using var innerClient = new TestChatClient
         {


### PR DESCRIPTION
This generally works out fine, though I wonder if I just went too far with `AdditionalUsageValues`. It could just be an `IDictionary<string, object?>` or an `AdditionalPropertiesDictionary`, with the convention that we will sum supported numeric values and discard unknown value types. That would have eliminated most of the code from this PR.

However:

 * This wouldn't stop people from storing non-numeric values `AdditionalUsageValues`, which would then get lost. Or we'd need to implement `IDictionary<...>` and block the writes based on `value.GetType()`.
 * Every read or write would be boxing. Middleware might do that many times during the course of a single `CompleteAsync`.

So I implemented a custom collection that can only hold designated numeric types does so without boxing. It is quite laborious, though not super complicated. This in turn requires custom JSON serialization since we can't expect people providing a custom JSO to attach any nonobvious or private types to their source generator.

I discounted use of `INumber<T>` or `IAdditionOperators<T>` since they aren't available on netstandard2.0. Limiting to a fixed set of types (int/long/float/double/decimal) is highly likely to suffice.