### PR TITLE
Add marker AITool for enabling code interpreters

### DIFF
--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/AITool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/AITool.cs
@@ -1,13 +1,55 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Shared.Collections;
+
 namespace Microsoft.Extensions.AI;
 
+#pragma warning disable S1694 // An abstract class should have both abstract and concrete methods
+
 /// <summary>Represents a tool that can be specified to an AI service.</summary>
-public class AITool
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public abstract class AITool
 {
     /// <summary>Initializes a new instance of the <see cref="AITool"/> class.</summary>
     protected AITool()
     {
+    }
+
+    /// <summary>Gets the name of the tool.</summary>
+    public virtual string Name => GetType().Name;
+
+    /// <summary>Gets a description of the tool, suitable for use in describing the purpose to a model.</summary>
+    public virtual string Description => string.Empty;
+
+    /// <summary>Gets any additional properties associated with the tool.</summary>
+    public virtual IReadOnlyDictionary<string, object?> AdditionalProperties => EmptyReadOnlyDictionary<string, object?>.Instance;
+
+    /// <inheritdoc/>
+    public override string ToString() => Name;
+
+    /// <summary>Gets the string to display in the debugger for this instance.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay
+    {
+        get
+        {
+            StringBuilder sb = new(Name);
+
+            if (Description is string description && !string.IsNullOrEmpty(description))
+            {
+                _ = sb.Append(" (").Append(description).Append(')');
+            }
+
+            foreach (var entry in AdditionalProperties)
+            {
+                _ = sb.Append(", ").Append(entry.Key).Append(" = ").Append(entry.Value);
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CodeInterpreterTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CodeInterpreterTool.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Represents a tool that can be specified to an AI service to enable it to execute code it generates.</summary>
+/// <remarks>
+/// This tool does not itself implement code interpration. It is a marker that can be used to inform a service
+/// that the service is allowed to execute its generated code if the service is capable of doing so.
+/// </remarks>
+public class CodeInterpreterTool : AITool
+{
+    /// <summary>Initializes a new instance of the <see cref="CodeInterpreterTool"/> class.</summary>
+    public CodeInterpreterTool()
+    {
+    }
+
+    /// <summary>Gets or sets additional properties that impact the behavior of the tool.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+}

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CodeInterpreterTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CodeInterpreterTool.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using Microsoft.Shared.Collections;
+
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a tool that can be specified to an AI service to enable it to execute code it generates.</summary>
@@ -11,10 +14,11 @@ namespace Microsoft.Extensions.AI;
 public class CodeInterpreterTool : AITool
 {
     /// <summary>Initializes a new instance of the <see cref="CodeInterpreterTool"/> class.</summary>
-    public CodeInterpreterTool()
+    public CodeInterpreterTool(IReadOnlyDictionary<string, object?>? additionalProperties = null)
     {
+        AdditionalProperties = additionalProperties ?? EmptyReadOnlyDictionary<string, object?>.Instance;
     }
 
-    /// <summary>Gets or sets additional properties that impact the behavior of the tool.</summary>
-    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+    /// <inheritdoc/>
+    public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/CodeInterpreterTool.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/CodeInterpreterTool.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Microsoft.Shared.Collections;
-
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a tool that can be specified to an AI service to enable it to execute code it generates.</summary>
@@ -14,11 +11,7 @@ namespace Microsoft.Extensions.AI;
 public class CodeInterpreterTool : AITool
 {
     /// <summary>Initializes a new instance of the <see cref="CodeInterpreterTool"/> class.</summary>
-    public CodeInterpreterTool(IReadOnlyDictionary<string, object?>? additionalProperties = null)
+    public CodeInterpreterTool()
     {
-        AdditionalProperties = additionalProperties ?? EmptyReadOnlyDictionary<string, object?>.Instance;
     }
-
-    /// <inheritdoc/>
-    public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
 }

--- a/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.Abstractions/Functions/AIFunction.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -12,15 +11,8 @@ using Microsoft.Shared.Collections;
 namespace Microsoft.Extensions.AI;
 
 /// <summary>Represents a function that can be described to an AI service and invoked.</summary>
-[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public abstract class AIFunction : AITool
 {
-    /// <summary>Gets the name of the function.</summary>
-    public abstract string Name { get; }
-
-    /// <summary>Gets a description of the function, suitable for use in describing the purpose to a model.</summary>
-    public abstract string Description { get; }
-
     /// <summary>Gets a JSON Schema describing the function and its input parameters.</summary>
     /// <remarks>
     /// <para>
@@ -56,11 +48,8 @@ public abstract class AIFunction : AITool
     /// </remarks>
     public virtual MethodInfo? UnderlyingMethod => null;
 
-    /// <summary>Gets any additional properties associated with the function.</summary>
-    public virtual IReadOnlyDictionary<string, object?> AdditionalProperties => EmptyReadOnlyDictionary<string, object?>.Instance;
-
     /// <summary>Gets a <see cref="JsonSerializerOptions"/> that can be used to marshal function parameters.</summary>
-    public virtual JsonSerializerOptions? JsonSerializerOptions => AIJsonUtilities.DefaultOptions;
+    public virtual JsonSerializerOptions JsonSerializerOptions => AIJsonUtilities.DefaultOptions;
 
     /// <summary>Invokes the <see cref="AIFunction"/> and returns its result.</summary>
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
@@ -75,9 +64,6 @@ public abstract class AIFunction : AITool
         return InvokeCoreAsync(arguments, cancellationToken);
     }
 
-    /// <inheritdoc/>
-    public override string ToString() => Name;
-
     /// <summary>Invokes the <see cref="AIFunction"/> and returns its result.</summary>
     /// <param name="arguments">The arguments to pass to the function's invocation.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
@@ -85,8 +71,4 @@ public abstract class AIFunction : AITool
     protected abstract Task<object?> InvokeCoreAsync(
         IEnumerable<KeyValuePair<string, object?>> arguments,
         CancellationToken cancellationToken);
-
-    /// <summary>Gets the string to display in the debugger for this instance.</summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private string DebuggerDisplay => string.IsNullOrWhiteSpace(Description) ? Name : $"{Name} ({Description})";
 }

--- a/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantClient.cs
+++ b/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIAssistantClient.cs
@@ -222,10 +222,10 @@ internal sealed class OpenAIAssistantClient : IChatClient
 
                             var functionParameters = BinaryData.FromBytes(
                                 JsonSerializer.SerializeToUtf8Bytes(
-                                    JsonSerializer.Deserialize(aiFunction.Metadata.Schema, OpenAIJsonContext.Default.OpenAIChatToolJson)!,
+                                    JsonSerializer.Deserialize(aiFunction.JsonSchema, OpenAIJsonContext.Default.OpenAIChatToolJson)!,
                                     OpenAIJsonContext.Default.OpenAIChatToolJson));
 
-                            runOptions.ToolsOverride.Add(ToolDefinition.CreateFunction(aiFunction.Metadata.Name, aiFunction.Metadata.Description, functionParameters, strict));
+                            runOptions.ToolsOverride.Add(ToolDefinition.CreateFunction(aiFunction.Name, aiFunction.Description, functionParameters, strict));
                             break;
 
                         case CodeInterpreterTool:

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactory.cs
@@ -340,7 +340,7 @@ public static partial class AIFunctionFactory
             JsonTypeInfo typeInfo = serializerOptions.GetTypeInfo(parameterType);
 
             // Create a marshaller that simply looks up the parameter by name in the arguments dictionary.
-            return (IReadOnlyDictionary<string, object?> arguments, AIFunctionContext? _) =>
+            return (arguments, _) =>
             {
                 // If the parameter has an argument specified in the dictionary, return that argument.
                 if (arguments.TryGetValue(parameter.Name, out object? value))

--- a/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactoryOptions.cs
+++ b/src/Libraries/Microsoft.Extensions.AI/Functions/AIFunctionFactoryOptions.cs
@@ -49,7 +49,7 @@ public sealed class AIFunctionFactoryOptions
     public string? Description { get; set; }
 
     /// <summary>
-    /// Gets or sets additional values to store on the resulting <see cref="AIFunction.AdditionalProperties" /> property.
+    /// Gets or sets additional values to store on the resulting <see cref="AITool.AdditionalProperties" /> property.
     /// </summary>
     /// <remarks>
     /// This property can be used to provide arbitrary information about the function.

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AIToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/AIToolTests.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class AIToolTests
+{
+    [Fact]
+    public void Constructor_Roundtrips()
+    {
+        DerivedAITool tool = new();
+        Assert.Equal(nameof(DerivedAITool), tool.Name);
+        Assert.Equal(nameof(DerivedAITool), tool.ToString());
+        Assert.Empty(tool.Description);
+        Assert.Empty(tool.AdditionalProperties);
+    }
+
+    private sealed class DerivedAITool : AITool;
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/CodeInterpreterToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/CodeInterpreterToolTests.cs
@@ -15,12 +15,5 @@ public class CodeInterpreterToolTests
         Assert.Empty(tool.Description);
         Assert.Empty(tool.AdditionalProperties);
         Assert.Equal(nameof(CodeInterpreterTool), tool.ToString());
-
-        var props = new AdditionalPropertiesDictionary();
-        tool = new CodeInterpreterTool(props);
-        Assert.Equal(nameof(CodeInterpreterTool), tool.Name);
-        Assert.Empty(tool.Description);
-        Assert.Same(props, tool.AdditionalProperties);
-        Assert.Equal(nameof(CodeInterpreterTool), tool.ToString());
     }
 }

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/CodeInterpreterToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/CodeInterpreterToolTests.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.Extensions.AI;
+
+public class CodeInterpreterToolTests
+{
+    [Fact]
+    public void Constructor_Roundtrips()
+    {
+        var tool = new CodeInterpreterTool();
+        Assert.Null(tool.AdditionalProperties);
+
+        var props = new AdditionalPropertiesDictionary();
+        tool.AdditionalProperties = props;
+        Assert.Same(props, tool.AdditionalProperties);
+    }
+}

--- a/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/CodeInterpreterToolTests.cs
+++ b/test/Libraries/Microsoft.Extensions.AI.Abstractions.Tests/CodeInterpreterToolTests.cs
@@ -11,10 +11,16 @@ public class CodeInterpreterToolTests
     public void Constructor_Roundtrips()
     {
         var tool = new CodeInterpreterTool();
-        Assert.Null(tool.AdditionalProperties);
+        Assert.Equal(nameof(CodeInterpreterTool), tool.Name);
+        Assert.Empty(tool.Description);
+        Assert.Empty(tool.AdditionalProperties);
+        Assert.Equal(nameof(CodeInterpreterTool), tool.ToString());
 
         var props = new AdditionalPropertiesDictionary();
-        tool.AdditionalProperties = props;
+        tool = new CodeInterpreterTool(props);
+        Assert.Equal(nameof(CodeInterpreterTool), tool.Name);
+        Assert.Empty(tool.Description);
         Assert.Same(props, tool.AdditionalProperties);
+        Assert.Equal(nameof(CodeInterpreterTool), tool.ToString());
     }
 }


### PR DESCRIPTION
Various AI services (Gemini, Bedrock, OpenAI, etc.) now support server-side code interpreting, where the model can generate code it can then execute in a sandbox. For good reason, they all require opting in. We can model that well as an AITool-derived type.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5898)