### PR TITLE
Remove the `ref int` parameter from `ChatConversationEvaluator.CanRenderAsync()` 

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ChatConversationEvaluator.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Evaluation.Quality/ChatConversationEvaluator.cs
@@ -108,10 +108,10 @@ public abstract class ChatConversationEvaluator : IEvaluator
             {
                 if (history.Count == 1)
                 {
-                    bool canRender =
+                    (bool canRender, tokenBudget) =
                         await CanRenderAsync(
                             history[0],
-                            ref tokenBudget,
+                            tokenBudget,
                             chatConfiguration,
                             cancellationToken).ConfigureAwait(false);
 
@@ -132,10 +132,10 @@ public abstract class ChatConversationEvaluator : IEvaluator
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        bool canRender =
+                        (bool canRender, tokenBudget) =
                             await CanRenderAsync(
                                 message,
-                                ref tokenBudget,
+                                tokenBudget,
                                 chatConfiguration,
                                 cancellationToken).ConfigureAwait(false);
 
@@ -222,12 +222,12 @@ public abstract class ChatConversationEvaluator : IEvaluator
     /// </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the operation.</param>
     /// <returns>
-    /// <see langword="true"/> if there is sufficient <paramref name="tokenBudget"/> remaining to render the supplied
-    /// <paramref name="message"/> as part of the evaluation prompt; <see langword="false"/> otherwise.
+    /// A tuple containing a boolean indicating if there is sufficient <paramref name="tokenBudget"/> remaining to render the supplied
+    /// <paramref name="message"/> as part of the evaluation prompt and an int returning the remaining token budget.
     /// </returns>
-    protected virtual ValueTask<bool> CanRenderAsync(
+    protected virtual ValueTask<(bool tokenBudgetSufficient, int tokenBudgetRemaining)> CanRenderAsync(
         ChatMessage message,
-        ref int tokenBudget,
+        int tokenBudget,
         ChatConfiguration chatConfiguration,
         CancellationToken cancellationToken)
     {
@@ -237,7 +237,7 @@ public abstract class ChatConversationEvaluator : IEvaluator
         IEvaluationTokenCounter? tokenCounter = chatConfiguration.TokenCounter;
         if (tokenCounter is null)
         {
-            return new ValueTask<bool>(true);
+            return new ValueTask<(bool, int)>((true, tokenBudget));
         }
 
         string? author = message.AuthorName;
@@ -261,12 +261,12 @@ public abstract class ChatConversationEvaluator : IEvaluator
 
         if (tokenCount > tokenBudget)
         {
-            return new ValueTask<bool>(false);
+            return new ValueTask<(bool, int)>((false, tokenBudget));
         }
         else
         {
             tokenBudget -= tokenCount;
-            return new ValueTask<bool>(true);
+            return new ValueTask<(bool, int)>((true, tokenBudget));
         }
     }
 


### PR DESCRIPTION
fixes #5895 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5896)