### PR TITLE
Improve reliability of CompleteAsync_StructuredOutputEnum test

### DIFF
--- a/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Integration.Tests/ChatClientIntegrationTests.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -720,11 +719,11 @@ public abstract class ChatClientIntegrationTests : IDisposable
     {
         SkipIfNotEnabled();
 
-        var response = await _chatClient.CompleteAsync<Architecture>("""
-            I'm using a Macbook Pro with an M2 chip. What architecture am I using?
+        var response = await _chatClient.CompleteAsync<JobType>("""
+            Taylor Swift is a famous singer and songwriter. What is her job?
             """);
 
-        Assert.Equal(Architecture.Arm64, response.Result);
+        Assert.Equal(JobType.PopStar, response.Result);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes #5570

Minor tweak to the test case to make it less ambiguous. With this phrasing I've never seen it fail on `llama3.1`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5731)