### PR TITLE
Move ResourceUtilizationInstruments to Shared project

### DIFF
--- a/eng/MSBuild/Shared.props
+++ b/eng/MSBuild/Shared.props
@@ -11,6 +11,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)\..\..\src\Shared\EmptyCollections\*.cs" LinkBase="Shared\EmptyCollections" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(InjectSharedInstruments)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)\..\..\src\Shared\Instruments\*.cs" LinkBase="Shared\Instruments" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(InjectSharedRentedSpan)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)\..\..\src\Shared\RentedSpan\*.cs" LinkBase="Shared\RentedSpan" />
   </ItemGroup>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.csproj
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization.csproj
@@ -11,6 +11,7 @@
     <InjectSharedDiagnosticIds>true</InjectSharedDiagnosticIds>
     <InjectExperimentalAttributeOnLegacy>true</InjectExperimentalAttributeOnLegacy>
     <InjectObsoleteAttributeOnLegacy>true</InjectObsoleteAttributeOnLegacy>
+    <InjectSharedInstruments>true</InjectSharedInstruments>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/ResourceUtilizationHealthCheck.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization/ResourceUtilizationHealthCheck.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 using Microsoft.Extensions.Options;
 using Microsoft.Shared.Diagnostics;
+using Microsoft.Shared.Instruments;
 
 namespace Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -157,7 +158,7 @@ internal sealed partial class ResourceUtilizationHealthCheck : IHealthCheck, IDi
 
     private void OnInstrumentPublished(Instrument instrument, MeterListener listener)
     {
-        if (instrument.Meter.Name is "Microsoft.Extensions.Diagnostics.ResourceMonitoring")
+        if (instrument.Meter.Name == ResourceUtilizationInstruments.MeterName)
         {
             listener.EnableMeasurementEvents(instrument);
         }
@@ -169,12 +170,12 @@ internal sealed partial class ResourceUtilizationHealthCheck : IHealthCheck, IDi
     {
         switch (instrument.Name)
         {
-            case "process.cpu.utilization":
-            case "container.cpu.limit.utilization":
+            case ResourceUtilizationInstruments.ProcessCpuUtilization:
+            case ResourceUtilizationInstruments.ContainerCpuLimitUtilization:
                 _cpuUsedPercentage = measurement * _multiplier;
                 break;
-            case "dotnet.process.memory.virtual.utilization":
-            case "container.memory.limit.utilization":
+            case ResourceUtilizationInstruments.ProcessMemoryUtilization:
+            case ResourceUtilizationInstruments.ContainerMemoryLimitUtilization:
                 _memoryUsedPercentage = measurement * _multiplier;
                 break;
         }

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationProvider.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Shared.Instruments;
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux;
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Network/LinuxNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/Network/LinuxNetworkMetrics.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.Shared.Instruments;
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Network;
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Microsoft.Extensions.Diagnostics.ResourceMonitoring.csproj
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Microsoft.Extensions.Diagnostics.ResourceMonitoring.csproj
@@ -17,6 +17,7 @@
     <InjectSharedBufferWriterPool>true</InjectSharedBufferWriterPool>
     <InjectSharedDiagnosticIds>true</InjectSharedDiagnosticIds>
     <InjectStringSplitExtensions>true</InjectStringSplitExtensions>
+    <InjectSharedInstruments>true</InjectSharedInstruments>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Network/WindowsNetworkMetrics.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/Network/WindowsNetworkMetrics.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.Shared.Instruments;
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Network;
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsContainerSnapshotProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Shared.Instruments;
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 

--- a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
+++ b/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Windows/WindowsSnapshotProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Shared.Instruments;
 
 namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows;
 

--- a/src/Shared/Instruments/README.md
+++ b/src/Shared/Instruments/README.md
@@ -1,0 +1,11 @@
+# Diagnostic IDs
+
+Defines various diagnostic IDs reported by this repo.
+
+To use this in your project, add the following to your `.csproj` file:
+
+```xml
+<PropertyGroup>
+  <InjectSharedDiagnosticIds>true</InjectSharedInstruments>
+</PropertyGroup>
+```

--- a/src/Shared/Instruments/README.md
+++ b/src/Shared/Instruments/README.md
@@ -1,11 +1,11 @@
 # Diagnostic IDs
 
-Defines various diagnostic IDs reported by this repo.
+Contains common telemetry instruments names that are created or consumed in other projects.
 
 To use this in your project, add the following to your `.csproj` file:
 
 ```xml
 <PropertyGroup>
-  <InjectSharedDiagnosticIds>true</InjectSharedInstruments>
+  <InjectSharedInstruments>true</InjectSharedInstruments>
 </PropertyGroup>
 ```

--- a/src/Shared/Instruments/ResourceUtilizationInstruments.cs
+++ b/src/Shared/Instruments/ResourceUtilizationInstruments.cs
@@ -1,7 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable CA1716
 namespace Microsoft.Shared.Instruments;
+#pragma warning restore CA1716
+
+#pragma warning disable CS1574
 
 /// <summary>
 /// Represents the names of instruments published by this package.
@@ -62,3 +66,5 @@ internal static class ResourceUtilizationInstruments
     /// </remarks>
     public const string SystemNetworkConnections = "system.network.connections";
 }
+
+#pragma warning disable CS1574

--- a/src/Shared/Instruments/ResourceUtilizationInstruments.cs
+++ b/src/Shared/Instruments/ResourceUtilizationInstruments.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-
-namespace Microsoft.Extensions.Diagnostics.ResourceMonitoring;
+namespace Microsoft.Shared.Instruments;
 
 /// <summary>
 /// Represents the names of instruments published by this package.

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/AcceptanceTest.cs
@@ -11,11 +11,11 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Test;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Testing;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.Shared.Instruments;
 using Microsoft.TestUtilities;
 using Xunit;
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxCountersTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading;
 using FluentAssertions;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Network;
+using Microsoft.Shared.Instruments;
 using Moq;
 using Xunit;
 

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxNetworkMetricsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxNetworkMetricsTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Linux.Network;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
+using Microsoft.Shared.Instruments;
 using Microsoft.TestUtilities;
 using Moq;
 using Xunit;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Linux/LinuxUtilizationProviderTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Shared.Instruments;
 using Microsoft.TestUtilities;
 using Moq;
 using VerifyXunit;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsContainerSnapshotProviderTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.Shared.Instruments;
 using Moq;
 using VerifyXunit;
 using Xunit;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsNetworkMetricsTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsNetworkMetricsTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Test.Helpers;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Network;
+using Microsoft.Shared.Instruments;
 using Microsoft.TestUtilities;
 using Moq;
 using Xunit;

--- a/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
+++ b/test/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring.Tests/Windows/WindowsSnapshotProviderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Diagnostics.ResourceMonitoring.Windows.Interop;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.Shared.Instruments;
 using Microsoft.TestUtilities;
 using Moq;
 using VerifyXunit;


### PR DESCRIPTION
Fixes #5813 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5844)