### PR TITLE
Fix hashing in Logging source gen

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -155,7 +155,8 @@ internal sealed partial class Emitter : EmitterBase
                 result = (c ^ result) * Mult;
             }
 
-            return Math.Abs((int)result);
+            const uint NegativeMask = 0x7FFFFFFF;
+            return (int)(result & NegativeMask); // Ensure the result is non-negative
         }
 
         static bool ShouldStringifyParameter(LoggingMethodParameter p)
@@ -174,7 +175,7 @@ internal sealed partial class Emitter : EmitterBase
 
             if (!p.Type.Contains("."))
             {
-                // no . means this is a primitive type, pass as-is 
+                // no . means this is a primitive type, pass as-is
                 return false;
             }
 
@@ -198,7 +199,7 @@ internal sealed partial class Emitter : EmitterBase
 
             if (!p.Type.Contains("."))
             {
-                // no . means this is a primitive type, pass as-is 
+                // no . means this is a primitive type, pass as-is
                 return false;
             }
 


### PR DESCRIPTION
This change to avoid throwing from the hashing method which can break logging source generation.

https://github.com/dotnet/runtime/issues/110698
https://github.com/dotnet/runtime/pull/111073

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5776)