### PR TITLE
Adjust hashing in logging source gen

### DIFF
--- a/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
+++ b/src/Generators/Microsoft.Gen.Logging/Emission/Emitter.Method.cs
@@ -155,8 +155,8 @@ internal sealed partial class Emitter : EmitterBase
                 result = (c ^ result) * Mult;
             }
 
-            const uint NegativeMask = 0x7FFFFFFF;
-            return (int)(result & NegativeMask); // Ensure the result is non-negative
+            int ret = (int)result;
+            return ret == int.MinValue ? 0 : Math.Abs(ret); // Ensure the result is non-negative
         }
 
         static bool ShouldStringifyParameter(LoggingMethodParameter p)


### PR DESCRIPTION
We had the fix to avoid having the hashing throw exception when using `Math.Abs`. The fix is not done in compatible way which will make the hashing generate different values than what it used to generate. The change here is to make hashing return the same value as it used to return.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5782)