### PR TITLE
Use an environment variable for configuring Ollama integration tests

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI/README.md
+++ b/src/Libraries/Microsoft.Extensions.AI/README.md
@@ -83,3 +83,12 @@ Optionally also run the following. The values shown here are the defaults if you
 dotnet user-secrets set AzureAIInference:ChatModel gpt-4o-mini
 dotnet user-secrets set AzureAIInference:EmbeddingModel text-embedding-3-small
 ```
+
+### Configuring Ollama tests
+
+Run commands like the following. The settings will be saved in your user profile.
+
+```
+cd test/Libraries/Microsoft.Extensions.AI.Integration.Tests
+dotnet user-secrets set Ollama:Endpoint http://localhost:11434/
+```

--- a/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/IntegrationTestHelpers.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Ollama.Tests/IntegrationTestHelpers.cs
@@ -13,7 +13,8 @@ internal static class IntegrationTestHelpers
     /// <summary>Gets a <see cref="Uri"/> to use for testing, or null if the associated tests should be disabled.</summary>
     public static Uri? GetOllamaUri()
     {
-        // return new Uri("http://localhost:11434");
-        return null;
+        return TestRunnerConfiguration.Instance["Ollama:Endpoint"] is string endpoint
+            ? new Uri(endpoint)
+            : null;
     }
 }


### PR DESCRIPTION
I very often catch myself accidentally committing changes to Ollama's integration test helper. This changes the helper so that the endpoint is detected from the environment.