### PR TITLE
Fix streaming function calling

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs
@@ -325,7 +325,7 @@ public partial class FunctionInvokingChatClient : DelegatingChatClient
                     // If there were any, remove them from the update. We do this before yielding the update so
                     // that we're not modifying an instance already provided back to the caller.
                     int addedFccs = functionCallContents.Count - preFccCount;
-                    if (addedFccs > preFccCount)
+                    if (addedFccs > 0)
                     {
                         update.Contents = addedFccs == update.Contents.Count ?
                             [] : update.Contents.Where(c => c is not FunctionCallContent).ToList();

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/FunctionInvokingChatClientTests.cs
@@ -495,7 +495,7 @@ public class FunctionInvokingChatClientTests
     }
 
     [Fact]
-    public async Task SupportsMultipleCallsInSameStreamingUpdate()
+    public async Task SupportsConsecutiveStreamingUpdatesWithFunctionCalls()
     {
         var options = new ChatOptions
         {
@@ -511,7 +511,7 @@ public class FunctionInvokingChatClientTests
         {
             CompleteStreamingAsyncCallback = (chatContents, chatOptions, cancellationToken) =>
             {
-                // If the conversation is just starting, issue two calls in a single streaming update
+                // If the conversation is just starting, issue two consecutive updates with function calls
                 // Otherwise just end the conversation
                 return chatContents.Last().Text == "Hello"
                     ? YieldAsync(


### PR DESCRIPTION
There was part of the `FunctionInvokingChatClient` implementation that I couldn't understand, and after investigation, I think it's a bug.

Our tests don't cover any cases where streaming returns multiple updates that contain function calls. I *think* that's a legitimate scenario, but I'm not sure that it can be modelled by the `InvokeAndAssertStreamingAsync` helper we use in those tests, because it treats each "plan" entry as the end of a response.

I've added a test showing what I think is this legitimate response format with multiple updates that have function calls. Without the fix in `FunctionInvokingChatClient`, it only removes one of the two FCCs from the result (and so the other one is both added to history *and* returned, which the method's XML docs say should not happen). The fix is completely trivial.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5718)