### PR TITLE
Ollama support for streaming function calling and native structured output

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseFormat.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseFormat.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
 
@@ -33,8 +32,8 @@ public class ChatResponseFormat
     /// <param name="schemaDescription">An optional description of the schema.</param>
     /// <returns>The <see cref="ChatResponseFormatJson"/> instance.</returns>
     public static ChatResponseFormatJson ForJsonSchema(
-        [StringSyntax(StringSyntaxAttribute.Json)] string schema, string? schemaName = null, string? schemaDescription = null) =>
-        new(Throw.IfNull(schema),
+        JsonElement schema, string? schemaName = null, string? schemaDescription = null) =>
+        new(schema,
             schemaName,
             schemaDescription);
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseFormatJson.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/ChatCompletion/ChatResponseFormatJson.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Shared.Diagnostics;
 
@@ -19,7 +18,7 @@ public sealed class ChatResponseFormatJson : ChatResponseFormat
     /// <param name="schemaDescription">A description of the schema.</param>
     [JsonConstructor]
     public ChatResponseFormatJson(
-        [StringSyntax(StringSyntaxAttribute.Json)] string? schema, string? schemaName = null, string? schemaDescription = null)
+        JsonElement? schema, string? schemaName = null, string? schemaDescription = null)
     {
         if (schema is null && (schemaName is not null || schemaDescription is not null))
         {
@@ -34,7 +33,7 @@ public sealed class ChatResponseFormatJson : ChatResponseFormat
     }
 
     /// <summary>Gets the JSON schema associated with the response, or null if there is none.</summary>
-    public string? Schema { get; }
+    public JsonElement? Schema { get; }
 
     /// <summary>Gets a name for the schema.</summary>
     public string? SchemaName { get; }
@@ -42,19 +41,7 @@ public sealed class ChatResponseFormatJson : ChatResponseFormat
     /// <summary>Gets a description of the schema.</summary>
     public string? SchemaDescription { get; }
 
-    /// <inheritdoc/>
-    public override bool Equals(object? obj) =>
-        obj is ChatResponseFormatJson other &&
-        Schema == other.Schema &&
-        SchemaName == other.SchemaName &&
-        SchemaDescription == other.SchemaDescription;
-
-    /// <inheritdoc/>
-    public override int GetHashCode() =>
-        Schema?.GetHashCode(StringComparison.Ordinal) ??
-        typeof(ChatResponseFormatJson).GetHashCode();
-
     /// <summary>Gets a string representing this instance to display in the debugger.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => Schema ?? "JSON";
+    private string DebuggerDisplay => Schema?.ToString() ?? "JSON";
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.csproj
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Microsoft.Extensions.AI.Abstractions.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <Stage>preview</Stage>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <MinCodeCoverage>84</MinCodeCoverage>
+    <MinCodeCoverage>83</MinCodeCoverage>
     <MinMutationScore>0</MinMutationScore>
   </PropertyGroup>
 

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.AI;
 public sealed class OllamaChatClient : IChatClient
 {
     private static readonly JsonElement _defaultParameterSchema = JsonDocument.Parse("{}").RootElement;
-    private static readonly JsonElement _defaultJsonSchema = JsonDocument.Parse("\"json\"").RootElement;
+    private static readonly JsonElement _schemalessJsonResponseFormatValue = JsonDocument.Parse("\"json\"").RootElement;
 
     /// <summary>The api/chat endpoint URI.</summary>
     private readonly Uri _apiChatEndpoint;
@@ -263,7 +263,7 @@ public sealed class OllamaChatClient : IChatClient
     {
         if (format is ChatResponseFormatJson jsonFormat)
         {
-            return jsonFormat.Schema ?? _defaultJsonSchema;
+            return jsonFormat.Schema ?? _schemalessJsonResponseFormatValue;
         }
         else
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -263,14 +263,7 @@ public sealed class OllamaChatClient : IChatClient
     {
         if (format is ChatResponseFormatJson jsonFormat)
         {
-            if (!string.IsNullOrEmpty(jsonFormat.Schema))
-            {
-                return JsonDocument.Parse(jsonFormat.Schema!).RootElement;
-            }
-            else
-            {
-                return _defaultJsonSchema;
-            }
+            return jsonFormat.Schema ?? _defaultJsonSchema;
         }
         else
         {

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -255,7 +255,11 @@ public sealed class OllamaChatClient : IChatClient
 
     private static FunctionCallContent ToFunctionCallContent(OllamaFunctionToolCall function)
     {
+#if NET
+        var id = System.Security.Cryptography.RandomNumberGenerator.GetHexString(8);
+#else
         var id = Guid.NewGuid().ToString().Substring(0, 8);
+#endif
         return new FunctionCallContent(id, function.Name, function.Arguments);
     }
 

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatRequest.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatRequest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace Microsoft.Extensions.AI;
 
@@ -9,7 +10,7 @@ internal sealed class OllamaChatRequest
 {
     public required string Model { get; set; }
     public required OllamaChatRequestMessage[] Messages { get; set; }
-    public string? Format { get; set; }
+    public JsonElement? Format { get; set; }
     public bool Stream { get; set; }
     public IEnumerable<OllamaTool>? Tools { get; set; }
     public OllamaRequestOptions? Options { get; set; }

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatResponseFormat.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatResponseFormat.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+internal sealed class OllamaChatResponseFormat
+{
+    public required string Type { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatResponseFormat.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatResponseFormat.cs
@@ -1,9 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Microsoft.Extensions.AI;
-
-internal sealed class OllamaChatResponseFormat
-{
-    public required string Type { get; set; }
-}

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs
@@ -500,8 +500,12 @@ public sealed class OpenAIChatClient : IChatClient
             }
             else if (options.ResponseFormat is ChatResponseFormatJson jsonFormat)
             {
-                result.ResponseFormat = jsonFormat.Schema is string jsonSchema ?
-                    OpenAI.Chat.ChatResponseFormat.CreateJsonSchemaFormat(jsonFormat.SchemaName ?? "json_schema", BinaryData.FromString(jsonSchema), jsonFormat.SchemaDescription) :
+                result.ResponseFormat = jsonFormat.Schema is { } jsonSchema ?
+                    OpenAI.Chat.ChatResponseFormat.CreateJsonSchemaFormat(
+                        jsonFormat.SchemaName ?? "json_schema",
+                        BinaryData.FromBytes(
+                            JsonSerializer.SerializeToUtf8Bytes(jsonSchema, OpenAIJsonContext.Default.JsonElement)),
+                        jsonFormat.SchemaDescription) :
                     OpenAI.Chat.ChatResponseFormat.CreateJsonObjectFormat();
             }
         }

--- a/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/ChatClientStructuredOutputExtensions.cs
@@ -128,12 +128,12 @@ public static class ChatClientStructuredOutputExtensions
             inferenceOptions: _inferenceOptions);
 
         bool isWrappedInObject;
-        string schema;
+        JsonElement schema;
         if (SchemaRepresentsObject(schemaElement))
         {
             // For object-representing schemas, we can use them as-is
             isWrappedInObject = false;
-            schema = JsonSerializer.Serialize(schemaElement, AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonElement)));
+            schema = schemaElement;
         }
         else
         {
@@ -141,7 +141,7 @@ public static class ChatClientStructuredOutputExtensions
             // the real LLM providers today require an object schema as the root. This is currently
             // true even for providers that support native structured output.
             isWrappedInObject = true;
-            schema = JsonSerializer.Serialize(new JsonObject
+            schema = JsonSerializer.SerializeToElement(new JsonObject
             {
                 { "$schema", "https://json-schema.org/draft/2020-12/schema" },
                 { "type", "object" },

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatOptionsTests.cs
@@ -155,8 +155,7 @@ public class ChatOptionsTests
         Assert.Equal(0.4f, deserialized.FrequencyPenalty);
         Assert.Equal(0.5f, deserialized.PresencePenalty);
         Assert.Equal(12345, deserialized.Seed);
-        Assert.Equal(ChatResponseFormat.Json, deserialized.ResponseFormat);
-        Assert.NotSame(ChatResponseFormat.Json, deserialized.ResponseFormat);
+        Assert.IsType<ChatResponseFormatJson>(deserialized.ResponseFormat);
         Assert.Equal("modelId", deserialized.ModelId);
         Assert.NotSame(stopSequences, deserialized.StopSequences);
         Assert.Equal(stopSequences, deserialized.StopSequences);

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseFormatTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/ChatCompletion/ChatResponseFormatTests.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Extensions.AI;
 
 public class ChatResponseFormatTests
 {
+    private static JsonElement EmptySchema => JsonDocument.Parse("{}").RootElement;
+
     [Fact]
     public void Singletons_Idempotent()
     {
@@ -36,45 +38,10 @@ public class ChatResponseFormatTests
     [Fact]
     public void Constructor_PropsRoundtrip()
     {
-        ChatResponseFormatJson f = new("{}", "name", "description");
-        Assert.Equal("{}", f.Schema);
+        ChatResponseFormatJson f = new(EmptySchema, "name", "description");
+        Assert.Equal("{}", JsonSerializer.Serialize(f.Schema, TestJsonSerializerContext.Default.JsonElement));
         Assert.Equal("name", f.SchemaName);
         Assert.Equal("description", f.SchemaDescription);
-    }
-
-    [Fact]
-    public void Equality_ComparersProduceExpectedResults()
-    {
-        Assert.True(ChatResponseFormat.Text == ChatResponseFormat.Text);
-        Assert.True(ChatResponseFormat.Text.Equals(ChatResponseFormat.Text));
-        Assert.Equal(ChatResponseFormat.Text.GetHashCode(), ChatResponseFormat.Text.GetHashCode());
-        Assert.False(ChatResponseFormat.Text.Equals(ChatResponseFormat.Json));
-        Assert.False(ChatResponseFormat.Text.Equals(new ChatResponseFormatJson(null)));
-        Assert.False(ChatResponseFormat.Text.Equals(new ChatResponseFormatJson("{}")));
-
-        Assert.True(ChatResponseFormat.Json == ChatResponseFormat.Json);
-        Assert.True(ChatResponseFormat.Json.Equals(ChatResponseFormat.Json));
-        Assert.False(ChatResponseFormat.Json.Equals(ChatResponseFormat.Text));
-        Assert.False(ChatResponseFormat.Json.Equals(new ChatResponseFormatJson("{}")));
-
-        Assert.True(ChatResponseFormat.Json.Equals(new ChatResponseFormatJson(null)));
-        Assert.Equal(ChatResponseFormat.Json.GetHashCode(), new ChatResponseFormatJson(null).GetHashCode());
-
-        Assert.True(new ChatResponseFormatJson("{}").Equals(new ChatResponseFormatJson("{}")));
-        Assert.Equal(new ChatResponseFormatJson("{}").GetHashCode(), new ChatResponseFormatJson("{}").GetHashCode());
-
-        Assert.False(new ChatResponseFormatJson("""{ "prop": 42 }""").Equals(new ChatResponseFormatJson("""{ "prop": 43 }""")));
-        Assert.NotEqual(new ChatResponseFormatJson("""{ "prop": 42 }""").GetHashCode(), new ChatResponseFormatJson("""{ "prop": 43 }""").GetHashCode()); // technically not guaranteed
-
-        Assert.False(new ChatResponseFormatJson("""{ "prop": 42 }""").Equals(new ChatResponseFormatJson("""{ "PROP": 42 }""")));
-        Assert.NotEqual(new ChatResponseFormatJson("""{ "prop": 42 }""").GetHashCode(), new ChatResponseFormatJson("""{ "PROP": 42 }""").GetHashCode()); // technically not guaranteed
-
-        Assert.True(new ChatResponseFormatJson("{}", "name", "description").Equals(new ChatResponseFormatJson("{}", "name", "description")));
-        Assert.False(new ChatResponseFormatJson("{}", "name", "description").Equals(new ChatResponseFormatJson("{}", "name", "description2")));
-        Assert.False(new ChatResponseFormatJson("{}", "name", "description").Equals(new ChatResponseFormatJson("{}", "name2", "description")));
-        Assert.False(new ChatResponseFormatJson("{}", "name", "description").Equals(new ChatResponseFormatJson("{}", "name2", "description2")));
-
-        Assert.Equal(new ChatResponseFormatJson("{}", "name", "description").GetHashCode(), new ChatResponseFormatJson("{}", "name", "description").GetHashCode());
     }
 
     [Fact]
@@ -94,19 +61,24 @@ public class ChatResponseFormatTests
         Assert.Equal("""{"$type":"json"}""", json);
 
         ChatResponseFormat? result = JsonSerializer.Deserialize(json, TestJsonSerializerContext.Default.ChatResponseFormat);
-        Assert.Equal(ChatResponseFormat.Json, result);
+        var actual = Assert.IsType<ChatResponseFormatJson>(result);
+        Assert.Null(actual.Schema);
+        Assert.Null(actual.SchemaDescription);
+        Assert.Null(actual.SchemaName);
     }
 
     [Fact]
     public void Serialization_ForJsonSchemaRoundtrips()
     {
-        string json = JsonSerializer.Serialize(ChatResponseFormat.ForJsonSchema("[1,2,3]", "name", "description"), TestJsonSerializerContext.Default.ChatResponseFormat);
-        Assert.Equal("""{"$type":"json","schema":"[1,2,3]","schemaName":"name","schemaDescription":"description"}""", json);
+        string json = JsonSerializer.Serialize(
+            ChatResponseFormat.ForJsonSchema(JsonSerializer.Deserialize<JsonElement>("[1,2,3]"), "name", "description"),
+            TestJsonSerializerContext.Default.ChatResponseFormat);
+        Assert.Equal("""{"$type":"json","schema":[1,2,3],"schemaName":"name","schemaDescription":"description"}""", json);
 
         ChatResponseFormat? result = JsonSerializer.Deserialize(json, TestJsonSerializerContext.Default.ChatResponseFormat);
-        Assert.Equal(ChatResponseFormat.ForJsonSchema("[1,2,3]", "name", "description"), result);
-        Assert.Equal("[1,2,3]", (result as ChatResponseFormatJson)?.Schema);
-        Assert.Equal("name", (result as ChatResponseFormatJson)?.SchemaName);
-        Assert.Equal("description", (result as ChatResponseFormatJson)?.SchemaDescription);
+        var actual = Assert.IsType<ChatResponseFormatJson>(result);
+        Assert.Equal("[1,2,3]", JsonSerializer.Serialize(actual.Schema, TestJsonSerializerContext.Default.JsonElement));
+        Assert.Equal("name", actual.SchemaName);
+        Assert.Equal("description", actual.SchemaDescription);
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.AzureAIInference.Tests/AzureAIInferenceChatClientTests.cs
@@ -406,7 +406,7 @@ public class AzureAIInferenceChatClientTests
 
         Assert.NotNull(await client.CompleteAsync("hello", new()
         {
-            ResponseFormat = ChatResponseFormat.ForJsonSchema("""
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(JsonSerializer.Deserialize<JsonElement>("""
                 {
                   "type": "object",
                   "properties": {
@@ -416,7 +416,7 @@ public class AzureAIInferenceChatClientTests
                   },
                   "required": ["description"]
                 }
-                """, "DescribedObject", "An object with a description"),
+                """), "DescribedObject", "An object with a description"),
         }));
     }
 

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientIntegrationTests.cs
@@ -18,12 +18,6 @@ public class OllamaChatClientIntegrationTests : ChatClientIntegrationTests
             new OllamaChatClient(endpoint, "llama3.1") :
             null;
 
-    public override Task FunctionInvocation_AutomaticallyInvokeFunction_WithParameters_Streaming() =>
-        throw new SkipTestException("Ollama does not currently support function invocation with streaming.");
-
-    public override Task Logging_LogsFunctionCalls_Streaming() =>
-        throw new SkipTestException("Ollama does not currently support function invocation with streaming.");
-
     public override Task FunctionInvocation_RequireAny() =>
         throw new SkipTestException("Ollama does not currently support requiring function invocation.");
 

--- a/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Tests/ChatCompletion/ChatClientStructuredOutputExtensionsTests.cs
@@ -177,10 +177,12 @@ public class ChatClientStructuredOutputExtensionsTests
                 var responseFormat = Assert.IsType<ChatResponseFormatJson>(options!.ResponseFormat);
                 Assert.Equal(nameof(Animal), responseFormat.SchemaName);
                 Assert.Equal("Some test description", responseFormat.SchemaDescription);
-                Assert.Contains("https://json-schema.org/draft/2020-12/schema", responseFormat.Schema);
+
+                var responseFormatJsonSchema = JsonSerializer.Serialize(responseFormat.Schema, TestJsonSerializerContext.Default.JsonElement);
+                Assert.Contains("https://json-schema.org/draft/2020-12/schema", responseFormatJsonSchema);
                 foreach (Species v in Enum.GetValues(typeof(Species)))
                 {
-                    Assert.Contains(v.ToString(), responseFormat.Schema); // All enum values are described as strings
+                    Assert.Contains(v.ToString(), responseFormatJsonSchema); // All enum values are described as strings
                 }
 
                 // The chat history isn't mutated any further, since native structured output is used instead of a prompt


### PR DESCRIPTION
Fixes #5726 by adding support for native structured output added in [Ollama 0.5.0](https://github.com/ollama/ollama/releases/tag/v0.5.0).

Also adds support for streaming function calling added in [Ollama 0.4.6](https://github.com/ollama/ollama/releases/tag/v0.4.6).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5730)