### PR TITLE
Use unsafe relaxed escaping in `AIJsonUtilities.DefaultOptions`.

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -13,7 +15,26 @@ namespace Microsoft.Extensions.AI;
 
 public static partial class AIJsonUtilities
 {
-    /// <summary>Gets the <see cref="JsonSerializerOptions"/> singleton used as the default in JSON serialization operations.</summary>
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerOptions"/> singleton used as the default in JSON serialization operations.
+    /// </summary>
+    /// <remarks>
+    /// <para>For Native AOT or applications disabling <see cref="JsonSerializer.IsReflectionEnabledByDefault"/> this instance includes source generated contracts
+    /// for all common exchange types contained in the Microsoft.Extensions.AI.Abstractions library.
+    /// </para>
+    /// <para>
+    /// It additionally turns on the following settings:
+    /// <list type="number">
+    /// <item>Enables the <see cref="JsonSerializerOptions.WriteIndented"/> property.</item>
+    /// <item>Enables string based enum serialization as implemented by <see cref="JsonStringEnumConverter"/>.</item>
+    /// <item>Enables <see cref="JsonIgnoreCondition.WhenWritingNull"/> as the default ignore condition for properties.</item>
+    /// <item>
+    /// Enables <see cref="JavaScriptEncoder.UnsafeRelaxedJsonEscaping"/> when escaping JSON strings.
+    /// Consuming applications must ensure that JSON outputs are adequately escaped before embedding in HTML documents.
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
     public static JsonSerializerOptions DefaultOptions { get; } = CreateDefaultOptions();
 
     /// <summary>Creates the default <see cref="JsonSerializerOptions"/> to use for serialization-related operations.</summary>
@@ -24,25 +45,31 @@ public static partial class AIJsonUtilities
         // If reflection-based serialization is enabled by default, use it, as it's the most permissive in terms of what it can serialize,
         // and we want to be flexible in terms of what can be put into the various collections in the object model.
         // Otherwise, use the source-generated options to enable trimming and Native AOT.
+        JsonSerializerOptions options;
 
         if (JsonSerializer.IsReflectionEnabledByDefault)
         {
             // Keep in sync with the JsonSourceGenerationOptions attribute on JsonContext below.
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
+            options = new(JsonSerializerDefaults.Web)
             {
                 TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
                 Converters = { new JsonStringEnumConverter() },
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 WriteIndented = true,
             };
-
-            options.MakeReadOnly();
-            return options;
         }
         else
         {
-            return JsonContext.Default.Options;
+            options = new(JsonContext.Default.Options)
+            {
+                // Compile-time encoder setting not yet available
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
         }
+
+        options.MakeReadOnly();
+        return options;
     }
 
     // Keep in sync with CreateDefaultOptions above.
@@ -82,5 +109,6 @@ public static partial class AIJsonUtilities
     [JsonSerializable(typeof(Embedding<float>))]
     [JsonSerializable(typeof(Embedding<double>))]
     [JsonSerializable(typeof(AIContent))]
+    [EditorBrowsable(EditorBrowsableState.Never)] // Never use JsonContext directly, use DefaultOptions instead.
     private sealed partial class JsonContext : JsonSerializerContext;
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Defaults.cs
@@ -30,7 +30,7 @@ public static partial class AIJsonUtilities
     /// <item>Enables <see cref="JsonIgnoreCondition.WhenWritingNull"/> as the default ignore condition for properties.</item>
     /// <item>
     /// Enables <see cref="JavaScriptEncoder.UnsafeRelaxedJsonEscaping"/> when escaping JSON strings.
-    /// Consuming applications must ensure that JSON outputs are adequately escaped before embedding in HTML documents.
+    /// Consuming applications must ensure that JSON outputs are adequately escaped before embedding in other document formats, such as HTML and XML.
     /// </item>
     /// </list>
     /// </para>

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Utilities/AIJsonUtilities.Schema.cs
@@ -212,7 +212,7 @@ public static partial class AIJsonUtilities
 
             return schemaObj is null
                 ? _trueJsonSchema
-                : JsonSerializer.SerializeToElement(schemaObj, JsonContext.Default.JsonNode);
+                : JsonSerializer.SerializeToElement(schemaObj, options.GetTypeInfo(typeof(JsonNode)));
         }
 
         if (key.Type == typeof(void))
@@ -227,7 +227,7 @@ public static partial class AIJsonUtilities
         };
 
         JsonNode node = options.GetJsonSchemaAsNode(key.Type, exporterOptions);
-        return JsonSerializer.SerializeToElement(node, JsonContext.Default.JsonNode);
+        return JsonSerializer.SerializeToElement(node, DefaultOptions.GetTypeInfo(typeof(JsonNode)));
 
         JsonNode TransformSchemaNode(JsonSchemaExporterContext schemaExporterContext, JsonNode schema)
         {


### PR DESCRIPTION
It is common for AI vendor APIs to embed JSON documents inside JSON strings, which results in quotes and most non-ASCII content being escaped and confusing consuming LLMs. This updates the default STJ options to use `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`.
 
FYI @GrabYourPitchforks @SergeyMenshykh
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5850)