### PR TITLE
API that allows to remove all resilience handlers from the HTTP client

### DIFF
--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.ExceptionSummarization;
@@ -90,7 +91,10 @@ public static partial class ResilienceHttpClientBuilderExtensions
         {
             for (int i = handlers.Count - 1; i >= 0; i--)
             {
-                handlers.RemoveAt(i);
+                if (handlers[i] is ResilienceHandler)
+                {
+                    handlers.RemoveAt(i);
+                }
             }
         });
         return builder;

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.ExceptionSummarization;

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.ExceptionSummarization;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Http.Resilience.Internal;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using Polly;
 using Polly.Registry;
@@ -80,6 +82,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder instance.</param>
     /// <returns>The value of <paramref name="builder"/>.</returns>
+    [Experimental(diagnosticId: DiagnosticIds.Experiments.Resilience, UrlFormat = DiagnosticIds.UrlFormat)]
     public static IHttpClientBuilder RemoveAllResilienceHandlers(this IHttpClientBuilder builder)
     {
         _ = Throw.IfNull(builder);

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -75,6 +75,24 @@ public static partial class ResilienceHttpClientBuilderExtensions
         return pipelineBuilder;
     }
 
+    /// <summary>
+    /// Removes all resilience handlers registered earlier.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <returns>The value of <paramref name="builder"/>.</returns>
+    public static IHttpClientBuilder RemoveAllResilienceHandlers(this IHttpClientBuilder builder)
+    {
+        _ = Throw.IfNull(builder);
+        _ = builder.ConfigureAdditionalHttpMessageHandlers(static (handlers, _) =>
+        {
+            for (int i = handlers.Count - 1; i >=0; i--)
+            {
+                handlers.RemoveAt(i);
+            }
+        });
+        return builder;
+    }
+
     private static Func<HttpRequestMessage, ResiliencePipeline<HttpResponseMessage>> CreatePipelineSelector(IServiceProvider serviceProvider, string pipelineName)
     {
         var resilienceProvider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<HttpKey>>();

--- a/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
+++ b/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/ResilienceHttpClientBuilderExtensions.Resilience.cs
@@ -88,7 +88,7 @@ public static partial class ResilienceHttpClientBuilderExtensions
         _ = Throw.IfNull(builder);
         _ = builder.ConfigureAdditionalHttpMessageHandlers(static (handlers, _) =>
         {
-            for (int i = handlers.Count - 1; i >=0; i--)
+            for (int i = handlers.Count - 1; i >= 0; i--)
             {
                 handlers.RemoveAt(i);
             }

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
@@ -336,7 +336,6 @@ public sealed partial class HttpClientBuilderExtensionsTests
         services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("custom");
     }
 
-
     private void ConfigureBuilder(ResiliencePipelineBuilder<HttpResponseMessage> builder) => builder.AddTimeout(TimeSpan.FromSeconds(1));
 
     private class TestMetricsEnricher : MeteringEnricher

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -330,6 +331,28 @@ public sealed partial class HttpClientBuilderExtensionsTests
         builder.ConfigureAdditionalHttpMessageHandlers((handlers, _) =>
         {
             Assert.Single(handlers);
+        });
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+        services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("custom");
+    }
+
+    [Fact]
+    public void RemoveAllResilienceHandlers_EnsureOnlyResilienceHandlersRemoved()
+    {
+        var services = new ServiceCollection();
+
+        IHttpClientBuilder? builder = services.AddHttpClient("custom");
+
+        builder.AddHttpMessageHandler(() => new TestHandlerStub(HttpStatusCode.OK));
+        builder.AddStandardResilienceHandler();
+
+        builder.RemoveAllResilienceHandlers();
+
+        builder.ConfigureAdditionalHttpMessageHandlers((handlers, _) =>
+        {
+            Assert.Single(handlers);
+            Assert.Equal("TestHandlerStub", handlers.First().GetType().Name);
         });
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
@@ -293,7 +293,6 @@ public sealed partial class HttpClientBuilderExtensionsTests
         var services = new ServiceCollection();
         IHttpClientBuilder? builder = null;
         Assert.Throws<ArgumentNullException>(() => builder!.RemoveAllResilienceHandlers());
-        Assert.Throws<ArgumentNullException>(() => builder!.RemoveAllResilienceHandlers());
     }
 
     [Fact]
@@ -356,7 +355,7 @@ public sealed partial class HttpClientBuilderExtensionsTests
         });
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();
-        services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("custom");
+        serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("custom");
     }
 
     private void ConfigureBuilder(ResiliencePipelineBuilder<HttpResponseMessage> builder) => builder.AddTimeout(TimeSpan.FromSeconds(1));

--- a/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
+++ b/test/Libraries/Microsoft.Extensions.Http.Resilience.Tests/Resilience/HttpClientBuilderExtensionsTests.Resilience.cs
@@ -292,8 +292,8 @@ public sealed partial class HttpClientBuilderExtensionsTests
     {
         var services = new ServiceCollection();
         IHttpClientBuilder? builder = null;
-        Assert.Throws<ArgumentNullException>(() => builder!.AddResilienceHandler("pipeline-name", _ => { }));
-        Assert.Throws<ArgumentNullException>(() => builder!.AddResilienceHandler("pipeline-name", (_, _) => { }));
+        Assert.Throws<ArgumentNullException>(() => builder!.RemoveAllResilienceHandlers());
+        Assert.Throws<ArgumentNullException>(() => builder!.RemoveAllResilienceHandlers());
     }
 
     [Fact]
@@ -318,7 +318,7 @@ public sealed partial class HttpClientBuilderExtensionsTests
         });
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();
-        services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("custom");
+        serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("custom");
     }
 
     [Fact]
@@ -334,7 +334,7 @@ public sealed partial class HttpClientBuilderExtensionsTests
         });
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();
-        services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("custom");
+        serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("custom");
     }
 
     [Fact]
@@ -352,7 +352,7 @@ public sealed partial class HttpClientBuilderExtensionsTests
         builder.ConfigureAdditionalHttpMessageHandlers((handlers, _) =>
         {
             Assert.Single(handlers);
-            Assert.Equal("TestHandlerStub", handlers.First().GetType().Name);
+            Assert.Equal(typeof(TestHandlerStub), handlers.First().GetType());
         });
 
         using ServiceProvider serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
**Background and motivation**

.NET provides the [ConfigureHttpClientDefaults](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.httpclientfactoryservicecollectionextensions.configurehttpclientdefaults?view=net-8.0) method that allows you to configure the default behavior of the HttpClient. With the help of this method you can register the [StandardResiliencePipeline](https://github.com/dotnet/extensions/tree/main/src/Libraries/Microsoft.Extensions.Http.Resilience#resilience) as part of the default configuration of the HttpClient:

`services.ConfigureHttpClientDefaults(builder => builder.AddStandardResilienceHandler());`

This is convenient, since you don't need to configure the resilience pipeline for each HttpClient. But with the API we currently provide users face a few issues/challenges when they need to change the default configuration. This change focuses on the following issue:

Removing the existing default resilience pipeline and adding a custom one

For example, a user registers the `StandardResilienceHandler` as default configuration, but at the same time he/she wants to use the `StandardHedgingHandler` for a particular named `HttpClient`:

```
services.ConfigureHttpClientDefaults(builder => builder.AddStandardResilienceHandler());

// For a named HttpClient "custom" we want to remove the StandardResilienceHandler and add instead the StandardHedgingHandler.
services.AddHttpClient("custom")./*Remove StandardResilienceHandler*/.AddStandardHedgingHandler();
```

**API description**

This API provides functionality to remove all assigned handlers from the HttpClient.

**API Usage**

```
services.ConfigureHttpClientDefaults(builder => builder.AddStandardResilienceHandler());
// For a named HttpClient "custom" we want to remove the StandardResilienceHandler and add instead the StandardHedgingHandler.
services.AddHttpClient("custom")
    .RemoveAllResilienceHandlers()
    .AddStandardHedgingHandler();
```

This PR partially resolves #5695 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5801)