### PR TITLE
Ensure Ollama streaming updates specify a CompletionId.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Ollama/OllamaChatClient.cs
@@ -142,6 +142,7 @@ public sealed class OllamaChatClient : IChatClient
 
             StreamingChatCompletionUpdate update = new()
             {
+                CompletionId = chunk.CreatedAt,
                 Role = chunk.Message?.Role is not null ? new ChatRole(chunk.Message.Role) : null,
                 CreatedAt = DateTimeOffset.TryParse(chunk.CreatedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset createdAt) ? createdAt : null,
                 FinishReason = ToFinishReason(chunk),

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMapper.ChatCompletion.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -54,7 +55,7 @@ internal static partial class OpenAIModelMappers
         }
 
         return OpenAIChatModelFactory.ChatCompletion(
-            id: chatCompletion.CompletionId,
+            id: chatCompletion.CompletionId ?? CreateCompletionId(),
             model: chatCompletion.ModelId,
             createdAt: chatCompletion.CreatedAt ?? default,
             role: ToOpenAIChatRole(chatCompletion.Message.Role).Value,
@@ -583,6 +584,8 @@ internal static partial class OpenAIModelMappers
 
     private static T? GetValueOrDefault<T>(this AdditionalPropertiesDictionary? dict, string key) =>
         dict?.TryGetValue(key, out T? value) is true ? value : default;
+
+    private static string CreateCompletionId() => $"chatcmpl-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}";
 
     /// <summary>Used to create the JSON payload for an OpenAI chat tool description.</summary>
     public sealed class OpenAIChatToolJson

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMappers.StreamingChatCompletion.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIModelMappers.StreamingChatCompletion.cs
@@ -46,7 +46,7 @@ internal static partial class OpenAIModelMappers
             }
 
             yield return OpenAIChatModelFactory.StreamingChatCompletionUpdate(
-                completionId: chatCompletionUpdate.CompletionId,
+                completionId: chatCompletionUpdate.CompletionId ?? CreateCompletionId(),
                 model: chatCompletionUpdate.ModelId,
                 createdAt: chatCompletionUpdate.CreatedAt ?? default,
                 role: ToOpenAIChatRole(chatCompletionUpdate.Role),

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/OllamaChatClientTests.cs
@@ -185,6 +185,7 @@ public class OllamaChatClientTests
 
         for (int i = 0; i < updates.Count; i++)
         {
+            Assert.NotNull(updates[i].CompletionId);
             Assert.Equal(i < updates.Count - 1 ? 1 : 2, updates[i].Contents.Count);
             Assert.Equal(ChatRole.Assistant, updates[i].Role);
             Assert.Equal("llama3.1", updates[i].ModelId);


### PR DESCRIPTION
Discovered while working on https://github.com/eiriktsarpalis/blackbeard-extension-cs/pull/1. Non-streaming completions use the `CreatedAt` timestamp as the completion id, however this is being omitted for the case of streaming completions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5795)