### PR TITLE
Fix handling of text-only user messages in AzureAIInferenceChatClient

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs
@@ -451,7 +451,7 @@ public sealed class AzureAIInferenceChatClient : IChatClient
             {
                 // TODO: ChatRequestAssistantMessage only enables text content currently.
                 // Update it with other content types when it supports that.
-                ChatRequestAssistantMessage message = new(input.Text ?? string.Empty);
+                ChatRequestAssistantMessage message = new(string.Concat(input.Contents.Where(c => c is TextContent)));
 
                 foreach (var content in input.Contents)
                 {

--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/Microsoft.Extensions.AI.AzureAIInference.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/Microsoft.Extensions.AI.AzureAIInference.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <Stage>preview</Stage>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <MinCodeCoverage>77</MinCodeCoverage>
+    <MinCodeCoverage>83</MinCodeCoverage>
     <MinMutationScore>0</MinMutationScore>
   </PropertyGroup>
 

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
@@ -16,6 +16,8 @@ using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 #pragma warning disable S103 // Lines should not be too long
+#pragma warning disable S3358 // Ternary operators should not be nested
+#pragma warning disable SA1204 // Static elements should appear before instance elements
 
 namespace Microsoft.Extensions.AI;
 
@@ -88,9 +90,14 @@ public class AzureAIInferenceChatClientTests
         Assert.NotNull(pipeline.GetService<DistributedCachingChatClient>());
         Assert.NotNull(pipeline.GetService<CachingChatClient>());
         Assert.NotNull(pipeline.GetService<OpenTelemetryChatClient>());
+        Assert.NotNull(pipeline.GetService<object>());
 
         Assert.Same(client, pipeline.GetService<ChatCompletionsClient>());
         Assert.IsType<FunctionInvokingChatClient>(pipeline.GetService<IChatClient>());
+
+        Assert.Null(pipeline.GetService<ChatCompletionsClient>("key"));
+        Assert.Null(pipeline.GetService<AzureAIInferenceChatClient>("key"));
+        Assert.Null(pipeline.GetService<string>("key"));
     }
 
     [Theory]
@@ -236,6 +243,184 @@ public class AzureAIInferenceChatClientTests
     }
 
     [Fact]
+    public async Task AdditionalOptions_NonStreaming()
+    {
+        const string Input = """
+            {
+                "messages":[{"content":"hello","role":"user"}],
+                "max_tokens":10,
+                "temperature":0.5,
+                "top_p":0.5,
+                "stop":["yes","no"],
+                "presence_penalty":0.5,
+                "frequency_penalty":0.75,
+                "seed":42,
+                "model":"gpt-4o-mini",
+                "top_k":40,
+                "something_else":"value1",
+                "and_something_further":123
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "chatcmpl-ADx3PvAnCwJg0woha4pYsBTi3ZpOI",
+              "object": "chat.completion",
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I assist you today?"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
+
+        Assert.NotNull(await client.CompleteAsync("hello", new()
+        {
+            MaxOutputTokens = 10,
+            Temperature = 0.5f,
+            TopP = 0.5f,
+            TopK = 40,
+            FrequencyPenalty = 0.75f,
+            PresencePenalty = 0.5f,
+            Seed = 42,
+            StopSequences = ["yes", "no"],
+            AdditionalProperties = new()
+            {
+                ["something_else"] = "value1",
+                ["and_something_further"] = 123,
+            },
+        }));
+    }
+
+    [Fact]
+    public async Task ResponseFormat_Text_NonStreaming()
+    {
+        const string Input = """
+            {
+                "messages":[{"content":"hello","role":"user"}],
+                "model":"gpt-4o-mini",
+                "response_format":{"type":"text"}
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "chatcmpl-ADx3PvAnCwJg0woha4pYsBTi3ZpOI",
+              "object": "chat.completion",
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I assist you today?"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
+
+        Assert.NotNull(await client.CompleteAsync("hello", new()
+        {
+            ResponseFormat = ChatResponseFormat.Text,
+        }));
+    }
+
+    [Fact]
+    public async Task ResponseFormat_Json_NonStreaming()
+    {
+        const string Input = """
+            {
+                "messages":[{"content":"hello","role":"user"}],
+                "model":"gpt-4o-mini",
+                "response_format":{"type":"json_object"}
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "chatcmpl-ADx3PvAnCwJg0woha4pYsBTi3ZpOI",
+              "object": "chat.completion",
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I assist you today?"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
+
+        Assert.NotNull(await client.CompleteAsync("hello", new()
+        {
+            ResponseFormat = ChatResponseFormat.Json,
+        }));
+    }
+
+    [Fact]
+    public async Task ResponseFormat_JsonSchema_NonStreaming()
+    {
+        // NOTE: Azure.AI.Inference doesn't yet expose JSON schema support, so it's currently
+        // mapped to "json_object" for the time being.
+
+        const string Input = """
+            {
+                "messages":[{"content":"hello","role":"user"}],
+                "model":"gpt-4o-mini",
+                "response_format":{"type":"json_object"}
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "chatcmpl-ADx3PvAnCwJg0woha4pYsBTi3ZpOI",
+              "object": "chat.completion",
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I assist you today?"
+                  }
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
+
+        Assert.NotNull(await client.CompleteAsync("hello", new()
+        {
+            ResponseFormat = ChatResponseFormat.ForJsonSchema("""
+                {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["description"]
+                }
+                """, "DescribedObject", "An object with a description"),
+        }));
+    }
+
+    [Fact]
     public async Task MultipleMessages_NonStreaming()
     {
         const string Input = """
@@ -256,6 +441,16 @@ public class AzureAIInferenceChatClientTests
                     {
                         "content": "i\u0027m good. how are you?",
                         "role": "user"
+                    },
+                    {
+                        "content": "",
+                        "tool_calls": [{"id":"abcd123","type":"function","function":{"name":"GetMood","arguments":"null"}}],
+                        "role": "assistant"
+                    },
+                    {
+                        "content": "happy",
+                        "tool_call_id": "abcd123",
+                        "role": "tool"
                     }
                 ],
                 "temperature": 0.25,
@@ -312,6 +507,8 @@ public class AzureAIInferenceChatClientTests
             new(ChatRole.User, "hello!"),
             new(ChatRole.Assistant, "hi, how are you?"),
             new(ChatRole.User, "i'm good. how are you?"),
+            new(ChatRole.Assistant, [new FunctionCallContent("abcd123", "GetMood")]),
+            new(ChatRole.Tool, [new FunctionResultContent("abcd123", "GetMood", "happy")]),
         ];
 
         var response = await client.CompleteAsync(messages, new()
@@ -336,6 +533,61 @@ public class AzureAIInferenceChatClientTests
         Assert.Equal(42, response.Usage.InputTokenCount);
         Assert.Equal(15, response.Usage.OutputTokenCount);
         Assert.Equal(57, response.Usage.TotalTokenCount);
+    }
+
+    [Fact]
+    public async Task MultipleContent_NonStreaming()
+    {
+        const string Input = """
+            {
+                "messages":
+                [
+                    {
+                        "content":
+                        [
+                            {
+                                "text": "Describe this picture.",
+                                "type": "text"
+                            },
+                            {
+                                "image_url":
+                                {
+                                    "url": "http://dot.net/someimage.png"
+                                },
+                                "type": "image_url"
+                            }
+                        ],
+                        "role":"user"
+                    }
+                ],
+                "model": "gpt-4o-mini"
+            }
+            """;
+
+        const string Output = """
+            {
+              "id": "chatcmpl-ADyV17bXeSm5rzUx3n46O7m3M0o3P",
+              "object": "chat.completion",
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "A picture of a dog."
+                  }
+                }
+              ]
+            }
+            """;
+
+        using VerbatimHttpHandler handler = new(Input, Output);
+        using HttpClient httpClient = new(handler);
+        using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
+
+        Assert.NotNull(await client.CompleteAsync([new(ChatRole.User,
+        [
+            new TextContent("Describe this picture."),
+            new ImageContent("http://dot.net/someimage.png"),
+        ])]));
     }
 
     [Fact]
@@ -417,10 +669,18 @@ public class AzureAIInferenceChatClientTests
         Assert.Equal(57, response.Usage.TotalTokenCount);
     }
 
-    [Fact]
-    public async Task FunctionCallContent_NonStreaming()
+    public static IEnumerable<object[]> FunctionCallContent_NonStreaming_MemberData()
     {
-        const string Input = """
+        yield return [ChatToolMode.Auto];
+        yield return [ChatToolMode.RequireAny];
+        yield return [ChatToolMode.RequireSpecific("GetPersonAge")];
+    }
+
+    [Theory]
+    [MemberData(nameof(FunctionCallContent_NonStreaming_MemberData))]
+    public async Task FunctionCallContent_NonStreaming(ChatToolMode mode)
+    {
+        string input = $$"""
             {
                 "messages": [
                     {
@@ -448,7 +708,11 @@ public class AzureAIInferenceChatClientTests
                         }
                     }
                 ],
-                "tool_choice": "auto"
+                "tool_choice": {{(
+                    mode is AutoChatToolMode ? "\"auto\"" :
+                    mode is RequiredChatToolMode { RequiredFunctionName: not null } f ? "{\"type\":\"function\",\"function\":{\"name\":\"GetPersonAge\"}}" :
+                    "\"required\""
+                    )}}
             }
             """;
 
@@ -495,13 +759,14 @@ public class AzureAIInferenceChatClientTests
             }
             """;
 
-        using VerbatimHttpHandler handler = new(Input, Output);
+        using VerbatimHttpHandler handler = new(input, Output);
         using HttpClient httpClient = new(handler);
         using IChatClient client = CreateChatClient(httpClient, "gpt-4o-mini");
 
         var response = await client.CompleteAsync("How old is Alice?", new()
         {
             Tools = [AIFunctionFactory.Create(([Description("The person whose age is being requested")] string personName) => 42, "GetPersonAge", "Gets the age of the specified person.")],
+            ToolMode = mode,
         });
         Assert.NotNull(response);
 


### PR DESCRIPTION
`ChatRequestUserMessage` has three constructors:
```csharp
public ChatRequestUserMessage(string content)
public ChatRequestUserMessage(IEnumerable<ChatMessageContentItem> content)
public ChatRequestUserMessage(params ChatMessageContentItem[] content)
```
but even though all of the parameters are named `content` and represent the message's content, they behave differently. The first assigns the string content to the instance's `Content` property and leaves its `MultimodalContentItems` property null, and the others leave `Content` null and set `MultimodalContentItems` to the property. For models that don't support multi-modal, using the latter two constructors breaks, even when the content is a single text item.

I think this should be improved in Azure.AI.Inference, but regardless, this fixes the ToAzureAIInferenceChatMessages helper to special-case text-only inputs and use the first `string`-based constructor rather than always using the `IEnumerable<ChatMessageContentItem>`-based one.

Fixes https://github.com/dotnet/extensions/issues/5708
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5714)