### PR TITLE
HybridCache (tests only): add explicit System.Runtime.Caching dependency (CVE-related)

### DIFF
--- a/eng/packages/General.props
+++ b/eng/packages/General.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />

--- a/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/Microsoft.Extensions.Caching.Hybrid.Tests.csproj
+++ b/test/Libraries/Microsoft.Extensions.Caching.Hybrid.Tests/Microsoft.Extensions.Caching.Hybrid.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="System.Runtime.Caching" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The HybridCache test suite has a transitive dependency on `System.Runtime.Caching`, which is [flagging as CVE](https://github.com/dotnet/announcements/issues/327), although there may also be some confusion here as to whether this is meant to be `Microsoft.Extensions.Caching.Memory`, and so I *suspect* this is actually a false positive. To make the CI happy, I have added an explicit package-ref to `System.Runtime.Caching`, which via the pre-existing `$SystemRuntimeCachingVersion` pushes it to 9.0, which is fine. The `Microsoft.Extensions.Caching.Memory` in the project is also already 9.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5755)