### PR TITLE
Add note and sample for the case of using Azure OpenAI

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/README.md
+++ b/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/README.md
@@ -35,6 +35,13 @@ IChatClient client =
 Console.WriteLine(await client.CompleteAsync("What is AI?"));
 ```
 
+> **Note:** When connecting with Azure Open AI, the URL passed into the `ChatCompletionsClient` needs to include `openai/deployments/{yourDeployment}`. For example:
+> ```csharp
+> new Azure.AI.Inference.ChatCompletionsClient(
+>     new("https://{your-resource-name}.openai.azure.com/openai/deployments/{yourDeployment}"),
+>     new AzureKeyCredential(Environment.GetEnvironmentVariable("AZURE_OPENAI_KEY")!))
+> ```
+
 ### Chat + Conversation History
 
 ```csharp


### PR DESCRIPTION
When using Azure OpenAI the URL passed in to chat completions client needs to include the full path to the endpoint, otherwise you'll get a 404. This is documented in [Azure AI Inference docs](https://github.com/Azure/azure-sdk-for-net/blob/adc97b1f664dc1a07e2b07d6f4759b7a296ba07e/sdk/ai/Azure.AI.Inference/README.md?plain=1#L105), but might not be very discoverable for consumers of this package. For that reason, adding a small note on the readme of the AzureInference package to help guide users on how to connect correctly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5802)